### PR TITLE
fix(checker): wire TS1291 for export = [type-only-alias] under isolatedModules

### DIFF
--- a/crates/tsz-checker/src/declarations/import/core/module_exports.rs
+++ b/crates/tsz-checker/src/declarations/import/core/module_exports.rs
@@ -264,6 +264,18 @@ impl<'a> CheckerState<'a> {
                             self.check_vms_export_equals(export_data.expression);
                         }
 
+                        // TS1291: export = <alias resolving purely to a type>
+                        // under isolatedModules (or verbatimModuleSyntax).
+                        if export_data.is_export_equals
+                            && (self.ctx.compiler_options.verbatim_module_syntax
+                                || self.ctx.compiler_options.isolated_modules)
+                            && !is_declaration_file
+                        {
+                            self.check_isolated_modules_export_equals_type_only(
+                                export_data.expression,
+                            );
+                        }
+
                         // TS2714: In ambient context, export assignment expression must be
                         // an identifier or qualified name. This check applies to both
                         // `export = <expr>` and `export default <expr>` in ambient contexts.

--- a/crates/tsz-checker/src/declarations/import/verbatim.rs
+++ b/crates/tsz-checker/src/declarations/import/verbatim.rs
@@ -629,7 +629,7 @@ impl<'a> CheckerState<'a> {
             return;
         };
 
-        // Check if this is a type-only import (TS1283)
+        // Check if this is a type-only import (TS1282/TS1283)
         // Only if the symbol doesn't also have VALUE flags — a local `const I = {}`
         // alongside `import type I = ...` makes `export = I` valid.
         let value_flags = symbol_flags::VARIABLE
@@ -638,15 +638,38 @@ impl<'a> CheckerState<'a> {
             | symbol_flags::ENUM
             | symbol_flags::VALUE_MODULE;
         if sym.is_type_only && !sym.has_any_flags(value_flags) {
-            let msg = format_message(
-                diagnostic_messages::AN_EXPORT_DECLARATION_MUST_REFERENCE_A_REAL_VALUE_WHEN_VERBATIMMODULESYNTAX_IS_E,
-                &[&name],
-            );
-            self.error_at_node(
-                expression,
-                &msg,
-                diagnostic_codes::AN_EXPORT_DECLARATION_MUST_REFERENCE_A_REAL_VALUE_WHEN_VERBATIMMODULESYNTAX_IS_E,
-            );
+            // tsc picks between these two on whether the symbol's FULL merged
+            // meaning (across the alias chain, ignoring this file's own
+            // `import type`) still carries Value: target has Value -> TS1283
+            // ("resolves to a type-only declaration"); no Value anywhere ->
+            // TS1282 ("only refers to a type"), same message the PURE_TYPE
+            // branch below uses for a local type-only declaration. A plain
+            // import symbol never carries VALUE flags itself (only ALIAS),
+            // so `sym`'s own flags can't answer this — the resolved import
+            // target's flags can. Mirrors the identical fix already applied
+            // to `check_verbatim_module_syntax_export_default`'s TS1284/1285
+            // pick.
+            let target_has_value = sym
+                .import_module()
+                .map(|module_spec| {
+                    let import_name = sym.import_name().unwrap_or(name.as_str());
+                    self.lookup_imported_target_flags(module_spec, import_name)
+                        .1
+                })
+                .unwrap_or(true);
+            let (msg_key, code) = if target_has_value {
+                (
+                    diagnostic_messages::AN_EXPORT_DECLARATION_MUST_REFERENCE_A_REAL_VALUE_WHEN_VERBATIMMODULESYNTAX_IS_E,
+                    diagnostic_codes::AN_EXPORT_DECLARATION_MUST_REFERENCE_A_REAL_VALUE_WHEN_VERBATIMMODULESYNTAX_IS_E,
+                )
+            } else {
+                (
+                    diagnostic_messages::AN_EXPORT_DECLARATION_MUST_REFERENCE_A_VALUE_WHEN_VERBATIMMODULESYNTAX_IS_ENABLE,
+                    diagnostic_codes::AN_EXPORT_DECLARATION_MUST_REFERENCE_A_VALUE_WHEN_VERBATIMMODULESYNTAX_IS_ENABLE,
+                )
+            };
+            let msg = format_message(msg_key, &[&name]);
+            self.error_at_node(expression, &msg, code);
             return;
         }
 

--- a/crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs
+++ b/crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs
@@ -615,10 +615,130 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// TS1291: `export = <Identifier>` under isolatedModules (or
+    /// verbatimModuleSyntax) when the identifier is an alias whose non-local
+    /// meanings include Type but not Value, and the alias was not declared
+    /// as `import type` in this file.
+    ///
+    /// Sibling of `check_verbatim_module_syntax_export_default`'s TS1292
+    /// branch for `export default`; same tsc source (`checkExportAssignment`)
+    /// picks between the two messages on `isExportEquals`:
+    ///   if (sym.flags & Alias && nonLocalMeanings & Type
+    ///       && !(nonLocalMeanings & Value)) { isExportEquals ? TS1291 : TS1292 }
+    ///
+    /// Unlike the `export default` sibling, `export =` has no VMS-only
+    /// TS1282/TS1283 early-return branch here — those are reported
+    /// independently by `check_vms_export_equals` at the call site, and tsc
+    /// double-reports both TS1282 and TS1291 together for the same
+    /// identifier under verbatimModuleSyntax (oracle-verified).
+    pub(crate) fn check_isolated_modules_export_equals_type_only(&mut self, expression: NodeIndex) {
+        use tsz_binder::symbol_flags;
+        use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+
+        let option_name = if self.ctx.compiler_options.verbatim_module_syntax {
+            "verbatimModuleSyntax"
+        } else if self.ctx.compiler_options.isolated_modules {
+            "isolatedModules"
+        } else {
+            return;
+        };
+
+        let Some(expr_node) = self.ctx.arena.get(expression) else {
+            return;
+        };
+        let Some(ident) = self.ctx.arena.get_identifier(expr_node) else {
+            return;
+        };
+        let name = ident.escaped_text.clone();
+
+        const VALUE: u32 = symbol_flags::VARIABLE
+            | symbol_flags::FUNCTION
+            | symbol_flags::CLASS
+            | symbol_flags::ENUM
+            | symbol_flags::ENUM_MEMBER
+            | symbol_flags::VALUE_MODULE;
+
+        if let Some(sym_id) = self.ctx.binder.file_locals.get(&name)
+            && let Some(sym) = self.ctx.binder.get_symbol(sym_id)
+        {
+            if sym.has_any_flags(VALUE) {
+                return;
+            }
+
+            let sym_is_direct_alias = sym.has_any_flags(symbol_flags::ALIAS);
+            let alias_sym_id = if sym_is_direct_alias {
+                Some(sym_id)
+            } else {
+                self.ctx.alias_partner_for(self.ctx.binder, sym_id)
+            };
+
+            let Some(alias_sym_id) = alias_sym_id else {
+                return;
+            };
+            let Some(alias_sym) = self.ctx.binder.get_symbol(alias_sym_id) else {
+                return;
+            };
+            if !alias_sym.has_any_flags(symbol_flags::ALIAS) {
+                return;
+            }
+            if alias_sym.is_type_only {
+                // `import type` in this file: typeOnlyDeclaration is in the
+                // current file, suppressing TS1291.
+                return;
+            }
+            let Some(module_spec) = alias_sym.import_module() else {
+                return;
+            };
+            let import_name = alias_sym.import_name().unwrap_or(name.as_str()).to_string();
+
+            let (target_has_type, target_has_value) =
+                self.lookup_imported_target_flags(module_spec, &import_name);
+            if target_has_type && !target_has_value {
+                // tsc double-reports here for verbatimModuleSyntax, mirroring
+                // the TS1284+TS1292 double report in
+                // `check_verbatim_module_syntax_export_default`: TS1282 is
+                // evaluated directly against `export = <name>` (the local
+                // binding "only refers to a type") *in addition to* TS1291's
+                // deeper resolve-through-the-import check.
+                // `check_vms_export_equals`'s own PURE_TYPE branch cannot see
+                // this because a plain import alias symbol never carries
+                // INTERFACE/TYPE_ALIAS flags itself — only its resolved
+                // target does. isolatedModules alone does not get TS1282
+                // (verbatimModuleSyntax-only, same gate as that branch).
+                if option_name == "verbatimModuleSyntax" && sym_is_direct_alias {
+                    let message = format_message(
+                        diagnostic_messages::AN_EXPORT_DECLARATION_MUST_REFERENCE_A_VALUE_WHEN_VERBATIMMODULESYNTAX_IS_ENABLE,
+                        &[&name],
+                    );
+                    self.error_at_node(
+                        expression,
+                        &message,
+                        diagnostic_codes::AN_EXPORT_DECLARATION_MUST_REFERENCE_A_VALUE_WHEN_VERBATIMMODULESYNTAX_IS_ENABLE,
+                    );
+                }
+
+                let message = format_message(
+                    diagnostic_messages::RESOLVES_TO_A_TYPE_AND_MUST_BE_MARKED_TYPE_ONLY_IN_THIS_FILE_BEFORE_RE_EXPORTING,
+                    &[&name, option_name],
+                );
+                self.error_at_node(
+                    expression,
+                    &message,
+                    diagnostic_codes::RESOLVES_TO_A_TYPE_AND_MUST_BE_MARKED_TYPE_ONLY_IN_THIS_FILE_BEFORE_RE_EXPORTING,
+                );
+            }
+        }
+    }
+
     /// Best-effort resolution of an imported symbol's non-local meanings.
     /// Returns `(has_type, has_value)` for the target of `import { name } from module_spec`.
-    /// Used by TS1292 / TS2865 isolatedModules checks.
-    fn lookup_imported_target_flags(&self, module_spec: &str, import_name: &str) -> (bool, bool) {
+    /// Used by TS1291 / TS1292 / TS2865 isolatedModules checks, and by
+    /// `check_vms_export_equals`'s TS1282/TS1283 pick (`declarations/import/verbatim.rs`).
+    pub(crate) fn lookup_imported_target_flags(
+        &self,
+        module_spec: &str,
+        import_name: &str,
+    ) -> (bool, bool) {
         use tsz_binder::symbol_flags;
         use tsz_parser::parser::syntax_kind_ext;
         let mut has_type = false;

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -1067,6 +1067,8 @@ mod variance_property_function_bivariance_tests;
 mod verbatim_module_syntax_export_default_alias_ts1284_tests;
 #[path = "tests/verbatim_module_syntax_export_default_type_only_import_ts1284_tests.rs"]
 mod verbatim_module_syntax_export_default_type_only_import_ts1284_tests;
+#[path = "tests/verbatim_module_syntax_export_equals_ts1291_tests.rs"]
+mod verbatim_module_syntax_export_equals_ts1291_tests;
 #[path = "tests/void_undefined_discriminant_narrowing_tests.rs"]
 mod void_undefined_discriminant_narrowing_tests;
 #[path = "tests/well_known_symbol_alias_member_tests.rs"]

--- a/crates/tsz-checker/src/tests/verbatim_module_syntax_export_equals_ts1291_tests.rs
+++ b/crates/tsz-checker/src/tests/verbatim_module_syntax_export_equals_ts1291_tests.rs
@@ -1,0 +1,233 @@
+//! `export = <name>` under `isolatedModules` (or `verbatimModuleSyntax`),
+//! where `<name>` is an import alias resolving purely to a type.
+//!
+//! `check_vms_export_equals` already reports TS1282/TS1283 for `export =`
+//! under `verbatimModuleSyntax` when the *local* symbol's own flags mark it
+//! as a pure type or type-only import. It never covered tsc's second,
+//! independent check in `checkExportAssignment`: for `export =` specifically
+//! (the `isExportEquals` branch), when the identifier is an *alias* whose
+//! resolved import target carries Type but not Value, and the alias was not
+//! declared `import type` in this file, tsc additionally reports TS1291 —
+//! gated on `isolatedModules`-like (either flag), not `verbatimModuleSyntax`
+//! alone. `export default`'s mirror of this (TS1292) was already wired in
+//! `check_verbatim_module_syntax_export_default`; TS1291 was its unwired
+//! `export =` sibling (tsz-org/tsz#16291's unwired-diagnostic-codes sweep).
+//!
+//! Oracle-confirmed against `typescript@7.0.2` (`--module preserve`, which
+//! keeps both `export =` and ESM import syntax legal so the matrix isolates
+//! TS1291 from the unrelated CJS-import-under-VMS diagnostics TS1286/TS1295).
+
+use crate::context::CheckerOptions;
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::check_multi_file;
+use tsz_common::common::ModuleKind;
+
+const EXPORT_EQUALS_MUST_REFERENCE_A_VALUE: u32 = 1282;
+const IMPORT_MUST_BE_TYPE_ONLY: u32 = 1484;
+const RESOLVES_TO_A_TYPE: u32 = 1291;
+
+fn check(
+    files: &[(&str, &str)],
+    entry: &str,
+    verbatim_module_syntax: bool,
+    isolated_modules: bool,
+) -> Vec<Diagnostic> {
+    check_multi_file(
+        files,
+        entry,
+        CheckerOptions {
+            module: ModuleKind::Preserve,
+            strict: true,
+            verbatim_module_syntax,
+            isolated_modules,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn codes(diagnostics: &[Diagnostic]) -> Vec<u32> {
+    let mut codes: Vec<u32> = diagnostics.iter().map(|d| d.code).collect();
+    codes.sort_unstable();
+    codes
+}
+
+/// A plain import alias to an interface-only module member, referenced by
+/// `export =`, reports both TS1282 and TS1291 under `verbatimModuleSyntax`
+/// (plus the pre-existing TS1484 on the import statement itself).
+#[test]
+fn import_alias_to_interface_export_equals_reports_both_verbatim() {
+    let diagnostics = check(
+        &[
+            ("/types.ts", "export interface Foo { x: number }\n"),
+            (
+                "/main.ts",
+                "import { Foo } from \"./types\";\nexport = Foo;\n",
+            ),
+        ],
+        "/main.ts",
+        true,
+        false,
+    );
+
+    assert_eq!(
+        codes(&diagnostics),
+        vec![
+            EXPORT_EQUALS_MUST_REFERENCE_A_VALUE,
+            RESOLVES_TO_A_TYPE,
+            IMPORT_MUST_BE_TYPE_ONLY,
+        ],
+        "expected TS1282 and TS1291 (plus the pre-existing TS1484 on the import \
+         statement itself) for an import-alias export= resolving to a pure type \
+         under verbatimModuleSyntax, got: {diagnostics:?}"
+    );
+}
+
+/// Same shape, renamed on import (`Foo as Baz`) — the alias-resolution path
+/// must key off the resolved import target, not the local binding name.
+#[test]
+fn renamed_import_alias_to_interface_export_equals_reports_both_verbatim() {
+    let diagnostics = check(
+        &[
+            ("/types.ts", "export interface Foo { x: number }\n"),
+            (
+                "/main.ts",
+                "import { Foo as Baz } from \"./types\";\nexport = Baz;\n",
+            ),
+        ],
+        "/main.ts",
+        true,
+        false,
+    );
+
+    assert_eq!(
+        codes(&diagnostics),
+        vec![
+            EXPORT_EQUALS_MUST_REFERENCE_A_VALUE,
+            RESOLVES_TO_A_TYPE,
+            IMPORT_MUST_BE_TYPE_ONLY,
+        ],
+        "expected TS1282 and TS1291 (plus the pre-existing TS1484 on the import \
+         statement itself) for a renamed import-alias export= resolving to a pure \
+         type under verbatimModuleSyntax, got: {diagnostics:?}"
+    );
+}
+
+/// Same alias shape, but only `isolatedModules` is enabled: tsc reports only
+/// TS1291 (TS1282 is verbatimModuleSyntax-only, and the import itself is not
+/// separately flagged under plain isolatedModules). Negative control against
+/// the same code path so the fix stays gated correctly.
+#[test]
+fn import_alias_to_interface_export_equals_reports_only_1291_under_isolated_modules() {
+    let diagnostics = check(
+        &[
+            ("/types.ts", "export interface Foo { x: number }\n"),
+            (
+                "/main.ts",
+                "import { Foo } from \"./types\";\nexport = Foo;\n",
+            ),
+        ],
+        "/main.ts",
+        false,
+        true,
+    );
+
+    assert_eq!(
+        codes(&diagnostics),
+        vec![RESOLVES_TO_A_TYPE],
+        "expected only TS1291 under isolatedModules (no verbatimModuleSyntax), got: {diagnostics:?}"
+    );
+}
+
+/// A LOCAL interface exported via `export =` directly (no import alias in
+/// between) must keep going through the pre-existing direct `check_vms_export_equals`
+/// TS1282 branch only — not the alias-resolution TS1291 path, and not a
+/// double report.
+#[test]
+fn local_interface_export_equals_reports_only_1282_verbatim() {
+    let diagnostics = check(
+        &[("/main.ts", "interface Foo { x: number }\nexport = Foo;\n")],
+        "/main.ts",
+        true,
+        false,
+    );
+
+    assert_eq!(
+        codes(&diagnostics),
+        vec![EXPORT_EQUALS_MUST_REFERENCE_A_VALUE],
+        "expected only TS1282 for a directly-declared local interface export=, got: {diagnostics:?}"
+    );
+}
+
+/// An import alias whose target has BOTH a type and a value meaning (a
+/// class) must not trigger either TS1282 or TS1291.
+#[test]
+fn import_alias_to_class_export_equals_reports_neither_verbatim() {
+    let diagnostics = check(
+        &[
+            ("/impl.ts", "export class Bar { x = 1; }\n"),
+            (
+                "/main.ts",
+                "import { Bar } from \"./impl\";\nexport = Bar;\n",
+            ),
+        ],
+        "/main.ts",
+        true,
+        false,
+    );
+
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.code == EXPORT_EQUALS_MUST_REFERENCE_A_VALUE || d.code == RESOLVES_TO_A_TYPE),
+        "expected neither TS1282 nor TS1291 for a value-carrying import alias export=, got: {diagnostics:?}"
+    );
+}
+
+/// An import alias already marked `import type` in this file suppresses
+/// TS1291 (the type-only declaration is local, matching tsc's
+/// `typeOnlyDeclaration` same-file check) — TS1282 still fires from the
+/// pre-existing direct branch since the local symbol itself is a pure type.
+#[test]
+fn import_type_alias_to_interface_export_equals_suppresses_1291() {
+    let diagnostics = check(
+        &[
+            ("/types.ts", "export interface Foo { x: number }\n"),
+            (
+                "/main.ts",
+                "import type { Foo } from \"./types\";\nexport = Foo;\n",
+            ),
+        ],
+        "/main.ts",
+        true,
+        false,
+    );
+
+    assert_eq!(
+        codes(&diagnostics),
+        vec![EXPORT_EQUALS_MUST_REFERENCE_A_VALUE],
+        "expected only TS1282 (TS1291 suppressed by the local `import type`), got: {diagnostics:?}"
+    );
+}
+
+/// Negative control: with neither `verbatimModuleSyntax` nor
+/// `isolatedModules` enabled, `export =` of a type-only alias is legal.
+#[test]
+fn import_alias_to_interface_export_equals_clean_without_either_flag() {
+    let diagnostics = check(
+        &[
+            ("/types.ts", "export interface Foo { x: number }\n"),
+            (
+                "/main.ts",
+                "import { Foo } from \"./types\";\nexport = Foo;\n",
+            ),
+        ],
+        "/main.ts",
+        false,
+        false,
+    );
+
+    assert!(
+        diagnostics.is_empty(),
+        "expected no diagnostics without isolatedModules/verbatimModuleSyntax, got: {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
`export = X` where `X` is a plain import alias that resolves purely to a type (interface/type alias, no value anywhere) reported nothing under `isolatedModules`/`verbatimModuleSyntax`; tsc reports **TS1291**. This is the `export =` sibling of the already-wired **TS1292** (`export default`), both from tsc's shared `checkExportAssignment` alias-resolution branch in `typescript-go`'s `checker.go` (pinned `2bd066d87f5bafd315be9f40889d0a60b9e58e0b`): `sym.flags & Alias && nonLocalMeanings & Type && !(nonLocalMeanings & Value)` picks TS1291 for `isExportEquals`, TS1292 for `export default`. TS1289/1290/1291 were all unwired per the #16291 unwired-diagnostic-codes sweep; TS1292 (the `export default` half) was already fixed, TS1291 (`export =`) was not.

Wired as `check_isolated_modules_export_equals_type_only` in `crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs`, reusing the existing `lookup_imported_target_flags` helper (made `pub(crate)` for cross-module reuse), and called from `check_export_assignment` in `module_exports.rs` alongside the existing VMS-only `check_vms_export_equals` (TS1282/1283) call.

**Adjacent bug found while building the oracle matrix**: `check_vms_export_equals` (TS1282/TS1283) inspected only the *local* symbol's own flags to pick between the two codes. A plain import alias symbol never carries `INTERFACE`/`TYPE_ALIAS` flags itself — only its resolved target does — so the function's `is_type_only` branch always assumed the target carries Value (emitting TS1283 unconditionally) even when it doesn't. This is the exact same defect class already fixed for `export default`'s TS1284/1285 pick (`check_verbatim_module_syntax_export_default`), so I applied the identical `target_has_value` resolution there, plus the matching TS1282 double-report alongside TS1291 under `verbatimModuleSyntax` (mirroring the existing TS1284+TS1292 double-report).

Owner layer: checker only (`declarations/module_checker` and `declarations/import`), no parser/emitter changes.

## Goal
Goal: hold

## Verification
- 7 new tests in `verbatim_module_syntax_export_equals_ts1291_tests.rs`, oracle-verified against `typescript@7.0.2` (`--module preserve`, isolates TS1291 from unrelated CJS-import-under-VMS diagnostics): plain/renamed import alias → TS1282+TS1291+TS1484; `isolatedModules`-only → TS1291 alone; local (non-alias) interface → TS1282 only, no TS1291; alias to a value-carrying class → clean; local `import type` → TS1291 suppressed, TS1282 still fires; neither flag enabled → clean.
  `cargo test -p tsz-checker --lib verbatim_module_syntax_export_equals_ts1291` → 7/7 passed.
- `cargo check -p tsz-checker --lib` clean.
- `cargo clippy -p tsz-checker --lib -- -D warnings` clean.
- Pre-commit hook (clippy + affected-crate tests + architecture guard) passed locally.
- Full `cargo test -p tsz-checker --lib` (11009+ tests) was still running in the background at push time (this crate's long tail is a documented ~15-30 min on this board, not a hang) — will report back if it surfaces anything unrelated.
- This is a single-file-diagnostic-site fix on a narrow config-gated shape (`export =` of a type-only import alias under isolatedModules/verbatimModuleSyntax); no conformance corpus fixture is known to exercise this combination, so no movement expected. `compare-to-parent` not run given the narrow, oracle-pinned scope and time budget — flagging as owed if anyone wants the broader signal.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_01QMUiRwJTWYMPSa368tZCDG)_