### PR TITLE
fix(checker): accept type-alias async return types resolving to Promise (TS1064 false positive)

### DIFF
--- a/crates/tsz-checker/src/checkers/promise_checker.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker.rs
@@ -76,7 +76,7 @@ impl<'a> CheckerState<'a> {
                     .sym_id_is_current_cloned_lib_promise_or_promise_like(sym_id))
     }
 
-    fn current_symbol_is_lib_promise(&self, sym_id: SymbolId) -> bool {
+    pub(crate) fn current_symbol_is_lib_promise(&self, sym_id: SymbolId) -> bool {
         self.ctx.sym_id_is_lib_promise(sym_id)
             || self.ctx.sym_id_is_current_cloned_lib_promise(sym_id)
     }

--- a/crates/tsz-checker/src/state/type_analysis/core_alias_display.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core_alias_display.rs
@@ -44,7 +44,7 @@ impl CheckerState<'_> {
         }
     }
 
-    pub(super) fn symbol_is_type_alias(&self, sym_id: SymbolId) -> bool {
+    pub(crate) fn symbol_is_type_alias(&self, sym_id: SymbolId) -> bool {
         self.ctx
             .binder
             .symbols

--- a/crates/tsz-checker/src/types/function_type_helpers_async_promise.rs
+++ b/crates/tsz-checker/src/types/function_type_helpers_async_promise.rs
@@ -157,10 +157,13 @@ impl<'a> CheckerState<'a> {
             // (e.g., `type MyPromise<T> = Promise<T>` with `declare var MyPromise: typeof Promise`).
             // The merged symbol prevents is_global_promise_type from recognizing it.
             false
-        } else if self.return_type_annotation_is_exactly_promise(type_annotation) {
-            // The declared annotation resolves to the lib Promise symbol. Some
-            // evaluated Promise<T> forms lose the lazy base identity and arrive
-            // as an Application over an object shape; tsc still accepts them.
+        } else if self.return_type_annotation_resolves_to_promise(type_annotation) {
+            // The declared annotation resolves to the lib Promise symbol, either
+            // directly or through a chain of type aliases
+            // (`type P = Promise<number>` used as `P`). Some evaluated Promise<T>
+            // forms lose the lazy base identity and arrive as an Application over
+            // an object shape — or, for an alias, a fully flattened object — but
+            // tsc resolves the annotation through the alias and still accepts it.
             false
         } else if self.is_non_promise_application_type(return_type) {
             // Return type is an Application with a non-Promise base (e.g., MyPromise<T>).
@@ -168,11 +171,13 @@ impl<'a> CheckerState<'a> {
             true
         } else if return_type != TypeId::ERROR {
             // Return type evaluated to a non-Application form (e.g., Object).
-            // Fall back to strict syntactic check: only suppress TS1064 if the
-            // annotation literally says `Promise<...>`. TSC uses `isReferenceToType`
-            // which requires exactly the global Promise — not subclasses like
-            // `MyPromise`, not qualified names like `X.MyPromise`, not type aliases.
-            !self.return_type_annotation_is_exactly_promise(type_annotation)
+            // Fall back to the annotation-level check: suppress TS1064 only if the
+            // annotation resolves to the global `Promise` — directly or through a
+            // chain of type aliases. TSC uses `isReferenceToType` over the
+            // alias-resolved type, so `type P = Promise<T>` is accepted while
+            // subclasses like `MyPromise`, qualified names like `X.MyPromise`, and
+            // aliases to non-Promise types are rejected.
+            !self.return_type_annotation_resolves_to_promise(type_annotation)
         } else {
             // Return type is ERROR - use syntactic fallback
             // Check if the type annotation is a primitive keyword (never valid for async function)
@@ -401,7 +406,6 @@ impl<'a> CheckerState<'a> {
     /// among the symbol's declarations.
     pub(crate) fn is_promise_type_through_alias(&mut self, type_id: TypeId) -> bool {
         use crate::query_boundaries::checkers::promise as query;
-        use tsz_binder::symbol_flags;
 
         // Check if the base is a Lazy(DefId) pointing to a type alias
         let Some(def_id) = query::promise_application_base_lazy_def_id(self.ctx.types, type_id)
@@ -412,31 +416,139 @@ impl<'a> CheckerState<'a> {
         let Some(sym_id) = self.ctx.def_to_symbol_id(def_id) else {
             return false;
         };
-        let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
-            return false;
-        };
-
         // Only handle type aliases (not classes/interfaces)
-        if !symbol.has_any_flags(symbol_flags::TYPE_ALIAS) {
+        if !self.symbol_is_type_alias(sym_id) {
             return false;
         }
 
-        // Get the alias body type using type_reference_symbol_type_with_params which
-        // correctly handles merged symbols (e.g., `type MyPromise<T> = Promise<T>`
-        // merged with `declare var MyPromise: typeof Promise`). It finds the type
-        // alias declaration in the symbol's declarations list.
+        self.promise_alias_symbol_resolves_to_global(sym_id, 0)
+    }
+
+    /// Whether the async return-type annotation resolves — directly or through a
+    /// chain of type aliases — to the global `Promise`.
+    ///
+    /// tsc's `checkAsyncFunctionReturnType` runs its `isReferenceToType(global
+    /// Promise)` check on `getTypeFromTypeNode(returnTypeNode)`, which unwraps
+    /// type aliases first, so `type P = Promise<number>` referenced as `P` (and
+    /// alias chains `type P1 = P0; type P0 = Promise<number>`) is a valid async
+    /// return type. tsz evaluates such an alias body to a flattened object that
+    /// no longer carries the Promise reference identity, so the type-level
+    /// [`is_global_promise_type`](Self::is_global_promise_type) cannot see it.
+    /// This annotation-level check recovers tsc's answer by resolving the
+    /// annotation's symbol and chasing the alias body through
+    /// [`promise_alias_symbol_resolves_to_global`](Self::promise_alias_symbol_resolves_to_global),
+    /// which compares against the lib `Promise` symbol by identity. It stays
+    /// strict: a `PromiseLike` alias, a primitive alias, or a union alias still
+    /// reports TS1064, matching tsc.
+    pub(crate) fn return_type_annotation_resolves_to_promise(
+        &mut self,
+        type_annotation: NodeIndex,
+    ) -> bool {
+        use crate::symbol_resolver::TypeSymbolResolution;
+
+        let Some(node) = self.ctx.arena.get(type_annotation) else {
+            return false;
+        };
+        let Some(type_ref) = self.ctx.arena.get_type_ref(node) else {
+            return false;
+        };
+        let TypeSymbolResolution::Type(sym_id) =
+            self.resolve_identifier_symbol_in_type_position_without_tracking(type_ref.type_name)
+        else {
+            return false;
+        };
+        // Direct reference to the lib `Promise`.
+        if self.current_symbol_is_lib_promise(sym_id) {
+            return true;
+        }
+        // A type alias whose body resolves — directly or through a chain — to the
+        // global `Promise`. The alias body is chased through
+        // `type_reference_symbol_type_with_params` (the same resolution
+        // `is_promise_type_through_alias` relies on, and which forwards through
+        // alias chains), not the flattened annotation type.
+        self.symbol_is_type_alias(sym_id) && self.promise_alias_symbol_resolves_to_global(sym_id, 0)
+    }
+
+    /// Whether the type-alias symbol `sym_id`'s body resolves — directly or
+    /// through a chain of aliases — to the global `Promise`.
+    ///
+    /// Resolves the body via `type_reference_symbol_type_with_params`, which
+    /// correctly handles merged symbols (`type MyPromise<T> = Promise<T>` merged
+    /// with `declare var MyPromise: typeof Promise`) and forwards through alias
+    /// chains internally. This sees the unflattened alias body even when the
+    /// annotation itself evaluated to a flattened object shape (the
+    /// `type P = Promise<number>` referenced-as-`P` case), which is why the
+    /// annotation-level `return_type_annotation_resolves_to_promise` and the
+    /// type-level `is_promise_type_through_alias` both route through here. The
+    /// `depth` guard bounds a malformed mutually-aliasing pair.
+    pub(crate) fn promise_alias_symbol_resolves_to_global(
+        &mut self,
+        sym_id: tsz_binder::SymbolId,
+        depth: u8,
+    ) -> bool {
+        use crate::query_boundaries::checkers::promise as query;
+
+        if depth > 8 {
+            return false;
+        }
+
         let (body_type, _params) = self.type_reference_symbol_type_with_params(sym_id);
         if self.is_global_promise_type(body_type) {
             return true;
         }
-
-        // The body might itself be an Application (e.g., `Promise<T>`)
-        // Check if the Application base refers to the global Promise type
-        if let Some(body_base) = query::promise_application_base(self.ctx.types, body_type) {
-            // Check if the body's base is Promise
-            return self.is_global_promise_type(body_base);
+        // The body might itself be an Application (e.g., `Promise<T>`); check
+        // whether its base refers to the global Promise type.
+        if let Some(body_base) = query::promise_application_base(self.ctx.types, body_type)
+            && self.is_global_promise_type(body_base)
+        {
+            return true;
         }
+        // Alias chain: forward to the next type alias and re-check. Prefer the
+        // resolved body's own reference (kept lazy for a bare alias); fall back
+        // to walking the alias declaration's AST body, because an intermediate
+        // chain link (`type C = B`) resolves to a flattened object at the type
+        // level and can only be followed syntactically.
+        let next_from_type = query::promise_application_base_lazy_def_id(self.ctx.types, body_type)
+            .or_else(|| query::promise_lazy_def_id(self.ctx.types, body_type))
+            .and_then(|def| self.ctx.def_to_symbol_id(def))
+            .filter(|&next| next != sym_id && self.symbol_is_type_alias(next));
+        // Both producers already exclude `sym_id`, so the next symbol is always a
+        // distinct type alias.
+        let Some(next_sym) = next_from_type.or_else(|| self.next_alias_symbol_via_ast(sym_id))
+        else {
+            return false;
+        };
+        self.promise_alias_symbol_resolves_to_global(next_sym, depth + 1)
+    }
 
-        false
+    /// Follow a bare alias-to-alias link at the AST level: if `sym_id`'s
+    /// type-alias body is a plain reference to another type alias, return that
+    /// alias's symbol. Used to traverse chains such as
+    /// `type C = B; type B = A; type A = Promise<T>` whose intermediate links
+    /// resolve to a flattened object at the type level and so cannot be followed
+    /// through the resolved type.
+    fn next_alias_symbol_via_ast(
+        &self,
+        sym_id: tsz_binder::SymbolId,
+    ) -> Option<tsz_binder::SymbolId> {
+        use crate::symbol_resolver::TypeSymbolResolution;
+        use tsz_parser::parser::syntax_kind_ext;
+
+        let symbol = self.ctx.binder.get_symbol(sym_id)?;
+        let decl_node = symbol.declarations.iter().find_map(|&decl_idx| {
+            let node = self.ctx.arena.get(decl_idx)?;
+            (node.kind == syntax_kind_ext::TYPE_ALIAS_DECLARATION).then_some(node)
+        })?;
+        let type_alias = self.ctx.arena.get_type_alias(decl_node)?;
+        let body_node = self.ctx.arena.get(type_alias.type_node)?;
+        // Only a bare reference is an alias link to follow; `Promise<number>` is
+        // handled at the type level and a union/primitive body is not an alias.
+        let type_ref = self.ctx.arena.get_type_ref(body_node)?;
+        let TypeSymbolResolution::Type(next_sym) =
+            self.resolve_identifier_symbol_in_type_position_without_tracking(type_ref.type_name)
+        else {
+            return None;
+        };
+        (next_sym != sym_id && self.symbol_is_type_alias(next_sym)).then_some(next_sym)
     }
 }

--- a/crates/tsz-checker/tests/async_return_promise_identity_tests.rs
+++ b/crates/tsz-checker/tests/async_return_promise_identity_tests.rs
@@ -64,6 +64,127 @@ async function localPromise(): Promise<number> {
 }
 
 #[test]
+fn async_return_type_alias_to_promise_is_accepted() {
+    // `type P = Promise<number>` referenced as a bare async return annotation.
+    // tsc resolves the alias before its `isReferenceToType(globalPromise)` check
+    // and accepts it; tsz previously raised a false-positive TS1064 because the
+    // alias body evaluates to a flattened object that loses the Promise identity.
+    let codes = check_with_promise_lib(
+        r#"
+type P = Promise<number>;
+async function f(): P { return 1; }
+"#,
+    );
+    assert!(
+        !codes.contains(&1064),
+        "a type alias resolving to Promise<T> is a valid async return type; got {codes:?}"
+    );
+}
+
+#[test]
+fn async_return_type_alias_chain_to_promise_is_accepted() {
+    // A chain of non-generic aliases must be chased to the underlying Promise.
+    let codes = check_with_promise_lib(
+        r#"
+type Aaa = Promise<string>;
+type Bbb = Aaa;
+type Ccc = Bbb;
+async function g(): Ccc { return "x"; }
+"#,
+    );
+    assert!(
+        !codes.contains(&1064),
+        "a chain of aliases resolving to Promise<T> is a valid async return type; got {codes:?}"
+    );
+}
+
+#[test]
+fn async_return_type_alias_accepted_across_function_positions() {
+    // The alias must be accepted for methods, static methods, accessors-free
+    // object-literal methods, and arrow functions, not only free functions.
+    // Binder names are varied to guard against name-based shortcuts.
+    let codes = check_with_promise_lib(
+        r#"
+type Fut = Promise<void>;
+const arrow = async (): Fut => {};
+class Holder {
+    async instanceMethod(): Fut {}
+    static async staticMethod(): Fut {}
+}
+const literal = { async objMethod(): Fut {} };
+"#,
+    );
+    assert!(
+        !codes.contains(&1064),
+        "an alias to Promise must be accepted in every async function position; got {codes:?}"
+    );
+}
+
+#[test]
+fn async_return_generic_type_alias_application_is_accepted() {
+    // Guard the already-working Application form (`type Fut<T> = Promise<T>`
+    // used as `Fut<number>`) so the fix keeps both alias shapes in agreement.
+    let codes = check_with_promise_lib(
+        r#"
+type Fut<T> = Promise<T>;
+type NumFut = Fut<number>;
+async function h(): NumFut { return 1; }
+"#,
+    );
+    assert!(
+        !codes.contains(&1064),
+        "a generic alias application resolving to Promise<T> is a valid async return type; got {codes:?}"
+    );
+}
+
+#[test]
+fn async_return_type_alias_to_non_promise_still_reports() {
+    // A renamed alias whose body is a primitive must still report TS1064.
+    let codes = check_with_promise_lib(
+        r#"
+type Zebra = number;
+async function f(): Zebra { return 1; }
+"#,
+    );
+    assert!(
+        codes.contains(&1064),
+        "an alias to a non-Promise type must still report TS1064; got {codes:?}"
+    );
+}
+
+#[test]
+fn async_return_type_alias_to_promiselike_still_reports() {
+    // `PromiseLike` is not the global `Promise`; an alias to it must still
+    // report TS1064, matching tsc's strict `isReferenceToType` check.
+    let codes = check_with_promise_lib(
+        r#"
+type Thenable = PromiseLike<number>;
+async function f(): Thenable { return 1; }
+"#,
+    );
+    assert!(
+        codes.contains(&1064),
+        "an alias to PromiseLike must still report TS1064; got {codes:?}"
+    );
+}
+
+#[test]
+fn async_return_type_alias_to_promise_union_still_reports() {
+    // A union of Promises is not a reference to the global Promise; tsc reports
+    // TS1064, so the alias-chase must not over-accept unions.
+    let codes = check_with_promise_lib(
+        r#"
+type Either = Promise<number> | Promise<string>;
+async function f(): Either { return 1; }
+"#,
+    );
+    assert!(
+        codes.contains(&1064),
+        "an alias to a union of Promises must still report TS1064; got {codes:?}"
+    );
+}
+
+#[test]
 fn jsdoc_async_return_ignores_typedef_body_promise_mentions() {
     let codes = check_js_with_promise_lib(
         r#"


### PR DESCRIPTION
Fixes #17089

An `async` function / method / arrow whose return-type annotation is a **type alias that resolves to `Promise<T>`** raised a spurious **TS1064** (`The return type of an async function or method must be the global Promise<T> type`). `tsc` resolves the alias before its `isReferenceToType(globalPromise)` check and accepts it.

```ts
type P = Promise<number>;
async function f(): P { return 1; }   // was TS1064; tsc: clean
```

**Structural rule:** when an `async` function/method/arrow declares its return type via a type-alias reference (bare or chained) whose body resolves to the global `Promise<T>`, `tsc` resolves the alias before applying `isReferenceToType(globalPromise)` and accepts it; tsz now does the same through the checker's async-return gate.

## Owner layer & root cause

Checker (`crates/tsz-checker/src/types/function_type_helpers_async_promise.rs`, with a `pub(crate)` visibility bump in `checkers/promise_checker.rs` and `state/type_analysis/core_alias_display.rs`).

`is_global_promise_type` already chases aliases for the **Application** form (`type P<T> = Promise<T>` used as `P<number>`) via `promise_base_is_global_or_alias_to_global` → `type_alias_resolves_to_promise`. A **non-generic** alias referenced bare (`P`) evaluates to a *flattened object shape* that no longer carries the Promise reference identity, so no type-level check can see it, and the `check_async_return_type_is_promise` fallback (`return_type_annotation_is_exactly_promise`) required the annotation to spell `Promise<...>` literally — so every alias-typed async return became a false-positive TS1064.

The fix adds `return_type_annotation_resolves_to_promise`, which resolves the annotation's alias **symbol** and chases its body through `type_reference_symbol_type_with_params` (the same resolution the Application form uses), plus an AST-level walk (`next_alias_symbol_via_ast`) for bare alias-to-alias **chain** links whose intermediate hops flatten to an object. The existing `is_promise_type_through_alias` is refactored to share the new `promise_alias_symbol_resolves_to_global` helper. Decisions remain symbol-identity based (no name/string matching).

## Adjacent-case matrix (measured vs pinned `typescript@7.0.2`, `--strict --target es2022 --module esnext`)

| annotation | before | tsc | after |
| --- | --- | --- | --- |
| `Promise<number>` (direct) | clean | clean | clean |
| `type P = Promise<number>` → `P` | **TS1064** | clean | clean |
| chain `P1 = P0; P0 = Promise<number>` → `P1` | **TS1064** | clean | clean |
| generic alias `P<T> = Promise<T>` → `P<number>` | clean | clean | clean |
| method / static / object-literal method / arrow, alias | **TS1064** | clean | clean |
| renamed binder (`type Zebra = Promise<boolean>`) | **TS1064** | clean | clean |
| `type P = number` → `P` | TS1064 | TS1064 | TS1064 |
| `type P = PromiseLike<number>` → `P` | TS1064 | TS1064 | TS1064 |
| `type U = Promise<number> \| Promise<string>` → `U` | TS1064 | TS1064 | TS1064 |
| `interface MyP extends Promise<number>` → `MyP` | TS1064 | TS1064 | TS1064 |

## Not in scope

For the `interface extends Promise` and union-of-Promises negatives, tsz also emits a spurious **TS2322** after the (correct) TS1064 — it still checks the body `return` against the invalid async return type where `tsc` suppresses it. That is a distinct post-TS1064 body-suppression bug; this PR does not touch it (noted in #17089).

## Goal
Goal: green

## Verification
- New unit tests in `crates/tsz-checker/tests/async_return_promise_identity_tests.rs` pin both directions of the rule (accepted: bare alias, alias chain, all function positions, generic-alias application; still-reported: primitive alias, `PromiseLike` alias, union alias), with renamed binders — 9/9 pass locally.
- Pre-commit hook: `clippy -p tsz-checker` clean, architecture guard passed (both touched src files < 2000 LOC).
- Full `cargo test -p tsz-checker --lib` was run locally after the change: every completed test passed (no regressions) before the run was cut short by an unrelated pre-existing slow test (`ts2589_tests::recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589`, >60s, unrelated to this change).
- Every matrix row above cross-checked against `typescript@7.0.2` via `scripts/conformance/oracle.sh`.
- conformance / emit / fourslash run nightly; this change only *removes* a spurious TS1064 and preserves every negative, so it can only hold or improve the conformance floor.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01A3ieQMVrgfZF3KxcSgciCz)_