### PR TITLE
fix(checker): emit TS1039/TS1254 for implicitly-ambient `.d.ts` initializers

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -470,11 +470,13 @@ impl<'a> CheckerState<'a> {
         }
 
         let is_catch_variable = self.is_catch_clause_variable_declaration(decl_idx);
-        // TS1039/TS1254: Check initializers in ambient contexts.
-        // Use is_in_ambient_context (checks for explicit `declare` keyword ancestors)
-        // rather than is_ambient_declaration (which also returns true for all .d.ts files).
-        // TSC does not emit TS1039 for variable initializers in .d.ts files.
-        if var_decl.initializer.is_some() && self.ctx.arena.is_in_ambient_context(decl_idx) {
+        // TS1039/TS1254: initializers are illegal in any ambient declaration.
+        // Use is_ambient_declaration (`.d.ts` file OR an explicit `declare`/AMBIENT
+        // context), not the declare-only is_in_ambient_context: a `.d.ts` is entirely
+        // ambient, so tsc emits these for its implicitly-ambient members too — e.g.
+        // `const x: T = v;` / `export const x: T = v;` / `let x = v;` in a `.d.ts` —
+        // exactly as for `declare const x: T = v;` in a `.ts` (oracle: typescript@7.0.2).
+        if var_decl.initializer.is_some() && self.is_ambient_declaration(decl_idx) {
             use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
             let is_const = self.ctx.arena.is_var_const_like_declaration(decl_idx);
             if is_const && var_decl.type_annotation.is_none() {

--- a/crates/tsz-checker/src/tests/ambient_top_level_initializer_ts1039_tests.rs
+++ b/crates/tsz-checker/src/tests/ambient_top_level_initializer_ts1039_tests.rs
@@ -184,23 +184,101 @@ fn ambient_class_readonly_property_still_reports_ts1039() {
     );
 }
 
-/// Regression pin, not a correctness claim: `core.rs` gates this whole check
-/// on `is_in_ambient_context` (explicit `declare` ancestor), which is `false`
-/// for a bare `.d.ts` top-level declaration with no `declare` keyword, so
-/// tsz emits nothing here today. Oracle-verified against pinned
-/// `typescript@7.0.2` while writing this fix: real `tsc` DOES emit TS1039 in
-/// this exact `.d.ts` shape (`case.d.ts(1,19): error TS1039 ...`) — the
-/// pre-existing comment above the `is_in_ambient_context` check ("TSC does
-/// not emit TS1039 for variable initializers in .d.ts files") does not hold
-/// for this shape. That is a separate, pre-existing false-negative in the
-/// `is_in_ambient_context` gate itself, not the pre-contextual-reset drop
-/// this PR fixes, and out of scope here — this test only pins that the
-/// reset fix does not change `.d.ts` behavior one way or the other.
+// ---------------------------------------------------------------------------
+// The `.d.ts` emission gap (follow-up to #17080).
+//
+// A `.d.ts` file is entirely ambient, so tsc's ambient-initializer grammar
+// check fires for every top-level declaration in it — even with no `declare`
+// keyword — exactly as it does for an explicit `declare` in a `.ts` file
+// (oracle: pinned `typescript@7.0.2`, `--noEmit --strict --lib es2022`). The
+// emission was previously gated on `is_in_ambient_context` (explicit `declare`
+// ancestor only), which is `false` for a bare/`export`-modified `.d.ts` member,
+// so tsz dropped TS1039/TS1254 there — a false-negative #17080 identified and
+// deliberately left out of scope. The gate now uses `is_ambient_declaration`
+// (`.d.ts` file OR explicit ambient context), which closes it.
+// ---------------------------------------------------------------------------
+
+/// `const x: number = 1;` in a `.d.ts` (no `declare`) — tsc emits TS1039
+/// (`case.d.ts(1,19): error TS1039`), so tsz now must too.
 #[test]
-fn dts_file_bare_annotated_initializer_unaffected_by_this_fix() {
+fn dts_file_bare_annotated_initializer_reports_ts1039() {
     let got = codes_in_file("test.d.ts", "const x: number = 1;");
     assert!(
-        !got.contains(&INITIALIZERS_NOT_ALLOWED_IN_AMBIENT),
-        "this fix must not change bare-.d.ts TS1039 behavior; got {got:?}"
+        got.contains(&INITIALIZERS_NOT_ALLOWED_IN_AMBIENT),
+        "a bare-.d.ts annotated initializer is ambient — expected TS1039; got {got:?}"
     );
+}
+
+/// `export const x: number = 1;` in a `.d.ts` — an `export` modifier is not a
+/// `declare` keyword, but the file is still ambient. tsc emits TS1039.
+#[test]
+fn dts_file_export_const_annotated_initializer_reports_ts1039() {
+    let got = codes_in_file("test.d.ts", "export const x: number = 1;");
+    assert!(
+        got.contains(&INITIALIZERS_NOT_ALLOWED_IN_AMBIENT),
+        "an exported .d.ts annotated initializer is ambient — expected TS1039; got {got:?}"
+    );
+}
+
+/// `export let x: number = 1;` — a non-`const` binding gets no literal
+/// exception; tsc reports TS1039 in a `.d.ts`.
+#[test]
+fn dts_file_export_let_annotated_initializer_reports_ts1039() {
+    let got = codes_in_file("test.d.ts", "export let x: number = 1;");
+    assert!(
+        got.contains(&INITIALIZERS_NOT_ALLOWED_IN_AMBIENT),
+        "an exported .d.ts `let` initializer is ambient — expected TS1039; got {got:?}"
+    );
+}
+
+/// `export var x = 5;` — `var`/`let` never get the const-literal exception, so
+/// even a bare numeric literal initializer is TS1039 in a `.d.ts`.
+#[test]
+fn dts_file_export_var_literal_initializer_reports_ts1039() {
+    let got = codes_in_file("test.d.ts", "export var x = 5;");
+    assert!(
+        got.contains(&INITIALIZERS_NOT_ALLOWED_IN_AMBIENT),
+        "a `var` literal initializer in a .d.ts is TS1039; got {got:?}"
+    );
+}
+
+/// `let x = 1;` (bare, no `declare`) — non-`const` literal is still TS1039.
+#[test]
+fn dts_file_bare_let_literal_initializer_reports_ts1039() {
+    let got = codes_in_file("test.d.ts", "let x = 1;");
+    assert!(
+        got.contains(&INITIALIZERS_NOT_ALLOWED_IN_AMBIENT),
+        "a bare .d.ts `let` literal initializer is TS1039; got {got:?}"
+    );
+}
+
+/// `const x = 1 + 1;` (bare, no annotation) — the const-with-non-literal path is
+/// TS1254, not TS1039, in a `.d.ts` just as under `declare`.
+#[test]
+fn dts_file_bare_const_computed_initializer_reports_ts1254_not_ts1039() {
+    let got = codes_in_file("test.d.ts", "const x = 1 + 1;");
+    assert!(
+        got.contains(&CONST_INITIALIZER_MUST_BE_LITERAL)
+            && !got.contains(&INITIALIZERS_NOT_ALLOWED_IN_AMBIENT),
+        "a non-literal ambient const initializer is TS1254 in a .d.ts; got {got:?}"
+    );
+}
+
+/// Negative control: the const-literal exception still holds in a `.d.ts`, so a
+/// bare-literal `const` stays clean (no TS1039, no TS1254) — whether written
+/// bare, `export`ed, or `declare`d.
+#[test]
+fn dts_file_const_literal_initializers_stay_clean() {
+    for source in [
+        "const x = 1;",
+        "export const x = 1;",
+        "declare const x = 1;",
+    ] {
+        let got = codes_in_file("test.d.ts", source);
+        assert!(
+            !got.contains(&INITIALIZERS_NOT_ALLOWED_IN_AMBIENT)
+                && !got.contains(&CONST_INITIALIZER_MUST_BE_LITERAL),
+            "a bare-literal ambient const is legal in a .d.ts (`{source}`); got {got:?}"
+        );
+    }
 }


### PR DESCRIPTION
When a variable declaration in a `.d.ts` file carries an initializer, `tsc`
applies the ambient-initializer grammar check exactly as under an explicit
`declare` in a `.ts` file — a whole `.d.ts` is ambient, so every top-level
declaration in it is ambient even without a `declare` keyword. tsz gated
that emission on `is_in_ambient_context` (walks for an explicit
`declare`/AMBIENT ancestor only), so it dropped TS1039/TS1254 for
`export`-modified and bare `.d.ts` members through `crates/tsz-checker/src/state/variable_checking/core.rs`.

This is the distinct emission-gate gap that #17080 (the fix for #17073, the
pre-contextual-reset *drop*) identified via the oracle and explicitly left out
of scope, pinning the wrong behavior in
`dts_file_bare_annotated_initializer_unaffected_by_this_fix`. The gate now uses
`is_ambient_declaration` (`.d.ts` file OR explicit ambient context) — the full
grammar surface the const-literal exception already assumes. The emission logic
below the gate is unchanged and already matches tsc once it runs: const-literal
→ clean; const non-literal → TS1254; non-`const` or annotated → TS1039.

Oracle (pinned `typescript@7.0.2`, `--noEmit --strict --lib es2022 --target es2022`):

| source (`test.d.ts`) | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `const x: number = 1;` | TS1046, TS1039 | TS1046 | TS1046, TS1039 |
| `export const x: number = 1;` | TS1039 | (none) | TS1039 |
| `export let x: number = 1;` | TS1039 | (none) | TS1039 |
| `export var x = 5;` | TS1039 | (none) | TS1039 |
| `const x = 1 + 1;` | TS1046, TS1254 | TS1046 | TS1046, TS1254 |
| `const x = 1;` | TS1046 | TS1046 | TS1046 |
| `export const x = 1;` / `declare const x = 1;` | clean | clean | clean |

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib ambient_top_level_initializer_ts1039` — 17 pass, incl. the new `.d.ts` matrix and the flipped deferred-behavior pin.
- `cargo test -p tsz-checker --test ts1254_ambient_const_tests --test ambient_readonly_literal_initializer_tests` — pass (no regression on adjacent ambient paths).
- Each row above diffed directly against the pinned `typescript@7.0.2` oracle.
- clippy (`cargo clippy --profile ci-lint --workspace --all-targets -- -D warnings`) and arch-size (`scripts/arch/arch_guard.py`) — the two per-merge CI gates — both green locally.
- Full conformance/emit/fourslash not run locally (environment disk limit); those lanes are nightly/dispatch-only, not per-merge.

## Provenance
Machine: cloud
Assistant: claude-code
Model: Claude Opus (Claude Code)
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01BhZ7gCRpNkdk84t3Uk5GUp)_