### PR TITLE
fix(checker): qualified `typeof import(...).Member` drops TS2694 for a type-only member

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2838,3 +2838,6 @@ path = "tests/ts7023_self_recursive_var_reassigned_return_tests.rs"
 [[test]]
 name = "ts1339_bare_typeof_import_no_value_tests"
 path = "tests/ts1339_bare_typeof_import_no_value_tests.rs"
+[[test]]
+name = "ts2694_typeof_import_qualified_type_only_member_tests"
+path = "tests/ts2694_typeof_import_qualified_type_only_member_tests.rs"

--- a/crates/tsz-checker/src/state/type_analysis/core_type_query.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core_type_query.rs
@@ -1827,6 +1827,22 @@ impl<'a> CheckerState<'a> {
         }
 
         let sym_id = self.resolve_named_export_via_export_equals(module_name, next_segment)?;
+
+        // `typeof import("mod").Member` is a VALUE query: a member that exists
+        // but carries no value meaning (an interface, a type alias) must not
+        // resolve here — tsc reports TS2694 for it, matching a genuinely
+        // missing member, not the member's own (type) meaning. Mirrors the
+        // identical value-only gate `resolve_namespace_typeof_member` already
+        // applies to namespace members reached through the ordinary property
+        // path; this helper is the export=-target fallback for the same query
+        // and needs the same filter.
+        let member_is_value = self.get_cross_file_symbol(sym_id).is_some_and(|sym| {
+            sym.has_any_flags(tsz_binder::symbol_flags::VALUE | tsz_binder::symbol_flags::ALIAS)
+        });
+        if !member_is_value {
+            return None;
+        }
+
         Some(self.get_type_of_symbol(sym_id))
     }
 }

--- a/crates/tsz-checker/tests/ts2694_typeof_import_qualified_type_only_member_tests.rs
+++ b/crates/tsz-checker/tests/ts2694_typeof_import_qualified_type_only_member_tests.rs
@@ -1,0 +1,257 @@
+//! TS2694: `typeof import("mod").Member` is a VALUE query. When `Member`
+//! exists on the `export =` target but carries no value meaning (an
+//! interface or a type alias), `tsc` reports TS2694 — the same diagnostic a
+//! genuinely missing member gets, because a type-only member has nothing to
+//! offer a value position. Drop the `typeof` and the identical `Member`
+//! reference is a perfectly good type, so this is not a member-resolution bug
+//! in general; it is the value-meaning filter missing specifically on the
+//! qualified `typeof import(...).Member` path (the bare, unqualified form
+//! already gets this filter via TS1339, see
+//! `ts1339_bare_typeof_import_no_value_tests.rs`).
+//!
+//! Oracle-verified against pinned `typescript@7.0.2` for diagnostic CODE and
+//! member name; the namespace-name text tsz renders in the message
+//! (`"m".export=`) already diverges from tsc's (`N`) on the pre-existing
+//! sibling path this PR does not touch (see
+//! `export_equals_namespace_value_member_missing_sibling_reports_ts2694`) —
+//! a separate, out-of-scope display quirk, not part of this fix.
+//!
+//! Sibling of #17076/TS1339 — same underlying question ("does this
+//! import-type reference name a value?") asked at the qualified position
+//! instead of the bare one.
+//!
+//! Owner: `crates/tsz-checker/src/state/type_analysis/core_type_query.rs`
+//! (`try_resolve_typeof_import_segment_via_export_equals`), the export=-target
+//! fallback `resolve_typeof_import_query` reaches for a first segment that
+//! the ordinary namespace-member path (`resolve_namespace_typeof_member`,
+//! which already applies this same value-only filter) does not resolve.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_multi_file;
+use tsz_common::common::ModuleKind;
+
+const TS2694: u32 = 2694;
+
+fn check(files: &[(&str, &str)], entry: &str) -> Vec<(u32, String)> {
+    check_multi_file(
+        files,
+        entry,
+        CheckerOptions {
+            module: ModuleKind::CommonJS,
+            ..CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    .map(|d| (d.code, d.message_text))
+    .collect()
+}
+
+fn codes(diagnostics: &[(u32, String)]) -> Vec<u32> {
+    let mut codes: Vec<u32> = diagnostics.iter().map(|(code, _)| *code).collect();
+    codes.sort_unstable();
+    codes
+}
+
+/// `export = <namespace>` whose member is an interface: the member exists but
+/// has no value meaning, so `typeof import(...).Q` cannot name it.
+#[test]
+fn export_equals_namespace_interface_member_reports_ts2694() {
+    let diags = check(
+        &[
+            (
+                "/m.ts",
+                "namespace N {\n  export interface Q {}\n}\nexport = N;\n",
+            ),
+            ("/main.ts", "type T = typeof import(\"./m\").Q;\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diags), vec![TS2694], "{diags:?}");
+    let (_, message) = diags.iter().find(|(code, _)| *code == TS2694).unwrap();
+    // tsc's message names the namespace `N`; tsz renders the export=-target
+    // qualifier as `"m".export=` here even for this pre-existing sibling path
+    // (see `export_equals_namespace_value_member_missing_sibling_reports_ts2694`
+    // below, untouched by this PR) — a separate, already-diverging display
+    // quirk in the namespace-name formatting, not a TS2694 emission bug. Only
+    // the emission (code + member name) is this PR's concern.
+    assert_eq!(
+        message,
+        "Namespace '\"m\".export=' has no exported member 'Q'."
+    );
+}
+
+/// Same value-less shape via a type alias member instead of an interface.
+#[test]
+fn export_equals_namespace_type_alias_member_reports_ts2694() {
+    let diags = check(
+        &[
+            (
+                "/m.ts",
+                "namespace N {\n  export type Q = string;\n}\nexport = N;\n",
+            ),
+            ("/main.ts", "type T = typeof import(\"./m\").Q;\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diags), vec![TS2694], "{diags:?}");
+    let (_, message) = diags.iter().find(|(code, _)| *code == TS2694).unwrap();
+    assert_eq!(
+        message,
+        "Namespace '\"m\".export=' has no exported member 'Q'."
+    );
+}
+
+/// Negative control that keeps the fix honest: a genuinely missing member on
+/// the same type-only namespace must still report TS2694 with the same
+/// message shape — a fix keyed on "member not found" would coincidentally
+/// pass the two tests above without fixing the real gap, so this pins that
+/// the code path is not accidentally suppressing all output.
+#[test]
+fn export_equals_namespace_missing_member_reports_ts2694() {
+    let diags = check(
+        &[
+            (
+                "/m.ts",
+                "namespace N {\n  export interface Q {}\n}\nexport = N;\n",
+            ),
+            ("/main.ts", "type T = typeof import(\"./m\").Nope;\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diags), vec![TS2694], "{diags:?}");
+    let (_, message) = diags.iter().find(|(code, _)| *code == TS2694).unwrap();
+    assert_eq!(
+        message,
+        "Namespace '\"m\".export=' has no exported member 'Nope'."
+    );
+}
+
+/// Negative control: a value member (`const v`) on the same shape of
+/// namespace resolves cleanly — the filter must not over-suppress value
+/// members reached through this same export=-target fallback path.
+#[test]
+fn export_equals_namespace_value_member_is_clean() {
+    let diags = check(
+        &[
+            (
+                "/m.ts",
+                "namespace N {\n  export const v = 1;\n}\nexport = N;\n",
+            ),
+            ("/main.ts", "type T = typeof import(\"./m\").v;\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diags), Vec::<u32>::new(), "{diags:?}");
+}
+
+/// Negative control: a missing member on a value-instantiated namespace still
+/// reports TS2694 — this shape resolves through the ordinary namespace-member
+/// path (not the export=-target fallback this PR touches), so it must be
+/// unaffected.
+#[test]
+fn export_equals_namespace_value_member_missing_sibling_reports_ts2694() {
+    let diags = check(
+        &[
+            (
+                "/m.ts",
+                "namespace N {\n  export const v = 1;\n}\nexport = N;\n",
+            ),
+            ("/main.ts", "type T = typeof import(\"./m\").Nope;\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diags), vec![TS2694], "{diags:?}");
+    let (_, message) = diags.iter().find(|(code, _)| *code == TS2694).unwrap();
+    assert_eq!(
+        message,
+        "Namespace '\"m\".export=' has no exported member 'Nope'."
+    );
+}
+
+/// Negative control: a plain module (no `export =` at all) reports TS2694 for
+/// a missing member too, unaffected by this fix (it never reaches the
+/// export=-target fallback).
+#[test]
+fn plain_module_missing_member_reports_ts2694() {
+    let diags = check(
+        &[
+            ("/m.ts", "export const v = 1;\n"),
+            ("/main.ts", "type T = typeof import(\"./m\").Nope;\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diags), vec![TS2694], "{diags:?}");
+}
+
+/// Negative control: a plain module's actual value export resolves cleanly.
+#[test]
+fn plain_module_value_member_is_clean() {
+    let diags = check(
+        &[
+            ("/m.ts", "export const v = 1;\n"),
+            ("/main.ts", "type T = typeof import(\"./m\").v;\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diags), Vec::<u32>::new(), "{diags:?}");
+}
+
+/// Nested-namespace adjacent case: only the FIRST unqualified segment goes
+/// through the export=-target fallback this PR changes (`resolved_segments`
+/// must be empty); a second-segment miss inside an already-resolved nested
+/// namespace takes a different path entirely and must stay unaffected.
+#[test]
+fn nested_namespace_missing_member_reports_ts2694() {
+    let diags = check(
+        &[
+            (
+                "/m.ts",
+                "namespace N {\n  export namespace M {\n    export const v = 1;\n  }\n}\nexport = N;\n",
+            ),
+            ("/main.ts", "type T = typeof import(\"./m\").M.Nope;\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diags), vec![TS2694], "{diags:?}");
+    let (_, message) = diags.iter().find(|(code, _)| *code == TS2694).unwrap();
+    assert_eq!(
+        message,
+        "Namespace '\"m\".M.export=' has no exported member 'Nope'."
+    );
+}
+
+/// The discriminator: drop `typeof` and the identical `Q` reference is a
+/// perfectly good TYPE, so it must stay clean. This is what rules out any fix
+/// keyed on "member not found" — `Q` is found, and correctly so; it just has
+/// no value meaning for the `typeof`-qualified value position.
+#[test]
+fn qualified_import_type_without_typeof_on_interface_member_is_clean() {
+    let diags = check(
+        &[
+            (
+                "/m.ts",
+                "namespace N {\n  export interface Q {}\n}\nexport = N;\n",
+            ),
+            ("/main.ts", "type T = import(\"./m\").Q;\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diags), Vec::<u32>::new(), "{diags:?}");
+}
+
+/// Renamed-binder adjacent case: the interface's name must not be
+/// load-bearing.
+#[test]
+fn renamed_export_equals_namespace_interface_member_reports_ts2694() {
+    let diags = check(
+        &[
+            (
+                "/m.ts",
+                "namespace SomethingElse {\n  export interface Whatever {}\n}\nexport = SomethingElse;\n",
+            ),
+            ("/main.ts", "type T = typeof import(\"./m\").Whatever;\n"),
+        ],
+        "/main.ts",
+    );
+    assert_eq!(codes(&diags), vec![TS2694], "{diags:?}");
+}


### PR DESCRIPTION
`typeof import("mod").Member` is a VALUE query. When `Member` exists on the `export =` target but has no value meaning (an interface or a type alias), `tsc` reports TS2694 (`Namespace 'N' has no exported member 'Member'.`); tsz resolved it as a type and stayed silent.

Structural rule: when the export=-target fallback (`try_resolve_typeof_import_segment_via_export_equals` in `crates/tsz-checker/src/state/type_analysis/core_type_query.rs`) resolves the first unqualified segment of a `typeof import(...).Member` query, `tsc` treats that resolution as a VALUE lookup and rejects a type-only match; tsz resolved any member regardless of value/type meaning through the shared solver-backed `resolve_named_export_via_export_equals` query (which is correctly type-agnostic for its *other* callers — named-import resolution, JSDoc type lookups — so it cannot itself be narrowed). Fixed by gating this one call site on the same `VALUE | ALIAS` flag check `resolve_namespace_typeof_member` already applies to namespace members reached through the ordinary property-access path a few lines up in the same function; this helper is the export=-target fallback for that identical query and needed the same filter.

Drop the `typeof` and the identical `Member` reference is a perfectly good type (`import("mod").Q` stays clean), so this is not a member-resolution bug in general — the member is found, correctly, it just has no value meaning for this specific value position.

Sibling of #17076 (TS1339 for the bare, unqualified form) — same underlying question ("does this import-type reference name a value?") asked at the qualified position instead. Filed and matrix-built by @mohsen1 as #17081 while reviewing #17076.

## Adjacent-case matrix (10 new tests)

- `export =` namespace, interface member → TS2694 (the bug)
- `export =` namespace, type-alias member → TS2694 (same shape, second type kind)
- renamed-binder control (interface name is not load-bearing) → TS2694
- negative control: same type-only namespace, genuinely missing member → still TS2694 (rules out a fix that just suppresses all output through this path)
- negative control: value member (`const v`) on the same namespace shape → resolves cleanly (the filter must not over-suppress value members reached through this same fallback)
- negative control: value-instantiated namespace, missing sibling member → still TS2694 (this shape resolves through the *ordinary* namespace-member path, not the fallback this PR touches, so it must be unaffected)
- negative control: plain module (no `export =`), missing/present member pair → unaffected (never reaches the export=-target fallback)
- negative control: nested namespace, second-segment miss → unaffected (only the *first* unqualified segment goes through this fallback; `resolved_segments` must be non-empty for deeper segments)
- **the discriminator**: `import("mod").Q` (no `typeof`) on the same type-only member → stays clean, proving the member itself resolves fine and this is purely a value-position filter

Test-message note: the exact namespace-name text tsz renders (`"m".export=`) already diverges from `tsc`'s (`N`) on a pre-existing sibling path this PR does not touch — confirmed by the value-instantiated-namespace negative control showing the identical divergence with no code changed on that path. Tests assert tsz's actual (pre-existing) message text for that reason; only the diagnostic *code* and *member name* are this PR's concern, oracle-verified against `typescript@7.0.2`.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts2694_typeof_import_qualified_type_only_member_tests` — 10/10 pass
- `cargo test -p tsz-checker --test ts1339_bare_typeof_import_no_value_tests` — 9/9 pass (sibling suite, unaffected)
- `cargo test -p tsz-checker --test namespace_qualified_diagnostic_tests` — 22/22 pass (existing TS2694/namespace-display regression suite, unaffected)
- `cargo clippy -p tsz-checker --all-targets` — clean
- `cargo fmt --check -p tsz-checker` — clean
- Arch-size guard: touched file `core_type_query.rs` is 1848/2000 lines after this change, no new shard needed
- Full unfiltered `cargo test -p tsz-checker --lib` was still running past 40 minutes at push time (board's own documented long-tail behavior on this container); will report the result as a PR comment when it lands. The change is a single added filter at one call site with no new state, and every test suite that exercises the touched code path (the three above) already passed, so this is expected to be a no-op on the rest of the suite.
- `compare-to-parent`/conformance snapshot not run (time budget); this diagnostic path only fires for a narrow `export =` namespace + type-only-member + `typeof`-qualifier shape, expected zero/near-zero movement.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01HdKdSSEzLQtzJPsVWjb5se)_