### PR TITLE
fix(checker): TS1039/TS1254 for bare .d.ts implicit-ambient initializers

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -471,10 +471,10 @@ impl<'a> CheckerState<'a> {
 
         let is_catch_variable = self.is_catch_clause_variable_declaration(decl_idx);
         // TS1039/TS1254: Check initializers in ambient contexts.
-        // Use is_in_ambient_context (checks for explicit `declare` keyword ancestors)
-        // rather than is_ambient_declaration (which also returns true for all .d.ts files).
-        // TSC does not emit TS1039 for variable initializers in .d.ts files.
-        if var_decl.initializer.is_some() && self.ctx.arena.is_in_ambient_context(decl_idx) {
+        // Every top-level declaration in a `.d.ts` file is implicitly ambient, so
+        // `is_ambient_declaration` (declare-keyword ancestor OR .d.ts file) is the
+        // correct gate here, matching tsc's `isSimpleLiteralEnumReference` sibling checks.
+        if var_decl.initializer.is_some() && self.is_ambient_declaration(decl_idx) {
             use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
             let is_const = self.ctx.arena.is_var_const_like_declaration(decl_idx);
             if is_const && var_decl.type_annotation.is_none() {

--- a/crates/tsz-checker/src/tests/ambient_top_level_initializer_ts1039_tests.rs
+++ b/crates/tsz-checker/src/tests/ambient_top_level_initializer_ts1039_tests.rs
@@ -184,23 +184,66 @@ fn ambient_class_readonly_property_still_reports_ts1039() {
     );
 }
 
-/// Regression pin, not a correctness claim: `core.rs` gates this whole check
-/// on `is_in_ambient_context` (explicit `declare` ancestor), which is `false`
-/// for a bare `.d.ts` top-level declaration with no `declare` keyword, so
-/// tsz emits nothing here today. Oracle-verified against pinned
-/// `typescript@7.0.2` while writing this fix: real `tsc` DOES emit TS1039 in
-/// this exact `.d.ts` shape (`case.d.ts(1,19): error TS1039 ...`) — the
-/// pre-existing comment above the `is_in_ambient_context` check ("TSC does
-/// not emit TS1039 for variable initializers in .d.ts files") does not hold
-/// for this shape. That is a separate, pre-existing false-negative in the
-/// `is_in_ambient_context` gate itself, not the pre-contextual-reset drop
-/// this PR fixes, and out of scope here — this test only pins that the
-/// reset fix does not change `.d.ts` behavior one way or the other.
+/// Fixed by #17086: every top-level declaration in a `.d.ts` file is
+/// implicitly ambient, so a bare (no explicit `declare`) `.d.ts` top-level
+/// initializer is an ambient-initializer grammar error just like an explicit
+/// `declare`. `core.rs` now gates on `is_ambient_declaration` (declare
+/// keyword ancestor OR `.d.ts` file), matching tsc.
 #[test]
-fn dts_file_bare_annotated_initializer_unaffected_by_this_fix() {
+fn dts_file_bare_annotated_initializer_reports_ts1039() {
     let got = codes_in_file("test.d.ts", "const x: number = 1;");
     assert!(
+        got.contains(&INITIALIZERS_NOT_ALLOWED_IN_AMBIENT),
+        "expected TS1039 for a bare .d.ts top-level initializer, got {got:?}"
+    );
+}
+
+/// Adjacent case: the no-annotation const sibling picks TS1254, not TS1039,
+/// for a bare `.d.ts` top-level declaration too.
+#[test]
+fn dts_file_bare_no_annotation_non_literal_reports_ts1254() {
+    let got = codes_in_file("test.d.ts", "export const x = {};");
+    assert!(
+        got.contains(&CONST_INITIALIZER_MUST_BE_LITERAL),
+        "expected TS1254, got {got:?}"
+    );
+    assert!(
         !got.contains(&INITIALIZERS_NOT_ALLOWED_IN_AMBIENT),
-        "this fix must not change bare-.d.ts TS1039 behavior; got {got:?}"
+        "did not expect TS1039 for the no-annotation case, got {got:?}"
+    );
+}
+
+/// Adjacent case: a `.d.ts` declaration without an initializer stays clean.
+#[test]
+fn dts_file_no_initializer_is_clean() {
+    let got = codes_in_file("test.d.ts", "export const x: number;");
+    assert!(
+        !got.contains(&INITIALIZERS_NOT_ALLOWED_IN_AMBIENT)
+            && !got.contains(&CONST_INITIALIZER_MUST_BE_LITERAL),
+        "expected no ambient-initializer diagnostics, got {got:?}"
+    );
+}
+
+/// Adjacent case: an explicit `declare` inside a `.d.ts` file must still emit
+/// exactly one TS1039 — no double-report from the `.d.ts`-file gate stacking
+/// with the explicit `declare` ancestor gate.
+#[test]
+fn dts_file_explicit_declare_reports_ts1039_once() {
+    let got = codes_in_file("test.d.ts", "declare const x: number = 1;");
+    let ts1039_count = got
+        .iter()
+        .filter(|&&c| c == INITIALIZERS_NOT_ALLOWED_IN_AMBIENT)
+        .count();
+    assert_eq!(ts1039_count, 1, "expected exactly one TS1039, got {got:?}");
+}
+
+/// Adjacent case: renamed binder, `let` instead of `const`, in a bare `.d.ts`
+/// file.
+#[test]
+fn dts_file_bare_let_reports_ts1039() {
+    let got = codes_in_file("test.d.ts", "export let totallyDifferentName: number = 1;");
+    assert!(
+        got.contains(&INITIALIZERS_NOT_ALLOWED_IN_AMBIENT),
+        "expected TS1039, got {got:?}"
     );
 }


### PR DESCRIPTION
Every top-level declaration in a `.d.ts` file is implicitly ambient, so a variable initializer there is an ambient-initializer grammar error even without an explicit `declare` keyword: **when a `.d.ts` file has a top-level variable declaration with an initializer, tsc reports TS1039 (or TS1254 for a bare `const` with a non-literal initializer); tsz now does the same through `CheckerState::is_ambient_declaration` in `state/variable_checking/core.rs`.**

`variable_checking/core.rs` previously gated the TS1039/TS1254 check on `arena.is_in_ambient_context`, which only checks for an explicit `declare`-keyword ancestor. Its own comment claimed *"TSC does not emit TS1039 for variable initializers in .d.ts files"* — false per the pinned oracle, and exactly the false-negative filed in #17086 with a repro table. The fix swaps in `self.is_ambient_declaration(decl_idx)` (`CheckerState`, resolving to `CheckerContext::is_ambient_declaration` = `is_declaration_file() || arena.is_in_ambient_context`), the same helper the adjacent TS1155 check two call sites up in this file already uses — no new logic, just the correct existing gate.

Owner layer: checker only (`state/variable_checking/core.rs`), no parser/emitter changes.

Closes #17086.

## Goal
Goal: hold

## Verification
- Oracle-verified against pinned `typescript@7.0.2` (`--noEmit --strict --lib es2022 --target es2022`) across 8 `.d.ts` shapes (bare `const`/`let`/`var` with/without annotation, literal vs non-literal, explicit `declare`, no-initializer) — tsz now matches exactly on all 8.
- 5 new/updated unit tests in `crates/tsz-checker/src/tests/ambient_top_level_initializer_ts1039_tests.rs`: bare `.d.ts` annotated initializer → TS1039 (was previously pinned as a known-missing regression, now flipped to the correct expectation); bare no-annotation non-literal → TS1254 only; no-initializer stays clean; explicit `declare` inside `.d.ts` emits **exactly one** TS1039 (no double-report from the two gates stacking); renamed-binder `let` case.
  `cargo test -p tsz-checker --lib ambient_top_level_initializer_ts1039` → 15/15 passed (10 pre-existing + 5 new/updated).
- `cargo clippy -p tsz-checker --lib -- -D warnings` → clean.
- `cargo fmt -p tsz-checker -- --check` → clean.
- Pre-commit hook (clippy + affected-crate tests + architecture guard) passed locally.
- Full `cargo test -p tsz-checker --lib` (11000+ tests) was still running in the background at push time (documented long tail on this board, not a hang) — will report back if it surfaces anything unrelated.
- This gate change is narrow (only fires for a `.d.ts` file with a bare top-level variable initializer) but touches every `.d.ts` variable declaration path; no conformance/emit regression is expected since the change strictly *adds* previously-missing diagnostics matching tsc, and no benchmark row is known to hit this shape. `compare-to-parent` not run given the full-suite run already in flight and the hour's time budget — flagging as owed if a reviewer wants the broader signal.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDQ6e7G2bWrd3Gse7KsmBk)_