### PR TITLE
fix(checker): wire TS1278/TS1279 decorator-arity elaboration onto TS1238-1241

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -597,6 +597,9 @@ path = "tests/decorator_method_tdz_tests.rs"
 name = "ts1238_generic_decorator_tests"
 path = "tests/ts1238_generic_decorator_tests.rs"
 [[test]]
+name = "ts1278_ts1279_decorator_arity_elaboration_tests"
+path = "tests/ts1278_ts1279_decorator_arity_elaboration_tests.rs"
+[[test]]
 name = "ts2862_keyof_tparam_tests"
 path = "tests/ts2862_keyof_tparam_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking/class_decorators.rs
+++ b/crates/tsz-checker/src/state/state_checking/class_decorators.rs
@@ -272,16 +272,17 @@ impl<'a> CheckerState<'a> {
             None,
         );
 
-        let crate::query_boundaries::common::CallResult::Success(return_type) = result else {
-            self.error_at_node(
+        let crate::query_boundaries::common::CallResult::Success(return_type) = &result else {
+            self.emit_decorator_signature_error(
                 decorator_node,
                 diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                 diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
+                &result,
             );
             return;
         };
 
-        let return_type = self.evaluate_type_for_assignability(return_type);
+        let return_type = self.evaluate_type_for_assignability(*return_type);
         if matches!(return_type, TypeId::ERROR | TypeId::ANY | TypeId::UNKNOWN) {
             return;
         }

--- a/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
@@ -1,6 +1,8 @@
 //! Class-member decorator signature validation helpers.
 
-use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+use crate::diagnostics::{
+    Diagnostic, DiagnosticRelatedInformation, diagnostic_codes, diagnostic_messages, format_message,
+};
 use crate::query_boundaries::checkers::decorators as decorator_query;
 use crate::query_boundaries::common::CallResult;
 use crate::state::CheckerState;
@@ -17,6 +19,77 @@ const fn decorator_type_is_unchecked(t: TypeId) -> bool {
 }
 
 impl<'a> CheckerState<'a> {
+    /// TS1278/TS1279 elaboration for a decorator signature-resolution
+    /// failure: "The runtime will invoke the decorator with {1} arguments,
+    /// but the decorator expects {0}[ at least]." tsc always attaches this as
+    /// a message-chain link (no location of its own) alongside the primary
+    /// TS1238/1239/1240/1241 when the failure is an argument-count mismatch.
+    /// Other failure shapes (type mismatch, no overload match, ...) get no
+    /// elaboration here: tsc attaches a different, not-yet-wired shape there
+    /// (a `TS2345`-style "not assignable" line), so this deliberately leaves
+    /// those diagnostics exactly as before rather than attaching the wrong
+    /// kind of related information.
+    ///
+    /// "At least N" (TS1279) fires only when the decorator's own declared
+    /// arity is genuinely open-ended (`expected_max` is `None`, e.g. a
+    /// trailing `...rest: any[]`) and too few arguments were supplied; a
+    /// fixed-length rest tuple (`...rest: [string, number]`) still has a
+    /// concrete `expected_max` and takes the exact-N wording (TS1278).
+    fn decorator_arity_related_info(
+        &self,
+        result: &CallResult,
+    ) -> Vec<DiagnosticRelatedInformation> {
+        let &CallResult::ArgumentCountMismatch {
+            expected_min,
+            expected_max,
+            actual,
+        } = result
+        else {
+            return Vec::new();
+        };
+        let actual_str = actual.to_string();
+        let (code, message_template, expected) = if actual < expected_min && expected_max.is_none()
+        {
+            (
+                    diagnostic_codes::THE_RUNTIME_WILL_INVOKE_THE_DECORATOR_WITH_ARGUMENTS_BUT_THE_DECORATOR_EXPECTS_A,
+                    diagnostic_messages::THE_RUNTIME_WILL_INVOKE_THE_DECORATOR_WITH_ARGUMENTS_BUT_THE_DECORATOR_EXPECTS_A,
+                    expected_min,
+                )
+        } else {
+            (
+                    diagnostic_codes::THE_RUNTIME_WILL_INVOKE_THE_DECORATOR_WITH_ARGUMENTS_BUT_THE_DECORATOR_EXPECTS,
+                    diagnostic_messages::THE_RUNTIME_WILL_INVOKE_THE_DECORATOR_WITH_ARGUMENTS_BUT_THE_DECORATOR_EXPECTS,
+                    expected_max.unwrap_or(expected_min),
+                )
+        };
+        let expected_str = expected.to_string();
+        vec![Diagnostic::related_message(
+            code,
+            self.ctx.file_name.clone(),
+            0,
+            0,
+            format_message(message_template, &[&expected_str, &actual_str]),
+        )]
+    }
+
+    /// Emit a decorator signature-resolution error, attaching
+    /// [`Self::decorator_arity_related_info`] when `result` is an
+    /// argument-count mismatch.
+    pub(crate) fn emit_decorator_signature_error(
+        &mut self,
+        anchor: NodeIndex,
+        message: &str,
+        code: u32,
+        result: &CallResult,
+    ) {
+        let related = self.decorator_arity_related_info(result);
+        if related.is_empty() {
+            self.error_at_node(anchor, message, code);
+        } else {
+            self.error_at_node_with_related(anchor, message, code, related);
+        }
+    }
+
     /// tsc anchors member/parameter decorator failures (TS1239/TS1240/TS1241)
     /// at the decorator's EXPRESSION (one column after the `@`) for
     /// type-mismatch and extra-argument failures, but at the whole DECORATOR
@@ -110,10 +183,11 @@ impl<'a> CheckerState<'a> {
             self.resolve_call_with_checker_adapter(resolved, args, false, None, actual_this_type);
 
         if !matches!(result, CallResult::Success(_)) {
-            self.error_at_node(
+            self.emit_decorator_signature_error(
                 self.decorator_failure_anchor(decorator_node, resolved, args.len()),
                 diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_PROPERTY_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                 diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_PROPERTY_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
+                &result,
             );
         }
     }
@@ -351,10 +425,11 @@ impl<'a> CheckerState<'a> {
         let return_type = match &result {
             CallResult::Success(return_type) => Some(*return_type),
             _ => {
-                self.error_at_node(
+                self.emit_decorator_signature_error(
                     self.decorator_failure_anchor(decorator_node, resolved, arg_types.len()),
                     diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_METHOD_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                     diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_METHOD_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
+                    &result,
                 );
                 self.recover_decorator_return_type_with_any_args(resolved)
                     .or_else(|| {
@@ -724,13 +799,14 @@ impl<'a> CheckerState<'a> {
             actual_this_type,
         );
 
-        let return_type = match result {
-            CallResult::Success(return_type) => Some(return_type),
+        let return_type = match &result {
+            CallResult::Success(return_type) => Some(*return_type),
             _ => {
-                self.error_at_node(
+                self.emit_decorator_signature_error(
                     self.decorator_failure_anchor(decorator_node, resolved, arg_types.len()),
                     diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_PROPERTY_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                     diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_PROPERTY_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
+                    &result,
                 );
                 self.recover_decorator_return_type_with_any_args(resolved)
                     .or_else(|| {
@@ -856,13 +932,14 @@ impl<'a> CheckerState<'a> {
             actual_this_type,
         );
 
-        let return_type = match result {
-            CallResult::Success(return_type) => Some(return_type),
+        let return_type = match &result {
+            CallResult::Success(return_type) => Some(*return_type),
             _ => {
-                self.error_at_node(
+                self.emit_decorator_signature_error(
                     self.decorator_failure_anchor(decorator_node, resolved, 3),
                     diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_PARAMETER_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                     diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_PARAMETER_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
+                    &result,
                 );
                 // tsc keeps checking the return type after a failed signature
                 // resolution — `@bad` whose call fails AND whose return type is

--- a/crates/tsz-checker/tests/ts1278_ts1279_decorator_arity_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/ts1278_ts1279_decorator_arity_elaboration_tests.rs
@@ -1,0 +1,228 @@
+//! TS1278/TS1279 elaboration for decorator signature-resolution failures.
+//!
+//! Structural rule: when a decorator's call resolution fails specifically
+//! because of an argument-count mismatch, tsc attaches a related-information
+//! chain link to the primary TS1238/1239/1240/1241 ("Unable to resolve
+//! signature of ... decorator when called as an expression."):
+//! - TS1278 ("The runtime will invoke the decorator with {1} arguments, but
+//!   the decorator expects {0}.") when the decorator's declared arity has a
+//!   concrete upper bound.
+//! - TS1279 ("...but the decorator expects at least {0}.") when too few
+//!   arguments were supplied and the decorator's arity is genuinely
+//!   open-ended (a trailing `...rest: any[]`).
+//!
+//! tsz previously reported only the primary message, with no related
+//! information at all — the elaboration line was silently dropped in both
+//! the too-few and too-many argument shapes, across all five
+//! resolve-call-based decorator-signature-check sites (class, ES member,
+//! method/accessor, legacy property, parameter). A non-arity failure (e.g. an
+//! argument type mismatch) is deliberately left untouched: tsc attaches a
+//! different elaboration there (a `TS2345`-style "not assignable" line) that
+//! this change does not wire, so those diagnostics keep their pre-existing
+//! shape (no related information) rather than attaching the wrong kind.
+//!
+//! Oracle-verified against pinned `typescript@7.0.2` for every shape below.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+
+fn diagnostics_experimental(source: &str) -> Vec<tsz_checker::diagnostics::Diagnostic> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            experimental_decorators: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn diagnostics_es(source: &str) -> Vec<tsz_checker::diagnostics::Diagnostic> {
+    check_source(source, "test.ts", CheckerOptions::default())
+}
+
+fn find(
+    diags: &[tsz_checker::diagnostics::Diagnostic],
+    code: u32,
+) -> Option<&tsz_checker::diagnostics::Diagnostic> {
+    diags.iter().find(|d| d.code == code)
+}
+
+// ───────────────────────── class decorator (TS1238, legacy) ─────────────────
+
+#[test]
+fn ts1278_class_decorator_too_few_args_exact() {
+    // `classDec` declares 2 required params; a legacy class decorator is
+    // invoked with exactly 1 (the class constructor) -> TS1278 "expects 2".
+    let diags = diagnostics_experimental(
+        r#"
+function classDec(target: Function, extra: string) {}
+
+@classDec
+class C {}
+"#,
+    );
+    let primary = find(&diags, 1238).expect("expected TS1238");
+    assert_eq!(primary.related_information.len(), 1);
+    assert_eq!(primary.related_information[0].code, 1278);
+    assert_eq!(
+        primary.related_information[0].message_text,
+        "The runtime will invoke the decorator with 1 arguments, but the decorator expects 2."
+    );
+}
+
+#[test]
+fn ts1279_class_decorator_too_few_args_at_least() {
+    // A genuinely variadic decorator (`...rest: any[]`) with a required
+    // `name` param that isn't supplied -> TS1279 "expects at least 2".
+    let diags = diagnostics_experimental(
+        r#"
+function classDec(target: Function, name: string, ...rest: any[]) {}
+
+@classDec
+class C {}
+"#,
+    );
+    let primary = find(&diags, 1238).expect("expected TS1238");
+    assert_eq!(primary.related_information.len(), 1);
+    assert_eq!(primary.related_information[0].code, 1279);
+    assert_eq!(
+        primary.related_information[0].message_text,
+        "The runtime will invoke the decorator with 1 arguments, but the decorator expects at least 2."
+    );
+}
+
+#[test]
+fn ts1278_class_decorator_fixed_length_rest_stays_exact() {
+    // A fixed-length tuple rest param (`...rest: [string, number]`) has a
+    // concrete max arity, so this stays TS1278 ("expects 3"), not TS1279 --
+    // the discriminator is a concrete upper bound, not the presence of `...`.
+    let diags = diagnostics_experimental(
+        r#"
+function classDec(target: Function, ...rest: [string, number]) {}
+
+@classDec
+class C {}
+"#,
+    );
+    let primary = find(&diags, 1238).expect("expected TS1238");
+    assert_eq!(primary.related_information.len(), 1);
+    assert_eq!(primary.related_information[0].code, 1278);
+    assert_eq!(
+        primary.related_information[0].message_text,
+        "The runtime will invoke the decorator with 1 arguments, but the decorator expects 3."
+    );
+}
+
+#[test]
+fn ts1238_class_decorator_type_mismatch_stays_unelaborated() {
+    // Control: a non-arity failure (wrong parameter type, not wrong count)
+    // must not gain related information -- tsc's elaboration there is a
+    // different, not-yet-wired shape ("Argument of type X is not assignable
+    // to parameter of type Y."), so this stays exactly as before.
+    let diags = diagnostics_experimental(
+        r#"
+function classDec(target: string) {}
+
+@classDec
+class C {}
+"#,
+    );
+    let primary = find(&diags, 1238).expect("expected TS1238");
+    assert!(
+        primary.related_information.is_empty(),
+        "expected no related info for a type-mismatch failure, got: {:?}",
+        primary.related_information
+    );
+}
+
+// ───────────────────────── ES member decorator (TS1240) ─────────────────────
+
+#[test]
+fn ts1278_es_field_decorator_too_few_args() {
+    // ES (TC39) field decorators are invoked with `(value, context)` -- at
+    // most 2 synthetic args, capped by `es_member_decorator_argument_count`.
+    // A decorator declaring 3+ required params always underflows that cap
+    // (a 1- or 2-required-param decorator gets exactly the args it declared,
+    // per `min(max(paramCount, 1), 2)`, and never fails on arity alone).
+    let diags = diagnostics_es(
+        r#"
+function d(value: any, context: any, extra: string): any { return value; }
+class C { @d field = 1; }
+"#,
+    );
+    let primary = find(&diags, 1240).expect("expected TS1240");
+    assert_eq!(primary.related_information.len(), 1);
+    assert_eq!(primary.related_information[0].code, 1278);
+    assert_eq!(
+        primary.related_information[0].message_text,
+        "The runtime will invoke the decorator with 2 arguments, but the decorator expects 3."
+    );
+}
+
+// ───────────────────────── method/accessor decorator (TS1241) ───────────────
+
+#[test]
+fn ts1278_method_decorator_too_few_args() {
+    let diags = diagnostics_es(
+        r#"
+function d(value: any, context: any, extra: string): any { return value; }
+class C { @d method() {} }
+"#,
+    );
+    let primary = find(&diags, 1241).expect("expected TS1241");
+    assert_eq!(primary.related_information.len(), 1);
+    assert_eq!(primary.related_information[0].code, 1278);
+}
+
+// ───────────────────────── legacy property decorator (TS1240) ───────────────
+
+#[test]
+fn ts1278_legacy_property_decorator_too_many_args() {
+    // Legacy field decorators are invoked `(target, propertyKey)`; a
+    // 1-parameter decorator overflows -> TS1278 "expects 1" (the "too many"
+    // shape, not "too few" -- proves the exact-vs-at-least split isn't keyed
+    // on which direction the mismatch runs).
+    let diags = diagnostics_experimental(
+        r#"
+function propDec(target: any) {}
+
+class C {
+  @propDec
+  static x: number;
+}
+"#,
+    );
+    let primary = find(&diags, 1240).expect("expected TS1240");
+    assert_eq!(primary.related_information.len(), 1);
+    assert_eq!(primary.related_information[0].code, 1278);
+    assert_eq!(
+        primary.related_information[0].message_text,
+        "The runtime will invoke the decorator with 2 arguments, but the decorator expects 1."
+    );
+}
+
+// ───────────────────────── parameter decorator (TS1239) ─────────────────────
+
+#[test]
+fn ts1278_parameter_decorator_too_few_args() {
+    // Parameter decorators are always invoked with 3 args
+    // (`target, propertyKey, parameterIndex`); a 4-required-param decorator
+    // underflows -> TS1278 "expects 4".
+    let diags = diagnostics_experimental(
+        r#"
+function paramDec(a: any, b: any, c: any, d: any) {}
+
+class C {
+  m(@paramDec x: number) {}
+}
+"#,
+    );
+    let primary = find(&diags, 1239).expect("expected TS1239");
+    assert_eq!(primary.related_information.len(), 1);
+    assert_eq!(primary.related_information[0].code, 1278);
+    assert_eq!(
+        primary.related_information[0].message_text,
+        "The runtime will invoke the decorator with 3 arguments, but the decorator expects 4."
+    );
+}


### PR DESCRIPTION
A decorator whose call resolution fails specifically because of an
**argument-count mismatch** should carry tsc's TS1278/TS1279 elaboration
("The runtime will invoke the decorator with {1} arguments, but the
decorator expects {0}[ at least].") as related information beneath the
primary TS1238/1239/1240/1241 ("Unable to resolve signature of ... decorator
when called as an expression."). **When the failure is
`CallResult::ArgumentCountMismatch`, tsc attaches this elaboration; tsz now
does the same** at all five `resolve_call_with_checker_adapter`-based
decorator-signature-check sites, through a new shared
`emit_decorator_signature_error` helper in
`decorator_signature_checks.rs`.

Previously all five sites called plain `error_at_node`, dropping the
elaboration unconditionally — including in the common case of a decorator
declaring the wrong number of parameters, which is exactly the shape most
real decorator-arity bugs take. The exact-N (TS1278) vs at-least-N (TS1279)
split mirrors `expected_max.is_none()` (a genuinely open-ended rest
parameter) vs a concrete upper bound (including a *fixed-length* rest tuple,
which still has a concrete max and stays TS1278).

**Deliberately out of scope**, filed as #17104:
- TS6210 ("An argument for '{0}' was not provided."), a second
  location-anchored related-info line tsc attaches only in the "too few,
  specific missing param" sub-case — needs the decorator's resolved
  signature's parameter *declaration nodes*, which the current arity-only
  `decorator_signature_param_counts` helper doesn't expose.
- `check_es_class_decorator_arity` (the ES/TC39 stage-3 class-decorator arity
  check), which computes its own required-param count directly instead of
  going through `resolve_call_with_checker_adapter`/`CallResult`, so this
  fix's hook point doesn't reach it. Not yet oracle-verified whether it needs
  the same TS1278/1279 pair.
- Non-arity failures (`ArgumentTypeMismatch`, `NoOverloadMatch`, ...) keep
  their pre-existing shape (no related info) — tsc's elaboration there is a
  different, not-yet-wired `TS2345`-style "not assignable" line, so this PR
  does not attempt it rather than attach the wrong kind.

## Goal
Goal: hold

## Verification
- New test file `crates/tsz-checker/tests/ts1278_ts1279_decorator_arity_elaboration_tests.rs`
  (8 tests, oracle-verified against pinned `typescript@7.0.2`): one per
  call-resolution site (class/legacy, ES field, method, legacy property,
  parameter), the exact-vs-at-least split (including the fixed-length-rest-tuple
  discriminator), and a negative control proving a type-mismatch failure keeps
  zero related information. `cargo test -p tsz-checker --test ts1278_ts1279_decorator_arity_elaboration_tests`
  → 8/8 pass.
- All 12 pre-existing decorator integration test files (106 tests total:
  ts1238/1239/1240/1241/1249/1271/18036, decorator_this_binding,
  decorator_method_tdz, es_member_decorator_arity, issue_7681_super_decorator,
  ts2449_parameter_decorator_no_tdz) — 0 regressions.
- `cargo check -p tsz-checker --lib` clean; the pre-commit hook's own
  clippy + affected-crate verification passed at commit time
  (`Clippy passed. / Architecture guard passed. / Local verification
  passed.`). A standalone full unfiltered `cargo test -p tsz-checker --lib`
  was started but killed by an unrelated background-task timeout before
  finishing — flagging as still owed if a reviewer wants the full-suite
  number; every test that touches decorator signatures specifically
  (the 12 files above, run individually to completion) is green.
- `cargo clippy -p tsz-checker --lib -- -D warnings` → clean.
- `cargo fmt -p tsz-checker -- --check` → clean.
- Only decorator-signature-arity diagnostics (TS1238/1239/1240/1241's related
  information) can move; the TypeScript corpus submodule was not checked out
  for this change (`scripts/setup/reset-ts-submodule.sh` not run), so a full
  conformance/emit sweep is not run here — this is purely additive to those
  diagnostics' related-information shape (primary code/message/anchor
  unchanged in every case) rather than a count-moving change.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCuqe2vYWsPRV1kbaUhpgv)_