### PR TITLE
fix(parser): report TS1520 for a v-mode class-set operator missing its left operand

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -331,6 +331,10 @@ mod regex_class_set_operator_mixing_tests;
 mod regex_class_set_bare_hyphen_tests;
 
 #[cfg(test)]
+#[path = "../../tests/regex_class_set_operand_missing_tests.rs"]
+mod regex_class_set_operand_missing_tests;
+
+#[cfg(test)]
 #[path = "../../tests/modifier_ordering_tests.rs"]
 mod modifier_ordering_tests;
 

--- a/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
@@ -15,6 +15,8 @@ use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages, format_mess
 use tsz_scanner::SyntaxKind;
 use tsz_scanner::scanner_impl::TokenFlags;
 
+mod range_order;
+
 /// Map a UTF-8 `start` byte offset and a (possibly surrogate-pair) `char`
 /// into the UTF-16 code-unit offsets used by regex range-order analysis.
 ///
@@ -30,6 +32,16 @@ fn split_non_unicode_atom_offsets(start: usize, ch: char) -> Vec<u32> {
         .enumerate()
         .filter_map(|(i, _)| u32::try_from(start + (i * utf8_len) / utf16_len).ok())
         .collect()
+}
+
+/// Combine a high/low UTF-16 surrogate pair into its code point, or `None`
+/// when the halves are not a valid surrogate pair. Shared by the regex body
+/// scanner and the `range_order` range-order pass.
+const fn decode_surrogate_pair(high: u32, low: u32) -> Option<u32> {
+    if high < 0xD800 || high > 0xDBFF || low < 0xDC00 || low > 0xDFFF {
+        return None;
+    }
+    Some(0x10000 + ((high - 0xD800) << 10) + (low - 0xDC00))
 }
 
 impl ParserState {
@@ -78,277 +90,6 @@ impl ParserState {
                 }
             }
             None
-        }
-
-        fn decode_surrogate_pair(high: u32, low: u32) -> Option<u32> {
-            if !(0xD800..=0xDBFF).contains(&high) || !(0xDC00..=0xDFFF).contains(&low) {
-                return None;
-            }
-            Some(0x10000 + ((high - 0xD800) << 10) + (low - 0xDC00))
-        }
-
-        fn parse_hex_u32(raw_text: &str, start: usize, len: usize) -> Option<u32> {
-            raw_text
-                .get(start..start + len)
-                .and_then(|slice| u32::from_str_radix(slice, 16).ok())
-        }
-
-        fn regex_range_order_errors(raw_text: &str, body_end: usize) -> Vec<(u32, u32)> {
-            #[derive(Clone, Copy)]
-            enum ClassToken {
-                Atom { value: u32, start: u32 },
-                OpaqueAtom,
-                Hyphen,
-            }
-
-            type ClassAtomParse = (Vec<(u32, u32)>, usize);
-
-            fn parse_class_atom(
-                raw_text: &str,
-                start: usize,
-                class_end: usize,
-                unicode_mode: bool,
-            ) -> Option<ClassAtomParse> {
-                let rest = raw_text.get(start..class_end)?;
-                let mut chars = rest.chars();
-                let ch = chars.next()?;
-                if ch == '\\' {
-                    let next_start = start + ch.len_utf8();
-                    let next = raw_text.get(next_start..class_end)?.chars().next()?;
-                    if next == 'x' {
-                        let hex_start = next_start + next.len_utf8();
-                        let next_index = hex_start.saturating_add(2).min(class_end);
-                        if let Some(value) = parse_hex_u32(raw_text, hex_start, 2) {
-                            return Some((vec![(value, u32::try_from(start).ok()?)], next_index));
-                        }
-                        return Some((Vec::new(), next_index));
-                    }
-                    if next == 'u' {
-                        let brace_start = next_start + next.len_utf8();
-                        if raw_text.as_bytes().get(brace_start).copied() == Some(b'{') {
-                            let hex_start = brace_start + 1;
-                            let mut hex_end = hex_start;
-                            while hex_end < class_end
-                                && raw_text.as_bytes().get(hex_end).copied() != Some(b'}')
-                            {
-                                hex_end += 1;
-                            }
-                            if hex_end < class_end
-                                && let Some(value) =
-                                    parse_hex_u32(raw_text, hex_start, hex_end - hex_start)
-                            {
-                                return Some((
-                                    vec![(value, u32::try_from(start).ok()?)],
-                                    hex_end + 1,
-                                ));
-                            }
-                        } else if let Some(value) = parse_hex_u32(raw_text, brace_start, 4) {
-                            let next_index = brace_start + 4;
-                            if unicode_mode
-                                && let Some(after_first) = raw_text.get(next_index..class_end)
-                                && after_first.starts_with("\\u")
-                                && let Some(low) = parse_hex_u32(raw_text, next_index + 2, 4)
-                                && let Some(code_point) = decode_surrogate_pair(value, low)
-                            {
-                                return Some((
-                                    vec![(code_point, u32::try_from(start).ok()?)],
-                                    next_index + 6,
-                                ));
-                            }
-                            return Some((vec![(value, u32::try_from(start).ok()?)], next_index));
-                        }
-                    }
-
-                    let escaped_start = next_start;
-                    let escaped = raw_text.get(escaped_start..class_end)?.chars().next()?;
-                    if matches!(escaped, 'd' | 'D' | 's' | 'S' | 'w' | 'W' | 'p' | 'P') {
-                        return Some((Vec::new(), escaped_start + escaped.len_utf8()));
-                    }
-                    if unicode_mode {
-                        Some((
-                            vec![(escaped as u32, u32::try_from(start).ok()?)],
-                            escaped_start + escaped.len_utf8(),
-                        ))
-                    } else {
-                        Some((
-                            escaped
-                                .encode_utf16(&mut [0; 2])
-                                .iter()
-                                .zip(split_non_unicode_atom_offsets(start, escaped))
-                                .map(|(u, offset)| (*u as u32, offset))
-                                .collect(),
-                            escaped_start + escaped.len_utf8(),
-                        ))
-                    }
-                } else if unicode_mode {
-                    Some((
-                        vec![(ch as u32, u32::try_from(start).ok()?)],
-                        start + ch.len_utf8(),
-                    ))
-                } else {
-                    Some((
-                        ch.encode_utf16(&mut [0; 2])
-                            .iter()
-                            .zip(split_non_unicode_atom_offsets(start, ch))
-                            .map(|(u, offset)| (*u as u32, offset))
-                            .collect(),
-                        start + ch.len_utf8(),
-                    ))
-                }
-            }
-
-            /// Analyse one character class, starting just past its `[`, and
-            /// push range-order (TS1517) errors for the ranges it contains.
-            /// Under the `v` flag a class may contain further classes, and a
-            /// class that has committed to a `--`/`&&` class-set operator
-            /// contains no ranges at all — but its nested classes still do, so
-            /// the walk recurses instead of skipping.
-            fn analyze_class_ranges(
-                raw_text: &str,
-                i: &mut usize,
-                body_end: usize,
-                unicode_mode: bool,
-                unicode_sets_mode: bool,
-                errors: &mut Vec<(u32, u32)>,
-            ) {
-                let bytes = raw_text.as_bytes();
-                let mut tokens: Vec<ClassToken> = Vec::new();
-                let mut in_class_set_expression = false;
-
-                while *i < body_end {
-                    if bytes[*i] == b']' {
-                        *i += 1;
-                        break;
-                    }
-                    // `--` and `&&` commit the class to a `ClassSetExpression`,
-                    // which admits no ranges.
-                    if unicode_sets_mode
-                        && *i + 1 < body_end
-                        && ((bytes[*i] == b'-' && bytes[*i + 1] == b'-')
-                            || (bytes[*i] == b'&' && bytes[*i + 1] == b'&'))
-                    {
-                        in_class_set_expression = true;
-                        *i += 2;
-                        continue;
-                    }
-                    if bytes[*i] == b'-' {
-                        tokens.push(ClassToken::Hyphen);
-                        *i += 1;
-                        continue;
-                    }
-                    // A nested class is never a range bound, so it contributes
-                    // no code point to compare — but it is a class in its own
-                    // right and carries its own ranges.
-                    if unicode_sets_mode && bytes[*i] == b'[' {
-                        tokens.push(ClassToken::OpaqueAtom);
-                        *i += 1;
-                        analyze_class_ranges(
-                            raw_text,
-                            i,
-                            body_end,
-                            unicode_mode,
-                            unicode_sets_mode,
-                            errors,
-                        );
-                        continue;
-                    }
-                    // `\q{ ... }` is a class-string-disjunction operand, not a
-                    // code point: it spans through its closing brace and, like
-                    // a nested class, can never bound a range. Letting the
-                    // generic atom walk see it splits it into `q`, `{`, the
-                    // alternatives and `}`, and the brace then compares as a
-                    // range bound.
-                    if unicode_sets_mode
-                        && bytes[*i] == b'\\'
-                        && bytes.get(*i + 1).copied() == Some(b'q')
-                        && bytes.get(*i + 2).copied() == Some(b'{')
-                    {
-                        tokens.push(ClassToken::OpaqueAtom);
-                        *i += 3;
-                        while *i < body_end && bytes[*i] != b'}' {
-                            *i += 1;
-                        }
-                        if *i < body_end {
-                            *i += 1;
-                        }
-                        continue;
-                    }
-                    let Some((atoms, next_i)) =
-                        parse_class_atom(raw_text, *i, body_end, unicode_mode)
-                    else {
-                        break;
-                    };
-                    if atoms.is_empty() {
-                        tokens.push(ClassToken::OpaqueAtom);
-                    } else {
-                        tokens.extend(
-                            atoms
-                                .into_iter()
-                                .map(|(value, start)| ClassToken::Atom { value, start }),
-                        );
-                    }
-                    *i = next_i;
-                }
-
-                if in_class_set_expression {
-                    return;
-                }
-
-                let mut token_index = 0usize;
-                while token_index + 2 < tokens.len() {
-                    match &tokens[token_index..token_index + 3] {
-                        [
-                            ClassToken::Atom { value: left, start },
-                            ClassToken::Hyphen,
-                            ClassToken::Atom { value: right, .. },
-                        ] => {
-                            if left > right {
-                                errors.push((*start, 1));
-                            }
-                            token_index += 3;
-                        }
-                        _ => token_index += 1,
-                    }
-                }
-            }
-
-            let flags = &raw_text[body_end + 1..];
-            let unicode_mode = flags.contains('u') || flags.contains('v');
-            let unicode_sets_mode = flags.contains('v');
-            let bytes = raw_text.as_bytes();
-            let mut errors = Vec::new();
-            let mut i = 1usize;
-
-            while i < body_end {
-                match bytes[i] {
-                    b'\\' => {
-                        i += 1;
-                        if i < body_end {
-                            i += 1;
-                        }
-                    }
-                    b'[' => {
-                        i += 1;
-                        analyze_class_ranges(
-                            raw_text,
-                            &mut i,
-                            body_end,
-                            unicode_mode,
-                            unicode_sets_mode,
-                            &mut errors,
-                        );
-                    }
-                    _ => {
-                        if let Some(ch) = raw_text.get(i..body_end).and_then(|s| s.chars().next()) {
-                            i += ch.len_utf8();
-                        } else {
-                            break;
-                        }
-                    }
-                }
-            }
-
-            errors
         }
 
         fn validate_regex_literal_body(
@@ -559,13 +300,6 @@ impl ParserState {
                     value = (value << 4) | hex_byte_value(body[pos + offset])?;
                 }
                 Some(value)
-            }
-
-            const fn decode_surrogate_pair(high: u32, low: u32) -> Option<u32> {
-                if high < 0xD800 || high > 0xDBFF || low < 0xDC00 || low > 0xDFFF {
-                    return None;
-                }
-                Some(0x10000 + ((high - 0xD800) << 10) + (low - 0xDC00))
             }
 
             fn scan_braced_unicode_escape_value(
@@ -1554,6 +1288,25 @@ impl ParserState {
                     if ctx.unicode_sets_mode
                         && is_class_set_operator_at(ctx.body, *pos, ctx.body_end)
                     {
+                        // An operator reaching the top of the loop with no
+                        // operand scanned and no kind committed yet opens the
+                        // class (or follows `^`), so its *left* operand is
+                        // missing — TS1520 at the operator's first character.
+                        // `committed.is_none()` fires it once per class, so a
+                        // leading operator run (`/[&&&&]/v`) still draws a single
+                        // leading report; the missing *right* operand is a
+                        // separate report from `scan_class_set_operator` below,
+                        // which is why `/[&&]/v` draws two. (See the
+                        // `regex_class_set_operand_missing_tests` matrix.)
+                        if operand_index == 0 && committed.is_none() {
+                            (ctx.emit)(
+                                parser,
+                                *pos,
+                                1,
+                                diagnostic_messages::EXPECTED_A_CLASS_SET_OPERAND,
+                                diagnostic_codes::EXPECTED_A_CLASS_SET_OPERAND,
+                            );
+                        }
                         note_class_set_kind(
                             parser,
                             ctx,
@@ -2224,7 +1977,7 @@ impl ParserState {
             })
             .unwrap_or_default();
         let range_order_errors = regex_body_end(&raw_text)
-            .map(|body_end| regex_range_order_errors(&raw_text, body_end))
+            .map(|body_end| range_order::regex_range_order_errors(&raw_text, body_end))
             .unwrap_or_default();
         regex_body_end(&raw_text).into_iter().for_each(|body_end| {
             validate_regex_literal_body(self, &raw_text, start_pos, body_end);

--- a/crates/tsz-parser/src/parser/state_expressions_literals_regex/range_order.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals_regex/range_order.rs
@@ -1,0 +1,270 @@
+//! Regex character-class range-order (TS1517) analysis, extracted from
+//! `state_expressions_literals_regex.rs`.
+//!
+//! Pure file-organization move; no logic changes. Keeps the parent under the
+//! parser LOC ceiling. `regex_range_order_errors` was the largest
+//! self-contained unit in `parse_regex_literal` — a standalone pass over the
+//! raw literal text that borrows nothing from the parser, so it lifts out
+//! whole, carrying its private `parse_hex_u32` helper and borrowing the
+//! shared `decode_surrogate_pair`/`split_non_unicode_atom_offsets` from the
+//! parent module.
+use super::{decode_surrogate_pair, split_non_unicode_atom_offsets};
+
+fn parse_hex_u32(raw_text: &str, start: usize, len: usize) -> Option<u32> {
+    raw_text
+        .get(start..start + len)
+        .and_then(|slice| u32::from_str_radix(slice, 16).ok())
+}
+
+pub(super) fn regex_range_order_errors(raw_text: &str, body_end: usize) -> Vec<(u32, u32)> {
+    #[derive(Clone, Copy)]
+    enum ClassToken {
+        Atom { value: u32, start: u32 },
+        OpaqueAtom,
+        Hyphen,
+    }
+
+    type ClassAtomParse = (Vec<(u32, u32)>, usize);
+
+    fn parse_class_atom(
+        raw_text: &str,
+        start: usize,
+        class_end: usize,
+        unicode_mode: bool,
+    ) -> Option<ClassAtomParse> {
+        let rest = raw_text.get(start..class_end)?;
+        let mut chars = rest.chars();
+        let ch = chars.next()?;
+        if ch == '\\' {
+            let next_start = start + ch.len_utf8();
+            let next = raw_text.get(next_start..class_end)?.chars().next()?;
+            if next == 'x' {
+                let hex_start = next_start + next.len_utf8();
+                let next_index = hex_start.saturating_add(2).min(class_end);
+                if let Some(value) = parse_hex_u32(raw_text, hex_start, 2) {
+                    return Some((vec![(value, u32::try_from(start).ok()?)], next_index));
+                }
+                return Some((Vec::new(), next_index));
+            }
+            if next == 'u' {
+                let brace_start = next_start + next.len_utf8();
+                if raw_text.as_bytes().get(brace_start).copied() == Some(b'{') {
+                    let hex_start = brace_start + 1;
+                    let mut hex_end = hex_start;
+                    while hex_end < class_end
+                        && raw_text.as_bytes().get(hex_end).copied() != Some(b'}')
+                    {
+                        hex_end += 1;
+                    }
+                    if hex_end < class_end
+                        && let Some(value) = parse_hex_u32(raw_text, hex_start, hex_end - hex_start)
+                    {
+                        return Some((vec![(value, u32::try_from(start).ok()?)], hex_end + 1));
+                    }
+                } else if let Some(value) = parse_hex_u32(raw_text, brace_start, 4) {
+                    let next_index = brace_start + 4;
+                    if unicode_mode
+                        && let Some(after_first) = raw_text.get(next_index..class_end)
+                        && after_first.starts_with("\\u")
+                        && let Some(low) = parse_hex_u32(raw_text, next_index + 2, 4)
+                        && let Some(code_point) = decode_surrogate_pair(value, low)
+                    {
+                        return Some((
+                            vec![(code_point, u32::try_from(start).ok()?)],
+                            next_index + 6,
+                        ));
+                    }
+                    return Some((vec![(value, u32::try_from(start).ok()?)], next_index));
+                }
+            }
+
+            let escaped_start = next_start;
+            let escaped = raw_text.get(escaped_start..class_end)?.chars().next()?;
+            if matches!(escaped, 'd' | 'D' | 's' | 'S' | 'w' | 'W' | 'p' | 'P') {
+                return Some((Vec::new(), escaped_start + escaped.len_utf8()));
+            }
+            if unicode_mode {
+                Some((
+                    vec![(escaped as u32, u32::try_from(start).ok()?)],
+                    escaped_start + escaped.len_utf8(),
+                ))
+            } else {
+                Some((
+                    escaped
+                        .encode_utf16(&mut [0; 2])
+                        .iter()
+                        .zip(split_non_unicode_atom_offsets(start, escaped))
+                        .map(|(u, offset)| (*u as u32, offset))
+                        .collect(),
+                    escaped_start + escaped.len_utf8(),
+                ))
+            }
+        } else if unicode_mode {
+            Some((
+                vec![(ch as u32, u32::try_from(start).ok()?)],
+                start + ch.len_utf8(),
+            ))
+        } else {
+            Some((
+                ch.encode_utf16(&mut [0; 2])
+                    .iter()
+                    .zip(split_non_unicode_atom_offsets(start, ch))
+                    .map(|(u, offset)| (*u as u32, offset))
+                    .collect(),
+                start + ch.len_utf8(),
+            ))
+        }
+    }
+
+    /// Analyse one character class, starting just past its `[`, and
+    /// push range-order (TS1517) errors for the ranges it contains.
+    /// Under the `v` flag a class may contain further classes, and a
+    /// class that has committed to a `--`/`&&` class-set operator
+    /// contains no ranges at all — but its nested classes still do, so
+    /// the walk recurses instead of skipping.
+    fn analyze_class_ranges(
+        raw_text: &str,
+        i: &mut usize,
+        body_end: usize,
+        unicode_mode: bool,
+        unicode_sets_mode: bool,
+        errors: &mut Vec<(u32, u32)>,
+    ) {
+        let bytes = raw_text.as_bytes();
+        let mut tokens: Vec<ClassToken> = Vec::new();
+        let mut in_class_set_expression = false;
+
+        while *i < body_end {
+            if bytes[*i] == b']' {
+                *i += 1;
+                break;
+            }
+            // `--` and `&&` commit the class to a `ClassSetExpression`,
+            // which admits no ranges.
+            if unicode_sets_mode
+                && *i + 1 < body_end
+                && ((bytes[*i] == b'-' && bytes[*i + 1] == b'-')
+                    || (bytes[*i] == b'&' && bytes[*i + 1] == b'&'))
+            {
+                in_class_set_expression = true;
+                *i += 2;
+                continue;
+            }
+            if bytes[*i] == b'-' {
+                tokens.push(ClassToken::Hyphen);
+                *i += 1;
+                continue;
+            }
+            // A nested class is never a range bound, so it contributes
+            // no code point to compare — but it is a class in its own
+            // right and carries its own ranges.
+            if unicode_sets_mode && bytes[*i] == b'[' {
+                tokens.push(ClassToken::OpaqueAtom);
+                *i += 1;
+                analyze_class_ranges(
+                    raw_text,
+                    i,
+                    body_end,
+                    unicode_mode,
+                    unicode_sets_mode,
+                    errors,
+                );
+                continue;
+            }
+            // `\q{ ... }` is a class-string-disjunction operand, not a
+            // code point: it spans through its closing brace and, like
+            // a nested class, can never bound a range. Letting the
+            // generic atom walk see it splits it into `q`, `{`, the
+            // alternatives and `}`, and the brace then compares as a
+            // range bound.
+            if unicode_sets_mode
+                && bytes[*i] == b'\\'
+                && bytes.get(*i + 1).copied() == Some(b'q')
+                && bytes.get(*i + 2).copied() == Some(b'{')
+            {
+                tokens.push(ClassToken::OpaqueAtom);
+                *i += 3;
+                while *i < body_end && bytes[*i] != b'}' {
+                    *i += 1;
+                }
+                if *i < body_end {
+                    *i += 1;
+                }
+                continue;
+            }
+            let Some((atoms, next_i)) = parse_class_atom(raw_text, *i, body_end, unicode_mode)
+            else {
+                break;
+            };
+            if atoms.is_empty() {
+                tokens.push(ClassToken::OpaqueAtom);
+            } else {
+                tokens.extend(
+                    atoms
+                        .into_iter()
+                        .map(|(value, start)| ClassToken::Atom { value, start }),
+                );
+            }
+            *i = next_i;
+        }
+
+        if in_class_set_expression {
+            return;
+        }
+
+        let mut token_index = 0usize;
+        while token_index + 2 < tokens.len() {
+            match &tokens[token_index..token_index + 3] {
+                [
+                    ClassToken::Atom { value: left, start },
+                    ClassToken::Hyphen,
+                    ClassToken::Atom { value: right, .. },
+                ] => {
+                    if left > right {
+                        errors.push((*start, 1));
+                    }
+                    token_index += 3;
+                }
+                _ => token_index += 1,
+            }
+        }
+    }
+
+    let flags = &raw_text[body_end + 1..];
+    let unicode_mode = flags.contains('u') || flags.contains('v');
+    let unicode_sets_mode = flags.contains('v');
+    let bytes = raw_text.as_bytes();
+    let mut errors = Vec::new();
+    let mut i = 1usize;
+
+    while i < body_end {
+        match bytes[i] {
+            b'\\' => {
+                i += 1;
+                if i < body_end {
+                    i += 1;
+                }
+            }
+            b'[' => {
+                i += 1;
+                analyze_class_ranges(
+                    raw_text,
+                    &mut i,
+                    body_end,
+                    unicode_mode,
+                    unicode_sets_mode,
+                    &mut errors,
+                );
+            }
+            _ => {
+                if let Some(ch) = raw_text.get(i..body_end).and_then(|s| s.chars().next()) {
+                    i += ch.len_utf8();
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    errors
+}

--- a/crates/tsz-parser/tests/regex_class_set_bare_hyphen_tests.rs
+++ b/crates/tsz-parser/tests/regex_class_set_bare_hyphen_tests.rs
@@ -166,15 +166,16 @@ fn a_mixed_operator_hyphen_is_not_also_ts1508() {
 }
 
 /// `--` (subtraction with no operand) is TS1520's concern; a doubled hyphen
-/// is an operator, not this check's fresh-atom `-`. (The oracle reports
-/// TS1520 twice for `/[--]/v` — once for each side of the bare operator —
-/// where tsz reports it once; a pre-existing gap in that unrelated operand
-/// check, orthogonal to this fix. Both assertions only need to show 1508 is
-/// absent.)
+/// is an operator, not this check's fresh-atom `-`. `/[a--]/v` has a left
+/// operand (`a`) and only its right operand is missing, so it draws a single
+/// TS1520; `/[--]/v` opens on the operator, so *both* operands are missing
+/// and the oracle reports TS1520 twice — once anchored at the operator's
+/// first character (the missing left operand) and once at the `]` (the
+/// missing right operand). Both assertions also show 1508 is absent.
 #[test]
 fn a_doubled_hyphen_is_not_also_ts1508() {
     assert_eq!(regex_codes("const a = /[a--]/v;"), vec![1520]);
-    assert_eq!(regex_codes("const a = /[--]/v;"), vec![1520]);
+    assert_eq!(regex_codes("const a = /[--]/v;"), vec![1520, 1520]);
 }
 
 /// TS1508 is a `v`-only diagnostic: under `u` and under Annex B the same

--- a/crates/tsz-parser/tests/regex_class_set_operand_missing_tests.rs
+++ b/crates/tsz-parser/tests/regex_class_set_operand_missing_tests.rs
@@ -1,0 +1,165 @@
+//! TS1520 — `Expected a class set operand.` for the `v`-flag class-set
+//! operators `--` (subtraction) and `&&` (intersection).
+//!
+//! Both operators are binary: the grammar is `ClassSetOperand -- ClassSetOperand`
+//! and `ClassSetOperand && ClassSetOperand`, so an operator needs an operand on
+//! *each* side. tsc reports TS1520 for every missing operand:
+//!
+//! - a *right* operand goes missing when the operator is immediately followed
+//!   by `]` or by another operator (`/[a&&]/v`, `/[a--]/v`), and
+//! - a *left* operand goes missing when the operator opens the class or
+//!   immediately follows `^` (`/[&&a]/v`, `/[--a]/v`, `/[^--a]/v`).
+//!
+//! A class that opens on a bare operator therefore draws *two* TS1520s
+//! (`/[&&]/v`), one per side, while a class that opens on a normal operand and
+//! ends on a bare operator draws one.
+//!
+//! The reported column is the first character of the missing side's anchor:
+//! the operator's first character for a missing left operand, and the token
+//! that stood where the right operand should have been (`]` or the next
+//! operator) for a missing right operand — matching `typescript@7.0.2`
+//! (`--noEmit --strict --target es2024 --lib es2024`).
+use crate::parser::test_fixture::parse_source;
+use tsz_common::diagnostics::diagnostic_codes;
+
+const TS1520: u32 = diagnostic_codes::EXPECTED_A_CLASS_SET_OPERAND;
+
+fn regex_codes(source: &str) -> Vec<u32> {
+    let (parser, _root) = parse_source(source);
+    parser.get_diagnostics().iter().map(|d| d.code).collect()
+}
+
+/// `(code, zero-based offset)` pairs — the offset is what the CLI renders as a
+/// column, and a mis-anchored operand report is only visible here.
+fn regex_codes_at(source: &str) -> Vec<(u32, u32)> {
+    let (parser, _root) = parse_source(source);
+    parser
+        .get_diagnostics()
+        .iter()
+        .map(|d| (d.code, d.start))
+        .collect()
+}
+
+/// Offset of `needle` in `source`, for anchoring the expected report.
+fn at(source: &str, needle: &str) -> u32 {
+    source.find(needle).expect("needle in source") as u32
+}
+
+// ---------------------------------------------------------------------------
+// Missing right operand: the operator is the last thing before `]`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_trailing_operator_reports_a_missing_right_operand() {
+    assert_eq!(regex_codes("const a = /[a&&]/v;"), vec![TS1520]);
+    assert_eq!(regex_codes("const a = /[a--]/v;"), vec![TS1520]);
+}
+
+#[test]
+fn a_missing_right_operand_anchors_on_the_closing_bracket() {
+    let src = "const a = /[a&&]/v;";
+    assert_eq!(regex_codes_at(src), vec![(TS1520, at(src, "]"))]);
+    let src = "const a = /[a--]/v;";
+    assert_eq!(regex_codes_at(src), vec![(TS1520, at(src, "]"))]);
+}
+
+#[test]
+fn a_missing_right_operand_after_a_nested_class_still_reports() {
+    // `[[a]--]` — the left operand is the nested class `[a]`, the right is gone.
+    assert_eq!(regex_codes("const a = /[[a]--]/v;"), vec![TS1520]);
+}
+
+// ---------------------------------------------------------------------------
+// Missing left operand: the class opens on the operator
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_leading_operator_reports_a_missing_left_operand() {
+    assert_eq!(regex_codes("const a = /[&&a]/v;"), vec![TS1520]);
+    assert_eq!(regex_codes("const a = /[--a]/v;"), vec![TS1520]);
+}
+
+#[test]
+fn a_missing_left_operand_anchors_on_the_operators_first_character() {
+    let src = "const a = /[&&a]/v;";
+    assert_eq!(regex_codes_at(src), vec![(TS1520, at(src, "&&"))]);
+    let src = "const a = /[--a]/v;";
+    assert_eq!(regex_codes_at(src), vec![(TS1520, at(src, "--"))]);
+}
+
+#[test]
+fn a_leading_operator_after_negation_reports_a_missing_left_operand() {
+    // The `^` is not an operand, so `[^--a]` still opens on the operator.
+    let src = "const a = /[^--a]/v;";
+    assert_eq!(regex_codes(src), vec![TS1520]);
+    assert_eq!(regex_codes_at(src), vec![(TS1520, at(src, "--"))]);
+}
+
+#[test]
+fn a_leading_operator_before_a_nested_class_reports_a_missing_left_operand() {
+    // The right operand (`[a]`) is present; only the left is missing.
+    let src = "const a = /[--[a]]/v;";
+    assert_eq!(regex_codes(src), vec![TS1520]);
+    assert_eq!(regex_codes_at(src), vec![(TS1520, at(src, "--"))]);
+}
+
+// ---------------------------------------------------------------------------
+// Both operands missing: a class that is nothing but a bare operator
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_bare_operator_class_reports_both_sides() {
+    // Two TS1520s: the leading missing-left, then the trailing missing-right.
+    assert_eq!(regex_codes("const a = /[&&]/v;"), vec![TS1520, TS1520]);
+    assert_eq!(regex_codes("const a = /[--]/v;"), vec![TS1520, TS1520]);
+}
+
+#[test]
+fn a_bare_operator_class_anchors_both_reports() {
+    let src = "const a = /[&&]/v;";
+    assert_eq!(
+        regex_codes_at(src),
+        vec![(TS1520, at(src, "&&")), (TS1520, at(src, "]"))]
+    );
+    let src = "const a = /[--]/v;";
+    assert_eq!(
+        regex_codes_at(src),
+        vec![(TS1520, at(src, "--")), (TS1520, at(src, "]"))]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// A leading operator with an operand on the far side is still one report:
+// the run of operators commits the class's kind, so only the opening side is
+// counted as missing (matching tsc's single leading TS1520).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_leading_operator_with_more_operands_reports_only_the_opening_side() {
+    assert_eq!(regex_codes("const a = /[&&a&&b]/v;"), vec![TS1520]);
+    assert_eq!(regex_codes("const a = /[--a--b]/v;"), vec![TS1520]);
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls: a two-sided operator with both operands present is clean
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_well_formed_operator_is_clean() {
+    assert_eq!(regex_codes("const a = /[a&&b]/v;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[a--b]/v;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[[a--b]&&c]/v;"), Vec::<u32>::new());
+}
+
+// ---------------------------------------------------------------------------
+// The rule is `v`-only: under `u` and Annex B, `-`/`&` at the class edge are
+// ordinary class content, not operators, so no operand is ever missing.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn missing_operand_is_v_only() {
+    assert_eq!(regex_codes("const a = /[--a]/u;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[&&a]/u;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[--a]/;"), Vec::<u32>::new());
+    assert_eq!(regex_codes("const a = /[&&a]/;"), Vec::<u32>::new());
+}

--- a/scripts/arch/arch_guard_file_limits.py
+++ b/scripts/arch/arch_guard_file_limits.py
@@ -985,7 +985,7 @@ FILE_LINE_LIMIT_CHECKS = [
         / "src"
         / "parser"
         / "state_expressions_literals_regex.rs",
-        2438,
+        2191,
     ),
     (
         "CLI boundary: driver/check_utils/tests.rs size ratchet",


### PR DESCRIPTION
Fixes #17102.

The `v`-flag class-set operators `--` (subtraction) and `&&` (intersection) are
binary — the grammar requires a `ClassSetOperand` on each side — and `tsc`
reports **TS1520 `Expected a class set operand.`** for every missing operand.
tsz reported the missing **right** operand (`/[a&&]/v`) but silently dropped the
missing **left** operand: a class that opens on the operator, or has it right
after `^`, was accepted with no diagnostic. Found empirically by diffing tsz
against the pinned oracle (`typescript@7.0.2`, `--noEmit --strict --target
es2024 --lib es2024`) across an 84-pattern regex battery.

Structural rule: **when a `v`-mode class reaches a `--`/`&&` operator with no
operand yet scanned (the operator opens the class or follows `^`), `tsc` reports
TS1520 at the operator's first character; tsz now does the same through the
parser regex validator** (`state_expressions_literals_regex.rs`, the layer that
owns TS1517/TS1519/TS1522). Pure grammar early-error — no solver/checker
involvement.

The fix adds, in the top-of-loop class-set-operator branch, a TS1520 emit when
`operand_index == 0 && committed.is_none()`. `committed.is_none()` fires it
exactly once, so a class that opens on a run of operators (`/[&&&&]/v`) still
draws a single leading TS1520 like `tsc`; the existing missing-right report is
untouched, so `/[&&]/v` correctly draws two.

Adjacent-case matrix (all exact vs oracle, columns included):

| pattern | tsc | tsz after |
| --- | --- | --- |
| `/[&&a]/v`, `/[--a]/v` | TS1520 @ operator | ✓ |
| `/[^--a]/v` | TS1520 @ operator (after `^`) | ✓ |
| `/[--[a]]/v` | TS1520 @ operator (before nested class) | ✓ |
| `/[&&]/v`, `/[--]/v` | TS1520 @ operator + TS1520 @ `]` | ✓ |
| `/[&&a&&b]/v`, `/[--a--b]/v` | single leading TS1520 | ✓ |
| `/[a&&]/v`, `/[a--]/v` | TS1520 @ `]` (missing right, unchanged) | ✓ |
| `/[a&&b]/v`, `/[[a--b]&&c]/v` | clean | ✓ |
| `/[--a]/u`, `/[&&a]/u`, `/[--a]/`, `/[&&a]/` | clean (`v`-only rule) | ✓ |

**Refactor to stay under the arch-size ceiling.** The parser regex file was
pinned at its 2438-line ratchet. To add the fix without growing past it, the
self-contained `regex_range_order_errors` pass (plus its private `parse_hex_u32`
helper) — a standalone walk over the raw literal text that borrows nothing from
the parser — moves whole into a new child module
`state_expressions_literals_regex/range_order.rs`. Pure file-organization move,
no logic change (identical to how this file was itself split out of
`state_expressions_literals.rs`); the duplicated `decode_surrogate_pair` is
collapsed into one shared module-scope `const fn` on the way out. The parent's
size ratchet is lowered 2438 → 2191.

## Goal
Goal: hold

## Verification
- `cargo test --release -p tsz-parser --lib` — 2275 passed, 0 failed (adds 12
  tests in `regex_class_set_operand_missing_tests.rs`; updates
  `regex_class_set_bare_hyphen_tests` where `/[--]/v` now correctly draws two
  TS1520s, closing a gap the old test documented).
- `cargo clippy -p tsz-parser --all-targets -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — passed (arch-size gate) with the
  lowered ratchet.
- Oracle diff vs `typescript@7.0.2`: the whole TS1520 missing-operand family now
  matches `tsc` exactly (codes and columns); a 19-case adjacent/regression
  matrix through the release CLI passes 19/19.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01WaGnNH9NXh2w1NTSdABsRo)_