### PR TITLE
fix(checker): class-decorator TS1238/TS1270 anchor at expression, not `@`, except too-few-args

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -600,6 +600,9 @@ path = "tests/ts1238_generic_decorator_tests.rs"
 name = "ts1278_ts1279_decorator_arity_elaboration_tests"
 path = "tests/ts1278_ts1279_decorator_arity_elaboration_tests.rs"
 [[test]]
+name = "ts1238_experimental_decorator_anchor_tests"
+path = "tests/ts1238_experimental_decorator_anchor_tests.rs"
+[[test]]
 name = "ts2862_keyof_tparam_tests"
 path = "tests/ts2862_keyof_tparam_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking/class.rs
+++ b/crates/tsz-checker/src/state/state_checking/class.rs
@@ -1009,29 +1009,17 @@ impl<'a> CheckerState<'a> {
         }
 
         for (decorator_node, decorator_type) in experimental_class_decorators {
-            // tsc 7.0.2 anchors TS1238 at the decorator's EXPRESSION for bare
-            // entities (`@CtorDtor` flags col 2) but at the whole DECORATOR
-            // spanning the `@` when the expression is itself a call
-            // (`@dec()` flags col 1) — mirroring call-node arity anchoring.
-            let anchor = self
-                .ctx
-                .arena
-                .get(decorator_node)
-                .and_then(|n| self.ctx.arena.get_decorator(n))
-                .map(|d| {
-                    let expr_is_call = self
-                        .ctx
-                        .arena
-                        .get(d.expression)
-                        .is_some_and(|e| e.kind == syntax_kind_ext::CALL_EXPRESSION);
-                    if expr_is_call {
-                        decorator_node
-                    } else {
-                        d.expression
-                    }
-                })
-                .unwrap_or(decorator_node);
-            self.check_class_decorator_call_signature(anchor, decorator_type, stmt_idx, class);
+            // Anchor selection (bare identifier vs. call-expression decorator
+            // does NOT matter; tsc anchors both the same way) lives in
+            // `check_class_decorator_call_signature` itself, mirroring the
+            // `decorator_failure_anchor` rule the member/parameter decorator
+            // paths already use.
+            self.check_class_decorator_call_signature(
+                decorator_node,
+                decorator_type,
+                stmt_idx,
+                class,
+            );
         }
     }
 

--- a/crates/tsz-checker/src/state/state_checking/class_decorators.rs
+++ b/crates/tsz-checker/src/state/state_checking/class_decorators.rs
@@ -248,8 +248,9 @@ impl<'a> CheckerState<'a> {
         if !has_call_signatures {
             // No call signatures at all (e.g., a class used as decorator — has construct
             // signatures but no call signatures). Emit TS1238.
+            let anchor = self.decorator_failure_anchor(decorator_node, resolved, 1);
             self.error_at_node(
-                decorator_node,
+                anchor,
                 diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                 diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
             );
@@ -273,8 +274,9 @@ impl<'a> CheckerState<'a> {
         );
 
         let crate::query_boundaries::common::CallResult::Success(return_type) = &result else {
+            let anchor = self.decorator_failure_anchor(decorator_node, resolved, 1);
             self.emit_decorator_signature_error(
-                decorator_node,
+                anchor,
                 diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                 diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                 &result,
@@ -302,8 +304,9 @@ impl<'a> CheckerState<'a> {
                 diagnostic_messages::DECORATOR_FUNCTION_RETURN_TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                 &[&return_str, &expected_str],
             );
+            let anchor = self.decorator_failure_anchor(decorator_node, resolved, 1);
             self.error_at_node(
-                decorator_node,
+                anchor,
                 &message,
                 diagnostic_codes::DECORATOR_FUNCTION_RETURN_TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
             );

--- a/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
@@ -106,7 +106,9 @@ impl<'a> CheckerState<'a> {
             .unwrap_or(decorator_node)
     }
 
-    fn decorator_failure_anchor(
+    /// Shared with the class-decorator TS1238 path in `class_decorators.rs`,
+    /// which anchors legacy class-decorator call failures the same way.
+    pub(crate) fn decorator_failure_anchor(
         &self,
         decorator_node: NodeIndex,
         resolved: TypeId,

--- a/crates/tsz-checker/tests/ts1238_experimental_decorator_anchor_tests.rs
+++ b/crates/tsz-checker/tests/ts1238_experimental_decorator_anchor_tests.rs
@@ -1,0 +1,131 @@
+//! TS1238/TS1270 anchor position under `--experimentalDecorators` for class
+//! decorators. tsc anchors a call-resolution failure at the decorator's
+//! EXPRESSION (one column past `@`) for every failure kind EXCEPT "too few
+//! arguments" (every declared signature needs more than the 1 argument the
+//! runtime supplies), which anchors at the whole DECORATOR (`@`) instead —
+//! regardless of whether the decorator expression is itself a call
+//! expression. Oracle-verified against pinned `typescript@7.0.2`.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_source;
+
+fn check(source: &str) -> Vec<Diagnostic> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            experimental_decorators: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn has_diagnostic_at(diagnostics: &[Diagnostic], code: u32, start: usize) -> bool {
+    diagnostics
+        .iter()
+        .any(|diag| diag.code == code && diag.start == start as u32)
+}
+
+#[test]
+fn ts1238_too_few_args_bare_decorator_anchors_at_whole_decorator() {
+    let source = "function d(a: string, b: string, c: string) {} @d class C {}";
+    let diagnostics = check(source);
+    let at_sign = source.find('@').expect("@ present");
+    assert!(
+        has_diagnostic_at(&diagnostics, 1238, at_sign),
+        "expected TS1238 anchored at `@` ({at_sign}), got: {:?}",
+        diagnostics
+            .iter()
+            .filter(|d| d.code == 1238)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn ts1238_too_few_args_factory_call_decorator_anchors_at_whole_decorator() {
+    // The decorator expression is itself a call (`@d()`), which returns a
+    // function requiring more arguments than the runtime supplies (1, the
+    // class constructor). Still anchors at `@`, not at the inner call.
+    let source = "function d() { return (a: string, b: string, c: string) => {}; } @d() class C {}";
+    let diagnostics = check(source);
+    let at_sign = source.find('@').expect("@ present");
+    assert!(
+        has_diagnostic_at(&diagnostics, 1238, at_sign),
+        "expected TS1238 anchored at `@` ({at_sign}), got: {:?}",
+        diagnostics
+            .iter()
+            .filter(|d| d.code == 1238)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn ts1238_not_callable_bare_decorator_anchors_at_expression() {
+    let source = "const d = 1; @d class C {}";
+    let diagnostics = check(source);
+    let expr_start = source.rfind('d').expect("decorator identifier present");
+    assert!(
+        has_diagnostic_at(&diagnostics, 1238, expr_start),
+        "expected TS1238 anchored at the expression ({expr_start}), got: {:?}",
+        diagnostics
+            .iter()
+            .filter(|d| d.code == 1238)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn ts1238_not_callable_factory_call_decorator_anchors_at_expression_not_at_sign() {
+    // Regression: previously a call-expression decorator (`@d()`) always
+    // anchored at the whole decorator (`@`), which is wrong for every
+    // failure kind except "too few arguments".
+    let source = "function d() { return 1; } @d() class C {}";
+    let diagnostics = check(source);
+    let at_sign = source.find('@').expect("@ present");
+    let expr_start = at_sign + 1;
+    assert!(
+        has_diagnostic_at(&diagnostics, 1238, expr_start),
+        "expected TS1238 anchored at the call expression ({expr_start}), got: {:?}",
+        diagnostics
+            .iter()
+            .filter(|d| d.code == 1238)
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        !has_diagnostic_at(&diagnostics, 1238, at_sign),
+        "TS1238 should not anchor at `@` ({at_sign}) for a non-arity failure"
+    );
+}
+
+#[test]
+fn ts1238_class_used_as_decorator_anchors_at_expression() {
+    // No call signatures at all (construct signatures only) — still anchors
+    // at the expression, not the whole decorator.
+    let source = "class Decorate {} @Decorate class C {}";
+    let diagnostics = check(source);
+    let expr_start = source.find("Decorate class").expect("second Decorate use");
+    assert!(
+        has_diagnostic_at(&diagnostics, 1238, expr_start),
+        "expected TS1238 anchored at the expression ({expr_start}), got: {:?}",
+        diagnostics
+            .iter()
+            .filter(|d| d.code == 1238)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn ts1270_return_type_mismatch_anchors_at_expression() {
+    let source = "function d(a: any) { return 5; } @d class C {}";
+    let diagnostics = check(source);
+    let expr_start = source.rfind('d').expect("decorator identifier present");
+    assert!(
+        has_diagnostic_at(&diagnostics, 1270, expr_start),
+        "expected TS1270 anchored at the expression ({expr_start}), got: {:?}",
+        diagnostics
+            .iter()
+            .filter(|d| d.code == 1270)
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
Fixes #17107.

tsc anchors a class-decorator call-resolution failure at the decorator's
**EXPRESSION** (one column past `@`) for every failure kind **except** "too
few arguments" (every declared signature needs more than the 1 argument the
runtime supplies), which anchors at the whole **DECORATOR** node (`@`)
instead — mirroring the `decorator_failure_anchor` rule the member/parameter
decorator paths (TS1239/1240/1241) already use.

The legacy `check_class_decorator_call_signature` path used a different,
wrong heuristic: anchor at the whole decorator whenever the decorator's own
expression was itself a call (`@d()`), anchor at the expression otherwise.
Oracle-verified against pinned `typescript@7.0.2`: a call-expression
decorator (`@d()`) that resolves to a non-callable value anchors at the
expression (the `d()` call), same as a bare identifier — the call-expression
heuristic was backwards for every non-arity failure.

Widened `decorator_failure_anchor`
(`crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs`)
to `pub(crate)` and reused it at all three TS1238/TS1270 error sites in
`class_decorators.rs`'s `check_class_decorator_call_signature`, removing the
bespoke anchor computation from `class.rs`'s caller.

## Goal
Goal: hold

## Verification
- New `crates/tsz-checker/tests/ts1238_experimental_decorator_anchor_tests.rs`
  (6 tests, oracle-verified against pinned `typescript@7.0.2`): too-few-args
  bare and factory-call decorator (anchors at `@`), not-callable bare and
  factory-call decorator (anchors at expression — the factory-call case is
  the regression test for the old wrong heuristic), class-used-as-decorator
  (anchors at expression), TS1270 return-type mismatch (anchors at
  expression). `cargo test -p tsz-checker --test ts1238_experimental_decorator_anchor_tests` → 6/6 pass.
- All pre-existing decorator suites unaffected (0 regressions): `ts1238_tests`
  14/14, `ts1238_generic_decorator_tests` 2/2,
  `ts1278_ts1279_decorator_arity_elaboration_tests` 8/8,
  `decorator_this_binding_tests` 16/16, `decorator_method_tdz_tests` 10/10,
  `es_member_decorator_arity_tests` 15/15, `issue_7681_super_decorator_tests`
  7/7, `ts2449_parameter_decorator_no_tdz_tests` 2/2.
- `cargo check -p tsz-checker --lib` clean.
- `cargo clippy -p tsz-checker --lib -- -D warnings` clean; `cargo clippy -p tsz-checker --test ts1238_experimental_decorator_anchor_tests -- -D warnings` clean.
- `cargo fmt -p tsz-checker -- --check` clean.
- `python3 scripts/arch/arch_guard.py` → "Architecture guardrails passed."
- Only class-decorator TS1238/TS1270 anchor positions can move (message/code
  unchanged in every case); the TypeScript corpus submodule was not checked
  out for this change, so no full conformance/emit sweep was run — this is
  purely a position fix on diagnostics already exercised by the targeted
  suites above.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGcKwzHHMLQ7YdXSxfnzAW)_