### PR TITLE
fix(solver): non-primitive `object` source reports generic TS2322, not a `{}`-rendered TS2741

### DIFF
--- a/crates/tsz-checker/tests/ts2322_tests/part_06.rs
+++ b/crates/tsz-checker/tests/ts2322_tests/part_06.rs
@@ -229,3 +229,129 @@ const badCarryToRight: Right.Status = carry;
         "merged enum declaration auto-values should reset per declaration block, got: {messages:#?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// `object` (the non-primitive intrinsic) as an assignment/argument source.
+//
+// `object` is not a `TypeFlags.StructuredType`, so tsc never drills into a
+// target's members to elaborate a missing-property line for it. A failed
+// `object <: <object-like>` surfaces the generic TS2322 (naming `object`
+// verbatim) — never TS2741/TS2739/TS2740 rendered against a `{}` apparent
+// shape. Regression witness:
+// conformance/types/nonPrimitive/nonPrimitiveAssignError.ts.
+// ---------------------------------------------------------------------------
+
+/// Assert an `object` (non-primitive intrinsic) source produces exactly one
+/// generic TS2322 equal to `expected` and no missing-property elaboration
+/// (TS2739/TS2740/TS2741). Collects the diagnostics once.
+fn assert_object_source_single_ts2322(source: &str, expected: &str) {
+    let diagnostics = get_all_diagnostics(source);
+    for missing_property_code in [2739_u32, 2740, 2741] {
+        assert!(
+            !has_diagnostic_code(&diagnostics, missing_property_code),
+            "`object` source must not emit TS{missing_property_code}, got: {diagnostics:?}"
+        );
+    }
+    let ts2322: Vec<&str> = diagnostics
+        .iter()
+        .filter_map(|(code, message)| (*code == 2322).then_some(message.as_str()))
+        .collect();
+    assert_eq!(
+        ts2322,
+        vec![expected],
+        "expected exactly one generic TS2322 naming `object` verbatim (not a \
+         `{{}}`-rendered apparent shape), got: {diagnostics:?}"
+    );
+}
+
+/// A single required target property must NOT turn an `object` source into a
+/// TS2741 "property missing" line; tsc reports the generic TS2322 naming
+/// `object`.
+#[test]
+fn test_object_intrinsic_source_reports_ts2322_not_missing_property() {
+    assert_object_source_single_ts2322(
+        r#"
+declare var src: object;
+var dst: { foo: string } = src;
+"#,
+        "Type 'object' is not assignable to type '{ foo: string; }'.",
+    );
+}
+
+/// Multiple missing target properties must NOT produce TS2739/TS2740 for an
+/// `object` source either — still the generic TS2322.
+#[test]
+fn test_object_intrinsic_source_multi_property_target_reports_ts2322() {
+    assert_object_source_single_ts2322(
+        r#"
+declare var payload: object;
+var sink: { foo: string; bar: number } = payload;
+"#,
+        "Type 'object' is not assignable to type '{ foo: string; bar: number; }'.",
+    );
+}
+
+/// An index-signature target follows the same rule (renamed binder to keep the
+/// check binder-name independent).
+#[test]
+fn test_object_intrinsic_source_index_signature_target_reports_ts2322() {
+    assert_object_source_single_ts2322(
+        r#"
+declare var bag: object;
+var lookup: { [key: string]: number } = bag;
+"#,
+        "Type 'object' is not assignable to type '{ [key: string]: number; }'.",
+    );
+}
+
+/// The same discipline holds in argument position (TS2345): an `object`
+/// argument against an object-typed parameter reports the generic argument
+/// mismatch, not a nested missing-property elaboration.
+#[test]
+fn test_object_intrinsic_argument_source_reports_ts2345_not_missing_property() {
+    let source = r#"
+declare function sink(target: { foo: string }): void;
+declare var src: object;
+sink(src);
+"#;
+    let diagnostics = get_all_diagnostics(source);
+
+    assert!(
+        !has_diagnostic_code(&diagnostics, 2741),
+        "`object` argument must not emit TS2741, got: {diagnostics:?}"
+    );
+    let ts2345 = messages_with_code(source, 2345);
+    assert_eq!(
+        ts2345,
+        vec![
+            "Argument of type 'object' is not assignable to parameter of type '{ foo: string; }'."
+                .to_string()
+        ],
+        "expected generic TS2345 naming `object`, got: {diagnostics:?}"
+    );
+}
+
+/// Regression guard: the empty object type `{}` and a members-less interface
+/// ARE structured object sources, so a missing required target property still
+/// elaborates as TS2741 (tsc parity). The `object` fix must not disturb them.
+#[test]
+fn test_empty_object_and_empty_interface_sources_keep_ts2741() {
+    let empty_object = r#"
+declare var src: {};
+var dst: { foo: string } = src;
+"#;
+    assert!(
+        has_diagnostic_code(&get_all_diagnostics(empty_object), 2741),
+        "empty object literal `{{}}` source must keep TS2741"
+    );
+
+    let empty_interface = r#"
+interface Blank {}
+declare var src: Blank;
+var dst: { foo: string } = src;
+"#;
+    assert!(
+        has_diagnostic_code(&get_all_diagnostics(empty_interface), 2741),
+        "members-less interface source must keep TS2741"
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -526,26 +526,22 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             }
         }
 
-        // Handle `object` intrinsic (non-primitive type) as source when target is an object.
-        // `object` has no own properties, so all required target properties are "missing".
-        // This produces TS2741/TS2739 instead of generic TS2322.
-        if resolved_source == TypeId::OBJECT
-            || intrinsic_kind(self.interner, resolved_source) == Some(IntrinsicKind::Object)
-        {
-            if let Some(t_shape_id) = object_shape_id(self.interner, resolved_target) {
-                let t_shape = self.interner.object_shape(t_shape_id);
-                return self.explain_object_failure(source, target, &[], None, &t_shape.properties);
-            }
-            if let Some(t_shape_id) = object_with_index_shape_id(self.interner, resolved_target) {
-                let t_shape = self.interner.object_shape(t_shape_id);
-                return self.explain_indexed_object_failure(
-                    source,
-                    target,
-                    &ObjectShape::default(),
-                    None,
-                    &t_shape,
-                );
-            }
+        // The `object` intrinsic is `NonPrimitive`, not `StructuredType`, so
+        // tsc's structural property comparison (which owns TS2741/TS2739/TS2740)
+        // is never reached for an `object` source; a failed relation surfaces
+        // the generic `TypeMismatch` (TS2322) naming `object` verbatim, not a
+        // `{}`-rendered missing-property line (see nonPrimitiveAssignError.ts,
+        // and the test header for the full rationale). The empty object type
+        // `{}` and members-less interfaces are structured sources and keep the
+        // missing-property elaboration through the object-shape arms below.
+        // Placed before the union/array/callable-target arms so the generic
+        // reason wins regardless of target shape. `intrinsic_kind == Object`
+        // already subsumes the `TypeId::OBJECT` identity.
+        if intrinsic_kind(self.interner, resolved_source) == Some(IntrinsicKind::Object) {
+            return Some(SubtypeFailureReason::TypeMismatch {
+                source_type: source,
+                target_type: target,
+            });
         }
 
         if let (Some(s_shape_id), Some(t_shape_id)) = (


### PR DESCRIPTION
When the **source** of a failed assignability relation is the non-primitive `object` intrinsic, tsc reports the generic **TS2322** naming `object`; tsz was reporting a `{}`-rendered **TS2741/TS2739/TS2740** missing-property line through the solver relation-explain boundary (`crates/tsz-solver/src/relations/subtype/explain.rs`, `explain_failure_inner`).

`object` is `TypeFlags.NonPrimitive`, not `TypeFlags.StructuredType`, so tsc's structural property comparison (`propertiesRelatedTo`, which owns TS2741/TS2739/TS2740) is never reached for it. tsz had a special-case arm that routed an `object` source into `explain_object_failure(..., &[] /* empty source props */, ...)`, promoting the missing-property reason to the top-level diagnostic and rendering the source as its `{}` apparent shape.

**Fix (owner layer — solver):** return the generic `SubtypeFailureReason::TypeMismatch` (TS2322) for an `object` intrinsic source, placed before the union/array/callable-target arms so the generic reason wins regardless of target shape. The empty object type `{}` and members-less interfaces are structured sources and keep their correct TS2741 through the object-shape arms below.

Witness: `conformance/types/nonPrimitive/nonPrimitiveAssignError.ts` (the conformance snapshot's `one_extra_zero_missing` TS2741 slice). Closes #17103.

### Adjacent matrix (`typescript@7.0.2`, `--strict --target es2015 --lib es2015`)

| source | target | tsc / tsz (after) |
| --- | --- | --- |
| `object` | `{ foo: string }` | TS2322 |
| `object` | `{ foo: string; bar: number }` | TS2322 (not TS2740) |
| `object` | `{ [k: string]: number }` | TS2322 |
| `object` (argument) | `{ foo: string }` param | TS2345 (not missing-property) |
| `{}` empty object | `{ foo: string }` | TS2741 (unchanged) |
| members-less interface | `{ foo: string }` | TS2741 (unchanged) |

**Fallback / scope:** the global `Object` *interface* source → TS2696 divergence is a separate, disjoint path (`crates/tsz-checker/src/error_reporter/render_failure.rs`) and is out of scope (noted in #17103). The fix cannot interfere — after it, `object` returns `TypeMismatch`, not a property-failure reason, so it never reaches the TS2696 gate.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts2322_tests` — 314 pass, incl. 5 new tests (object → object-literal / multi-prop / index-signature / argument-position, plus `{}` and members-less-interface regression guards).
- `conformance/types/nonPrimitive/nonPrimitiveAssignError.ts` now matches tsc 7.0.2 (error codes identical); no regression across the fetched nonPrimitive family (`nonPrimitiveInFunction`, `nonPrimitiveNarrow`, `nonPrimitiveUnionIntersection`).
- `cargo clippy --profile ci-lint -p tsz-solver -p tsz-checker --all-targets -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — pass (explain.rs 2016 lines, under the 2026 ratchet).

## Provenance
Machine: cloud
Assistant: claude-code
Model: Opus 4.8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXi7azsVBviBqgZi1fdq7d)_