### PR TITLE
fix(solver): `object` intrinsic source surfaces generic TS2322/TS2345, not a {}-rendered TS2741/TS2739/TS2740

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2383,6 +2383,9 @@ path = "tests/stage3_lib_namespace_resolution_tests.rs"
 name = "ts2321_ts2859_tests"
 path = "tests/ts2321_ts2859_tests.rs"
 [[test]]
+name = "ts2322_object_intrinsic_source_tests"
+path = "tests/ts2322_object_intrinsic_source_tests.rs"
+[[test]]
 name = "deeply_nested_conditional_mapped_recursion_tests"
 path = "tests/deeply_nested_conditional_mapped_recursion_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/ts2322_object_intrinsic_source_tests.rs
+++ b/crates/tsz-checker/tests/ts2322_object_intrinsic_source_tests.rs
@@ -1,0 +1,200 @@
+//! The non-primitive `object` intrinsic as the SOURCE of a failed
+//! assignability relation surfaces the generic TS2322 (assignment) / TS2345
+//! (argument) head naming `object` verbatim — never a `{}`-rendered
+//! TS2741/TS2739/TS2740 missing-property head.
+//!
+//! `object` carries `TypeFlags.NonPrimitive`, not `TypeFlags.StructuredType`,
+//! so tsc never routes it through `propertiesRelatedTo` (the owner of
+//! TS2741/TS2739/TS2740). The empty object `{}` and a members-less interface,
+//! by contrast, are genuine structured object sources and keep their TS2741
+//! head. See issue #17103.
+//!
+//! Every row is pinned against `typescript@7.0.2`
+//! (`--strict --target es2015 --lib es2015 --pretty false`). The oracle keeps
+//! the missing-property line only as *nested* related information under the
+//! generic head; these tests assert the top-level diagnostic code, which is
+//! where tsz diverged (an extra `{}`-rendered TS2741/TS2739/TS2740 head).
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn top_level_codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// `object` intrinsic source → generic TS2322 head, never TS2741/TS2739/TS2740
+// ---------------------------------------------------------------------------
+
+#[test]
+fn object_source_to_single_property_target_is_ts2322_not_ts2741() {
+    let codes = top_level_codes(
+        "declare let a: object;\n\
+         let y: { foo: string } = a;\n",
+    );
+    assert!(
+        codes.contains(&2322),
+        "expected top-level TS2322 for `object` source, got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2741),
+        "the `{{}}`-rendered TS2741 missing-property head must not fire for an \
+         `object` source, got {codes:?}"
+    );
+}
+
+#[test]
+fn object_source_to_multi_property_target_is_ts2322_not_ts2739_or_ts2740() {
+    let codes = top_level_codes(
+        "declare let a: object;\n\
+         let y: { foo: string; bar: number } = a;\n",
+    );
+    assert!(codes.contains(&2322), "expected TS2322, got {codes:?}");
+    assert!(
+        !codes.contains(&2739) && !codes.contains(&2740),
+        "the multi-property missing head (TS2739/TS2740) must not fire for an \
+         `object` source, got {codes:?}"
+    );
+}
+
+#[test]
+fn object_source_to_interface_target_is_ts2322() {
+    let codes = top_level_codes(
+        "interface J { foo: string; bar: number; }\n\
+         declare let a: object;\n\
+         let j: J = a;\n",
+    );
+    assert!(codes.contains(&2322), "expected TS2322, got {codes:?}");
+    assert!(
+        !codes.contains(&2739) && !codes.contains(&2740) && !codes.contains(&2741),
+        "no missing-property head for an `object` source, got {codes:?}"
+    );
+}
+
+#[test]
+fn object_source_to_index_signature_target_is_ts2322() {
+    let codes = top_level_codes(
+        "declare let a: object;\n\
+         let idx: { [k: string]: number } = a;\n",
+    );
+    assert!(codes.contains(&2322), "expected TS2322, got {codes:?}");
+    assert!(
+        !codes.contains(&2741) && !codes.contains(&2739) && !codes.contains(&2740),
+        "an index-signature target must not draw a missing-property head for an \
+         `object` source, got {codes:?}"
+    );
+}
+
+#[test]
+fn object_source_to_class_target_is_ts2322() {
+    let codes = top_level_codes(
+        "class C { m() {} }\n\
+         declare let a: object;\n\
+         let c: C = a;\n",
+    );
+    assert!(codes.contains(&2322), "expected TS2322, got {codes:?}");
+    assert!(
+        !codes.contains(&2741),
+        "a class target must not draw TS2741 for an `object` source, got {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Argument position: the same source surfaces TS2345, never a missing-property
+// head
+// ---------------------------------------------------------------------------
+
+#[test]
+fn object_source_in_argument_position_is_ts2345_not_ts2741() {
+    let codes = top_level_codes(
+        "declare let a: object;\n\
+         function need(p: { foo: string }): void {}\n\
+         need(a);\n",
+    );
+    assert!(
+        codes.contains(&2345),
+        "expected top-level TS2345 for an `object` argument, got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2741),
+        "no TS2741 head for an `object` argument, got {codes:?}"
+    );
+}
+
+#[test]
+fn object_source_argument_to_index_signature_is_ts2345() {
+    let codes = top_level_codes(
+        "declare let a: object;\n\
+         function need(p: { [k: string]: number }): void {}\n\
+         need(a);\n",
+    );
+    assert!(codes.contains(&2345), "expected TS2345, got {codes:?}");
+    assert!(
+        !codes.contains(&2741) && !codes.contains(&2739) && !codes.contains(&2740),
+        "no missing-property head for an `object` argument, got {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Anti-hardcoding: the rule is about the `object` intrinsic, not any name
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_rule_holds_regardless_of_binder_names() {
+    let codes = top_level_codes(
+        "declare let somethingElse: object;\n\
+         let target: { alpha: string; beta: number } = somethingElse;\n",
+    );
+    assert!(codes.contains(&2322), "expected TS2322, got {codes:?}");
+    assert!(
+        !codes.contains(&2739) && !codes.contains(&2740) && !codes.contains(&2741),
+        "renaming the binders must not change the head, got {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Controls: genuine structured object sources keep their TS2741 head, and
+// `unknown` keeps its TS2322 — the fix must not disturb either
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_object_literal_source_keeps_ts2741() {
+    let codes = top_level_codes(
+        "declare let e: {};\n\
+         let y: { foo: string } = e;\n",
+    );
+    assert!(
+        codes.contains(&2741),
+        "the empty object `{{}}` is a structured source and keeps TS2741, got {codes:?}"
+    );
+}
+
+#[test]
+fn members_less_interface_source_keeps_ts2741() {
+    let codes = top_level_codes(
+        "interface I {}\n\
+         declare let i: I;\n\
+         let y: { foo: string } = i;\n",
+    );
+    assert!(
+        codes.contains(&2741),
+        "a members-less interface is a structured source and keeps TS2741, got {codes:?}"
+    );
+}
+
+#[test]
+fn unknown_source_stays_ts2322() {
+    let codes = top_level_codes(
+        "declare let u: unknown;\n\
+         let y: { foo: string } = u;\n",
+    );
+    assert!(
+        codes.contains(&2322),
+        "expected TS2322 for `unknown`, got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2741),
+        "`unknown` never draws a missing-property head, got {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -526,26 +526,30 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             }
         }
 
-        // Handle `object` intrinsic (non-primitive type) as source when target is an object.
-        // `object` has no own properties, so all required target properties are "missing".
-        // This produces TS2741/TS2739 instead of generic TS2322.
+        // The `object` non-primitive intrinsic as the SOURCE of a failed
+        // relation surfaces the generic TS2322 (assignment) / TS2345 (argument)
+        // naming `object` verbatim — never a `{}`-rendered missing-property
+        // head. `object` carries `TypeFlags.NonPrimitive`, not
+        // `TypeFlags.StructuredType`, so tsc never reaches `propertiesRelatedTo`
+        // (the owner of TS2741/TS2739/TS2740) for it. Routing it into
+        // `explain_object_failure` with an empty source-property list promoted
+        // that missing-property reason to the top-level diagnostic, rendering
+        // `object` as its `{}` apparent shape. Return `TypeMismatch` so the
+        // checker emits the generic head instead, for every target shape and in
+        // both assignment and argument position.
+        //
+        // The empty object `{}` and a members-less interface are genuine
+        // structured object sources (they have an object shape), so they never
+        // reach this arm and keep their correct TS2741 through the object-shape
+        // arms below. Only the `object` intrinsic — which has no object shape of
+        // its own — lands here.
         if resolved_source == TypeId::OBJECT
             || intrinsic_kind(self.interner, resolved_source) == Some(IntrinsicKind::Object)
         {
-            if let Some(t_shape_id) = object_shape_id(self.interner, resolved_target) {
-                let t_shape = self.interner.object_shape(t_shape_id);
-                return self.explain_object_failure(source, target, &[], None, &t_shape.properties);
-            }
-            if let Some(t_shape_id) = object_with_index_shape_id(self.interner, resolved_target) {
-                let t_shape = self.interner.object_shape(t_shape_id);
-                return self.explain_indexed_object_failure(
-                    source,
-                    target,
-                    &ObjectShape::default(),
-                    None,
-                    &t_shape,
-                );
-            }
+            return Some(SubtypeFailureReason::TypeMismatch {
+                source_type: source,
+                target_type: target,
+            });
         }
 
         if let (Some(s_shape_id), Some(t_shape_id)) = (


### PR DESCRIPTION
Fixes #17103.

When the **source** of a failed assignability relation is the `object`
(non-primitive) intrinsic and the target is object-like, tsz drilled into the
target's members and emitted a missing-property head — TS2741 (single) /
TS2739 / TS2740 (multiple) — rendering the `object` source as its `{}` apparent
shape. `tsc` never does this: `object` carries `TypeFlags.NonPrimitive`, not
`TypeFlags.StructuredType`, so its structural property comparison
(`propertiesRelatedTo`, the owner of TS2741/TS2739/TS2740) is never reached for
it. A failed `object <: T` surfaces the generic **TS2322** (assignment) /
**TS2345** (argument) naming `object` verbatim, with the missing-property detail
kept only as *nested* related information.

**Structural rule:** when the source of a failed assignability relation is the
non-primitive `object` intrinsic, `tsc` reports the generic TS2322/TS2345; tsz
was reporting a `{}`-rendered TS2741/TS2739/TS2740 through the solver
relation-explain boundary. `explain_failure_inner`'s `object`-intrinsic arm
routed the source into `explain_object_failure(..., &[] /* empty source props */)`,
promoting the missing-property reason to the top-level diagnostic. It now
returns the generic `SubtypeFailureReason::TypeMismatch` for every target shape
and in both assignment and argument position.

Owner layer: solver relation-explain boundary
(`crates/tsz-solver/src/relations/subtype/explain.rs`).

### Why the broadening (all target shapes) is a strict parity gain

The empty object `{}` and a members-less interface are genuine *structured*
object sources (they have an object shape), so they never reach this arm and
keep their correct TS2741 head; `unknown` keeps its TS2322. For a NonPrimitive
`object` source the later arms only ever produced *more* structural detail than
`tsc` emits:

- object-shape / callable-target / union-target / conditional-branch arms drilled
  a `MissingProperty`/`UnionTargetMismatch`/`ConditionalBranchMismatch` head that
  `tsc` never shows for `object`;
- the scalar leaf arms (`IntrinsicTypeMismatch`, `NoUnionMemberMatches`) already
  render **byte-identical** to `TypeMismatch` for an `object` source — their only
  differentiator, a string-literal spelling suggestion (TS2820), is unreachable
  for a non-literal `object`.

So short-circuiting to `TypeMismatch` matches `tsc`'s top-level head for every
target (object literal, interface, index signature, class, union, primitive,
tuple, constructor) and additionally corrects several pre-existing
over-drilling cases.

The global `Object` *interface* source (a separate TS2696 path with murkier
`tsc` semantics) is deliberately out of scope, tracked in #17103.

## Goal
Goal: hold

## Verification
- New oracle-pinned test file
  `crates/tsz-checker/tests/ts2322_object_intrinsic_source_tests.rs` (11 tests,
  pinned against `typescript@7.0.2` `--strict --target es2015 --lib es2015`):
  `object` source → single-property / multi-property / interface /
  index-signature / class targets, argument position (TS2345), an anti-hardcoding
  renamed-binder row, and controls proving `{}` and a members-less interface keep
  TS2741 and `unknown` keeps TS2322. **11/11 pass.**
- **Conformance (isolated, same base `a93e825`, only this change differs):
  0 regressions; witness `conformance/types/nonPrimitive/nonPrimitiveAssignError.ts`
  fixed** (extra top-level TS2741 → TS2322; `types/nonPrimitive` 15/15).
  passed 11577 → 11578, failed 466 → 465. Details in the PR comment.
- Pre-commit gate on the exact head commit: `Clippy passed. / Architecture guard
  passed. / Local verification passed.` (affected crates `-p tsz-checker
  -p tsz-solver`). Per-merge CI green on head: `clippy` ✅, `arch-size` ✅.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high