### PR TITLE
fix(checker): render tuple/function type annotations canonically in diagnostics

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -162,6 +162,10 @@ impl<'a> CheckerState<'a> {
                         decl_arena,
                         param.type_annotation,
                     )
+                    || Self::annotation_is_canonicalized_structural_type(
+                        decl_arena,
+                        param.type_annotation,
+                    )
                 {
                     return None;
                 }
@@ -192,6 +196,10 @@ impl<'a> CheckerState<'a> {
                         decl_arena,
                         var_decl.type_annotation,
                     )
+                    || Self::annotation_is_canonicalized_structural_type(
+                        decl_arena,
+                        var_decl.type_annotation,
+                    )
                 {
                     return None;
                 }
@@ -207,6 +215,10 @@ impl<'a> CheckerState<'a> {
             {
                 if self.annotation_names_type_query_alias(decl_arena, prop_decl.type_annotation)
                     || Self::annotation_is_keyof_over_degenerate_operand(
+                        decl_arena,
+                        prop_decl.type_annotation,
+                    )
+                    || Self::annotation_is_canonicalized_structural_type(
                         decl_arena,
                         prop_decl.type_annotation,
                     )
@@ -296,6 +308,10 @@ impl<'a> CheckerState<'a> {
                     decl_arena,
                     param.type_annotation,
                 )
+                || Self::annotation_is_canonicalized_structural_type(
+                    decl_arena,
+                    param.type_annotation,
+                )
             {
                 return None;
             }
@@ -309,6 +325,10 @@ impl<'a> CheckerState<'a> {
         {
             if self.annotation_names_type_query_alias(decl_arena, var_decl.type_annotation)
                 || Self::annotation_is_keyof_over_degenerate_operand(
+                    decl_arena,
+                    var_decl.type_annotation,
+                )
+                || Self::annotation_is_canonicalized_structural_type(
                     decl_arena,
                     var_decl.type_annotation,
                 )

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/type_query_alias.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/type_query_alias.rs
@@ -208,6 +208,48 @@ impl<'a> CheckerState<'a> {
         )
     }
 
+    /// Whether a declared type annotation is a structural tuple or
+    /// function/constructor type that tsc always renders through `typeToString`
+    /// (`[number, string]`, `(a: number) => void`) rather than preserving as
+    /// written.
+    ///
+    /// tsz's structural `TypeFormatter` renders these identically to tsc —
+    /// including named / optional / rest tuple members and function parameter
+    /// names — so the declared-annotation source-text fallback
+    /// (`declared_type_annotation_text_for_expression_with_options`) must NOT
+    /// reproduce the written form, which leaks the author's whitespace:
+    /// `[number,string]` or `[number,   string]` instead of `[number, string]`,
+    /// and `(a:number,b:string)=>void` instead of `(a: number, b: string) =>
+    /// void`. Returning `true` here makes the caller fall back to the canonical
+    /// structural formatter, matching tsc. Parenthesized wrappers are unwrapped
+    /// so `([number, string])` is classified by its inner node. Mirrors
+    /// [`Self::annotation_is_keyof_over_degenerate_operand`], which drops the
+    /// written form for the same reason.
+    pub(in crate::error_reporter) fn annotation_is_canonicalized_structural_type(
+        arena: &tsz_parser::NodeArena,
+        annotation_idx: NodeIndex,
+    ) -> bool {
+        let mut idx = annotation_idx;
+        for _ in 0..16 {
+            let Some(node) = arena.get(idx) else {
+                return false;
+            };
+            match node.kind {
+                syntax_kind_ext::PARENTHESIZED_TYPE => {
+                    let Some(wrapped) = arena.get_wrapped_type(node) else {
+                        return false;
+                    };
+                    idx = wrapped.type_node;
+                }
+                syntax_kind_ext::TUPLE_TYPE
+                | syntax_kind_ext::FUNCTION_TYPE
+                | syntax_kind_ext::CONSTRUCTOR_TYPE => return true,
+                _ => return false,
+            }
+        }
+        false
+    }
+
     pub(in crate::error_reporter) fn annotation_names_type_query_alias(
         &self,
         arena: &tsz_parser::NodeArena,

--- a/crates/tsz-checker/src/error_reporter/mod.rs
+++ b/crates/tsz-checker/src/error_reporter/mod.rs
@@ -67,3 +67,7 @@ pub(crate) use fingerprint_policy::{
 #[cfg(test)]
 #[path = "render_request_tests.rs"]
 mod render_request_tests;
+
+#[cfg(test)]
+#[path = "tuple_annotation_display_tests.rs"]
+mod tuple_annotation_display_tests;

--- a/crates/tsz-checker/src/error_reporter/tuple_annotation_display_tests.rs
+++ b/crates/tsz-checker/src/error_reporter/tuple_annotation_display_tests.rs
@@ -1,0 +1,99 @@
+//! Regression tests for canonical display of structural tuple / function type
+//! annotations in assignability diagnostics.
+//!
+//! tsc always renders a written tuple or function/constructor type annotation
+//! through `typeToString` (`[number, string]`, `(a: number) => void`) rather
+//! than preserving the author's source spelling. tsz's declared-annotation
+//! source-text fallback previously leaked the written form — including
+//! non-canonical whitespace such as `[number,string]` or `[number,   string]`.
+//! The fix routes these structural annotations back through the canonical
+//! structural formatter (see
+//! `annotation_is_canonicalized_structural_type`), while type-reference /
+//! alias annotations keep their as-written name.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn ts2322_message(source: &str) -> String {
+    let diagnostics = check_source_diagnostics(source);
+    diagnostics
+        .iter()
+        .find(|d| d.code == 2322)
+        .unwrap_or_else(|| {
+            panic!(
+                "expected a TS2322 diagnostic, got codes: {:?}",
+                diagnostics.iter().map(|d| d.code).collect::<Vec<_>>()
+            )
+        })
+        .message_text
+        .clone()
+}
+
+#[test]
+fn tuple_annotation_renders_canonical_comma_spacing() {
+    // Source omits the space after the comma; tsc canonicalizes to `, `.
+    let message = ts2322_message("const t: [number,string] = [1, 's']; const a: number[] = t;");
+    assert!(
+        message.contains("Type '[number, string]'"),
+        "tuple annotation should render canonically as `[number, string]`, got: {message}"
+    );
+    assert!(
+        !message.contains("[number,string]"),
+        "tuple annotation must not leak the compact source spelling, got: {message}"
+    );
+}
+
+#[test]
+fn tuple_annotation_collapses_non_canonical_whitespace() {
+    // Extra interior whitespace must not survive into the rendered type.
+    let message = ts2322_message("const t: [number,   string] = [1, 's']; const a: number[] = t;");
+    assert!(
+        message.contains("Type '[number, string]'"),
+        "tuple annotation should collapse extra whitespace to `[number, string]`, got: {message}"
+    );
+}
+
+#[test]
+fn named_tuple_annotation_renders_canonical_spacing() {
+    let message = ts2322_message("const t: [a:number,b:string] = [1, 's']; const a: number[] = t;");
+    assert!(
+        message.contains("Type '[a: number, b: string]'"),
+        "named tuple annotation should render as `[a: number, b: string]`, got: {message}"
+    );
+}
+
+#[test]
+fn function_type_annotation_renders_canonical_spacing() {
+    let message = ts2322_message(
+        "const f: (a:number,b:string)=>void = (() => {}) as any; const g: number = f;",
+    );
+    assert!(
+        message.contains("Type '(a: number, b: string) => void'"),
+        "function-type annotation should render as `(a: number, b: string) => void`, got: {message}"
+    );
+}
+
+#[test]
+fn constructor_type_annotation_renders_canonical_spacing() {
+    let message = ts2322_message(
+        "const c: new(a:number,b:string)=>object = (class {}) as any; const g: number = c;",
+    );
+    assert!(
+        message.contains("Type 'new (a: number, b: string) => object'"),
+        "constructor-type annotation should render as `new (a: number, b: string) => object`, \
+         got: {message}"
+    );
+}
+
+#[test]
+fn tuple_type_alias_annotation_keeps_its_name() {
+    // A *reference* to a tuple alias must still display the alias name, not the
+    // expanded structural form — the fix is scoped to inline structural
+    // annotations only.
+    let message = ts2322_message(
+        "type Pair = [number, string]; const t: Pair = [1, 's']; const a: number[] = t;",
+    );
+    assert!(
+        message.contains("Type 'Pair'"),
+        "a tuple *alias* reference must keep its name `Pair`, got: {message}"
+    );
+}


### PR DESCRIPTION
Assignability diagnostics displayed a **written** tuple or function/constructor
type annotation using its raw source text, leaking the author's spelling and
whitespace instead of `tsc`'s canonical `typeToString` form:

| annotation as written | tsz (before) | tsc / tsz (after) |
| --- | --- | --- |
| `[number,string]` | `[number,string]` | `[number, string]` |
| `[number,   string]` | `[number,   string]` | `[number, string]` |
| `[a:number,b:string]` | `[a:number,b:string]` | `[a: number, b: string]` |
| `(a:number,b:string)=>void` | `(a:number,b:string)=>void` | `(a: number, b: string) => void` |
| `new(a:number)=>object` | `new(a:number)=>object` | `new (a: number) => object` |

Inferred tuple/function types already rendered correctly through the structural
formatter; only written annotations diverged, because the declared-annotation
source-text fallback echoed the node's exact source substring.

## Structural rule
When a variable / parameter / property declares an **inline structural** tuple
or function/constructor type (`TUPLE_TYPE`, `FUNCTION_TYPE`, `CONSTRUCTOR_TYPE`),
`tsc` renders it in diagnostics through canonical `typeToString`, never the
as-written text; `tsz` now does the same. A type-**reference** / alias
annotation (`type Pair = [number, string]; const t: Pair`) still displays its
as-written name (`Pair`), matching `tsc`.

## Owner layer
Checker diagnostics display — `error_reporter::core::diagnostic_source`. The new
`annotation_is_canonicalized_structural_type` gate makes the source-text
fallback defer these structural annotations to the canonical structural
formatter, mirroring the existing `annotation_is_keyof_over_degenerate_operand`
carve-out (same reason: `tsc` never preserves the written syntax). The structural
formatter already matches `tsc` for named / optional / rest tuple members and
function parameter names, so the fallback is exact. No solver/type semantics
change.

## Adjacent cases covered
Fixed: bare 2/3-element tuples, nested tuples, named / optional / rest tuple
members, function types (var, parameter, property, return position),
constructor types, non-canonical interior whitespace. Unchanged (regression
guards): tuple/function **alias** references keep their name, interface/generic
alias references, plain unions, `keyof` annotations.

## Goal
Goal: hold

## Verification
- Differential matrix against the pinned oracle `typescript@7.0.2` (tsz's
  target compiler): 10 divergent cases now match `tsc` exactly; 7
  regression-guard cases (alias/reference/union annotations) unchanged. All
  17 pass.
- Pre-commit hook on the exact head: **Clippy passed**, **Architecture guard
  passed** (`-p tsz-checker`; both changed files < 2000 lines).
- Added `tuple_annotation_display_tests.rs` (6 cases) asserting the canonical
  message text; the checker crate (incl. this test module) compiles under the
  pre-commit clippy build.
- Not run locally in this environment: the full unit / conformance / emit /
  fourslash suites — the `--release` checker test target hits a pre-existing
  `ScopedPerfCounters` `cfg(test, debug_assertions)` gate and the debug build
  exceeds the session memory/disk allowance. These run in nightly CI. The
  change is display-only and adds no new diagnostic codes, so conformance
  code-level results are unaffected.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ae6MCzHfpwWVWEmo4wEe8q)_