### PR TITLE
fix(checker): traverse re-export chain for the TS1484/TS1485 pick and report the type-only family alongside the commonjs syntax error (#17098)

### DIFF
--- a/crates/tsz-checker/src/declarations/import/verbatim.rs
+++ b/crates/tsz-checker/src/declarations/import/verbatim.rs
@@ -222,7 +222,14 @@ impl<'a> CheckerState<'a> {
                 )
             };
             self.error_at_node(error_node, message, code);
-            return;
+            // Fall through to the per-specifier loop rather than returning:
+            // under verbatimModuleSyntax tsc still reports the type-only-import
+            // diagnostics (TS1484/TS1485) at their own anchors *alongside* this
+            // ESM-in-CJS syntax error (oracle-verified: a type-only named import
+            // in a CommonJS file reports both TS1295 and TS1484/TS1485 at the
+            // same position). The `preserve_isolated` case (TS1293, where those
+            // verbatimModuleSyntax-exclusive checks do not apply) is stopped by
+            // the shared guard just below (tsz-org/tsz#17098).
         }
 
         // `module: "preserve"` + `isolatedModules` (without VMS) has no
@@ -276,43 +283,53 @@ impl<'a> CheckerState<'a> {
                 import_name.clone()
             };
 
-            // Determine which diagnostic to emit.  tsc distinguishes:
-            //   TS1484: "is a type" — the imported symbol is DIRECTLY a type
-            //           declaration in the source module (e.g. `export type A`).
-            //   TS1485: "resolves to a type-only declaration" — the imported
-            //           symbol is an alias that re-exports a type from
-            //           elsewhere via `export type { X } from "./mod"` or a
-            //           transitive chain.
+            // tsc's `checkAliasSymbol` decides *whether* a non-type-only import
+            // needs a type-only import, and *which* message, in two steps:
+            //   gate:  `isType || getTypeOnlyAliasDeclaration(symbol)` — the
+            //          alias is a pure type, or its resolution chain crossed an
+            //          explicit `import type`/`export type` boundary somewhere.
+            //   split: `isType ? TS1484 : TS1485`, where
+            //          `isType = !(getSymbolFlags(target) & Value)` on the
+            //          FULLY resolved target (following the whole re-export
+            //          chain), not on this module's immediate export symbol.
             //
-            // Both checks below hit `binder_symbol_is_type_only`, so we must
-            // disambiguate by looking at the exported symbol's flags:
-            // an ALIAS symbol routes to TS1485, otherwise TS1484.
-            let is_direct_type = self.is_import_specifier_type_only(module_name, &import_name)
-                && !self.is_import_specifier_alias_reexport(module_name, &import_name);
-            if is_direct_type {
-                let message = format_message(
-                    diagnostic_messages::IS_A_TYPE_AND_MUST_BE_IMPORTED_USING_A_TYPE_ONLY_IMPORT_WHEN_VERBATIMMODULESYNTA,
-                    &[&local_name],
-                );
-                self.error_at_node(
-                    local_name_idx,
-                    &message,
-                    diagnostic_codes::IS_A_TYPE_AND_MUST_BE_IMPORTED_USING_A_TYPE_ONLY_IMPORT_WHEN_VERBATIMMODULESYNTA,
-                );
-                continue;
-            }
-
-            // TS1485: alias-reexport / type-only export chain.
-            if self.is_export_type_only_across_binders(module_name, &import_name) {
-                let message = format_message(
-                    diagnostic_messages::RESOLVES_TO_A_TYPE_ONLY_DECLARATION_AND_MUST_BE_IMPORTED_USING_A_TYPE_ONLY_IMPOR,
-                    &[&local_name],
-                );
-                self.error_at_node(
-                    local_name_idx,
-                    &message,
-                    diagnostic_codes::RESOLVES_TO_A_TYPE_ONLY_DECLARATION_AND_MUST_BE_IMPORTED_USING_A_TYPE_ONLY_IMPOR,
-                );
+            // The gate is preserved verbatim from before (`is_import_specifier_type_only`
+            // handles pure types, uninstantiated namespaces and single-hop
+            // type-only re-exports; `is_export_type_only_across_binders` handles
+            // transitive type-only chains). Only the message split changed: the
+            // old code keyed TS1485 off "the immediate export is a re-export
+            // alias" (`is_import_specifier_alias_reexport`), which mislabels a
+            // pure type reached through a plain re-export hop (`export { Foo }`)
+            // or across an `export type` boundary — tsc reports TS1484 there
+            // because the target carries no value, regardless of the boundary.
+            // TS1485 is reserved for a target that STILL carries a runtime value
+            // but was reached across an explicit type-only boundary. Following
+            // the full chain also fixes arbitrary-depth plain re-export hops,
+            // which the immediate-export check never saw (tsz-org/tsz#17098).
+            let needs_type_only_import = self
+                .is_import_specifier_type_only(module_name, &import_name)
+                || self.is_export_type_only_across_binders(module_name, &import_name);
+            if needs_type_only_import {
+                let (_, target_has_value) =
+                    self.lookup_imported_target_flags(module_name, &import_name);
+                // `target_has_value` first so the pure-type case (the common
+                // TS1484 path) short-circuits before the extra chain-walk in
+                // `is_export_type_only_syntax_across_binders`.
+                let is_value_across_type_only_boundary = target_has_value
+                    && self.is_export_type_only_syntax_across_binders(module_name, &import_name);
+                let (message_key, diag_code) = if is_value_across_type_only_boundary {
+                    (
+                        diagnostic_messages::RESOLVES_TO_A_TYPE_ONLY_DECLARATION_AND_MUST_BE_IMPORTED_USING_A_TYPE_ONLY_IMPOR,
+                        diagnostic_codes::RESOLVES_TO_A_TYPE_ONLY_DECLARATION_AND_MUST_BE_IMPORTED_USING_A_TYPE_ONLY_IMPOR,
+                    )
+                } else {
+                    (
+                        diagnostic_messages::IS_A_TYPE_AND_MUST_BE_IMPORTED_USING_A_TYPE_ONLY_IMPORT_WHEN_VERBATIMMODULESYNTA,
+                        diagnostic_codes::IS_A_TYPE_AND_MUST_BE_IMPORTED_USING_A_TYPE_ONLY_IMPORT_WHEN_VERBATIMMODULESYNTA,
+                    )
+                };
+                let message = format_message(message_key, &[&local_name]);
+                self.error_at_node(local_name_idx, &message, diag_code);
                 continue;
             }
 
@@ -329,50 +346,6 @@ impl<'a> CheckerState<'a> {
                 );
             }
         }
-    }
-
-    /// Check whether the exported symbol for `import_name` in `module_name`
-    /// is itself an ALIAS (e.g. `export type { X } from "./other"`) rather
-    /// than a direct type declaration.  Used to pick TS1485 over TS1484.
-    pub(crate) fn is_import_specifier_alias_reexport(
-        &self,
-        module_name: &str,
-        import_name: &str,
-    ) -> bool {
-        use tsz_binder::symbol_flags;
-
-        let normalized = module_name.trim_matches('"').trim_matches('\'');
-        let target_idx = self
-            .ctx
-            .resolve_import_target_from_file(self.ctx.current_file_idx, normalized)
-            .or_else(|| self.ctx.resolve_import_target(normalized));
-        let Some(target_idx) = target_idx else {
-            return false;
-        };
-        let Some(target_binder) = self.ctx.get_binder_for_file(target_idx) else {
-            return false;
-        };
-        let target_arena = self.ctx.get_arena_for_file(target_idx as u32);
-        let Some(target_file_name) = target_arena
-            .source_files
-            .first()
-            .map(|f| f.file_name.clone())
-        else {
-            return false;
-        };
-        let Some(exports) = self
-            .ctx
-            .module_exports_for_module(target_binder, &target_file_name)
-        else {
-            return false;
-        };
-        let Some(sym_id) = exports.get(import_name) else {
-            return false;
-        };
-        let Some(sym) = target_binder.get_symbol(sym_id) else {
-            return false;
-        };
-        sym.has_any_flags(symbol_flags::ALIAS)
     }
 
     /// Check if a named import refers to a purely type-only entity.

--- a/crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs
+++ b/crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs
@@ -95,7 +95,18 @@ impl<'a> CheckerState<'a> {
                 )
             };
             self.error_at_node(anchor, message, code);
-            return;
+            // `module: "preserve"` + `isolatedModules` (TS1293) reports only the
+            // CJS syntax error. Under verbatimModuleSyntax, tsc still reports the
+            // per-specifier re-export type diagnostics (TS1205/TS1448) at their
+            // own anchors *alongside* the ESM-in-CJS syntax error — the same
+            // double-report the import side does (oracle-verified: a plain
+            // re-export of a type in a CommonJS file reports both TS1295 and
+            // TS1205 at the same position). Fall through to the per-specifier
+            // loop so the commonjs slice matches the ESM slice
+            // (tsz-org/tsz#17098).
+            if preserve_isolated {
+                return;
+            }
         }
 
         let module_specifier_text = if module_specifier_idx.is_some() {

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -1071,6 +1071,8 @@ mod verbatim_module_syntax_export_default_type_only_import_ts1284_tests;
 mod verbatim_module_syntax_export_default_type_only_reexport_ts1290_tests;
 #[path = "tests/verbatim_module_syntax_export_equals_ts1291_tests.rs"]
 mod verbatim_module_syntax_export_equals_ts1291_tests;
+#[path = "tests/verbatim_module_syntax_reexport_chain_ts1484_ts1485_tests.rs"]
+mod verbatim_module_syntax_reexport_chain_ts1484_ts1485_tests;
 #[path = "tests/void_undefined_discriminant_narrowing_tests.rs"]
 mod void_undefined_discriminant_narrowing_tests;
 #[path = "tests/well_known_symbol_alias_member_tests.rs"]

--- a/crates/tsz-checker/src/tests/verbatim_module_syntax_export_equals_ts1291_tests.rs
+++ b/crates/tsz-checker/src/tests/verbatim_module_syntax_export_equals_ts1291_tests.rs
@@ -378,15 +378,15 @@ fn import_alias_through_plain_reexport_to_class_reports_neither() {
 /// the multi-hop case silently read `(has_type: false, has_value: false)`
 /// and neither the TS1291 nor the TS1289 condition ever fired. tsz-org/tsz#17098.
 ///
-/// Filters to the TS1282/1283/1289/1291 family this fix owns rather than
-/// asserting the full diagnostic set: tsc additionally reports TS1484 here
-/// (`'Foo' is a type...`, oracle-verified), but tsz's independent TS1484-vs-
-/// TS1485 picker in `check_verbatim_module_syntax_imports`
-/// (`is_import_specifier_alias_reexport`) still emits TS1485 instead for a
-/// type reached through a plain re-export hop — a separate, pre-existing
-/// gap this PR does not touch.
+/// tsc additionally reports TS1484 on the import statement itself here
+/// (`'Foo' is a type...`, oracle-verified against `typescript@7.0.2`): the
+/// TS1484-vs-TS1485 picker in `check_verbatim_module_syntax_imports` follows
+/// the full re-export chain to the pure-type target (no runtime value), so a
+/// type reached through a plain re-export hop is TS1484 — not TS1485, which
+/// is reserved for a *value* target reached across an explicit type-only
+/// boundary. tsz-org/tsz#17098.
 #[test]
-fn import_alias_through_plain_reexport_to_interface_reports_1282_and_1291_verbatim() {
+fn import_alias_through_plain_reexport_to_interface_reports_1282_1291_and_1484_verbatim() {
     let diagnostics = check(
         &[
             ("/impl.ts", "export interface Foo { x: number }\n"),
@@ -401,24 +401,15 @@ fn import_alias_through_plain_reexport_to_interface_reports_1282_and_1291_verbat
         false,
     );
 
-    let export_assignment_codes: Vec<u32> = diagnostics
-        .iter()
-        .map(|d| d.code)
-        .filter(|code| {
-            [
-                EXPORT_EQUALS_MUST_REFERENCE_A_VALUE,
-                EXPORT_EQUALS_MUST_REFERENCE_A_REAL_VALUE,
-                RESOLVES_TO_A_TYPE,
-                RESOLVES_TO_A_TYPE_ONLY_DECLARATION,
-            ]
-            .contains(code)
-        })
-        .collect();
     assert_eq!(
-        export_assignment_codes,
-        vec![EXPORT_EQUALS_MUST_REFERENCE_A_VALUE, RESOLVES_TO_A_TYPE],
-        "expected TS1282 and TS1291 for an import alias resolving to a pure \
-         type through a plain (non-type-only) re-export hop under \
+        codes(&diagnostics),
+        vec![
+            EXPORT_EQUALS_MUST_REFERENCE_A_VALUE,
+            RESOLVES_TO_A_TYPE,
+            IMPORT_MUST_BE_TYPE_ONLY,
+        ],
+        "expected TS1282, TS1291 and TS1484 for an import alias resolving to a \
+         pure type through a plain (non-type-only) re-export hop under \
          verbatimModuleSyntax, got: {diagnostics:?}"
     );
 }

--- a/crates/tsz-checker/src/tests/verbatim_module_syntax_reexport_chain_ts1484_ts1485_tests.rs
+++ b/crates/tsz-checker/src/tests/verbatim_module_syntax_reexport_chain_ts1484_ts1485_tests.rs
@@ -1,0 +1,335 @@
+//! TS1484/TS1485 (type-only import) and the commonjs double-report for the
+//! `verbatimModuleSyntax` re-export-chain family — tsz-org/tsz#17098.
+//!
+//! Two distinct defects, one underlying question ("does alias resolution
+//! report the type-only boundary it crossed, when that boundary is in a third
+//! file?"):
+//!
+//!  1. **The TS1484-vs-TS1485 picker.** tsc's `checkAliasSymbol` splits on
+//!     `isType = !(getSymbolFlags(target) & Value)` over the FULLY resolved
+//!     target, following the whole re-export chain: a pure type (no runtime
+//!     value anywhere) is TS1484 *even when the chain crossed an explicit
+//!     `export type` boundary*; TS1485 is reserved for a target that still
+//!     carries a value but was reached across such a boundary. tsz previously
+//!     keyed the split off whether this module's *immediate* export was a
+//!     re-export alias (`is_import_specifier_alias_reexport`), which mislabels
+//!     a pure type reached through a plain re-export hop (`export { Foo }`) or
+//!     across an `export type` hop as TS1485.
+//!
+//!  2. **The commonjs early-return.** In a CommonJS file the ESM-in-CJS syntax
+//!     error (TS1295) short-circuited both the import check (skipping
+//!     TS1484/TS1485) and the named-export check (skipping TS1205). tsc reports
+//!     the type-only diagnostic at the same anchor *alongside* TS1295.
+//!
+//! Oracle-verified against pinned `typescript@7.0.2`. The picker rows use
+//! `module: preserve` (ESM-legal, so no CJS noise) and an import-only entry
+//! file so exactly the import diagnostic surfaces; the commonjs rows use
+//! `module: commonjs`.
+
+use crate::context::CheckerOptions;
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::{check_multi_file, check_multi_file_with_global_index};
+use tsz_common::common::ModuleKind;
+
+const RE_EXPORTING_A_TYPE: u32 = 1205;
+const ESM_IMPORTS_EXPORTS_IN_COMMONJS: u32 = 1295;
+const IMPORT_IS_A_TYPE: u32 = 1484;
+const IMPORT_RESOLVES_TO_TYPE_ONLY_DECLARATION: u32 = 1485;
+
+fn check(files: &[(&str, &str)], entry: &str, module: ModuleKind) -> Vec<Diagnostic> {
+    check_multi_file(
+        files,
+        entry,
+        CheckerOptions {
+            module,
+            strict: true,
+            verbatim_module_syntax: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn codes(diagnostics: &[Diagnostic]) -> Vec<u32> {
+    let mut codes: Vec<u32> = diagnostics.iter().map(|d| d.code).collect();
+    codes.sort_unstable();
+    codes
+}
+
+// Import-only entry: isolates the type-only-import diagnostic (no `export =`
+// noise) so each picker row asserts exactly one code.
+const IMPORT_ONLY_MAIN: &str = "import { Foo } from \"./reexport\";\nexport type Y = Foo;\n";
+
+// ===========================================================================
+// Picker: TS1484 vs TS1485 across the re-export chain (module: preserve)
+// ===========================================================================
+
+/// A pure interface reached through a *plain* (`export { Foo }`) re-export hop
+/// is TS1484 — the target carries no value. Previously mislabeled TS1485
+/// because the immediate export is a re-export alias.
+#[test]
+fn plain_reexport_of_interface_import_is_ts1484() {
+    let diagnostics = check(
+        &[
+            ("/impl.ts", "export interface Foo {}\n"),
+            ("/reexport.ts", "export { Foo } from \"./impl\";\n"),
+            ("/main.ts", IMPORT_ONLY_MAIN),
+        ],
+        "/main.ts",
+        ModuleKind::Preserve,
+    );
+    assert_eq!(
+        codes(&diagnostics),
+        vec![IMPORT_IS_A_TYPE],
+        "a pure type through a plain re-export hop must be TS1484, got: {diagnostics:?}"
+    );
+}
+
+/// A pure interface reached across an explicit `export type { Foo }` boundary
+/// is STILL TS1484: the split is on the target's value-ness, not on whether a
+/// type-only boundary was crossed. This is the row that proves the boundary
+/// alone does not force TS1485.
+#[test]
+fn export_type_reexport_of_interface_import_is_ts1484() {
+    let diagnostics = check(
+        &[
+            ("/impl.ts", "export interface Foo {}\n"),
+            ("/reexport.ts", "export type { Foo } from \"./impl\";\n"),
+            ("/main.ts", IMPORT_ONLY_MAIN),
+        ],
+        "/main.ts",
+        ModuleKind::Preserve,
+    );
+    assert_eq!(
+        codes(&diagnostics),
+        vec![IMPORT_IS_A_TYPE],
+        "a pure type across an `export type` boundary is still TS1484, got: {diagnostics:?}"
+    );
+}
+
+/// A class (a real value) reached across an explicit `export type { Foo }`
+/// boundary is TS1485 — the target keeps its value, so it "resolves to a
+/// type-only declaration" rather than "is a type".
+#[test]
+fn export_type_reexport_of_class_import_is_ts1485() {
+    let diagnostics = check(
+        &[
+            ("/impl.ts", "export class Foo {}\n"),
+            ("/reexport.ts", "export type { Foo } from \"./impl\";\n"),
+            ("/main.ts", IMPORT_ONLY_MAIN),
+        ],
+        "/main.ts",
+        ModuleKind::Preserve,
+    );
+    assert_eq!(
+        codes(&diagnostics),
+        vec![IMPORT_RESOLVES_TO_TYPE_ONLY_DECLARATION],
+        "a value across an `export type` boundary must be TS1485, got: {diagnostics:?}"
+    );
+}
+
+/// Control: a class reached through a *plain* re-export hop (no type-only
+/// boundary anywhere) is a legal value import — no TS1484/TS1485.
+#[test]
+fn plain_reexport_of_class_import_is_clean() {
+    let diagnostics = check(
+        &[
+            ("/impl.ts", "export class Foo {}\n"),
+            ("/reexport.ts", "export { Foo } from \"./impl\";\n"),
+            (
+                "/main.ts",
+                "import { Foo } from \"./reexport\";\nexport const x = new Foo();\n",
+            ),
+        ],
+        "/main.ts",
+        ModuleKind::Preserve,
+    );
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.code == IMPORT_IS_A_TYPE
+                || d.code == IMPORT_RESOLVES_TO_TYPE_ONLY_DECLARATION),
+        "a value through a plain re-export must not be flagged type-only, got: {diagnostics:?}"
+    );
+}
+
+/// The chain follow must not stop after one hop: a two-hop plain re-export of
+/// a pure interface is still TS1484.
+#[test]
+fn two_hop_plain_reexport_of_interface_import_is_ts1484() {
+    let diagnostics = check(
+        &[
+            ("/impl.ts", "export interface Foo {}\n"),
+            ("/mid.ts", "export { Foo } from \"./impl\";\n"),
+            ("/reexport.ts", "export { Foo } from \"./mid\";\n"),
+            ("/main.ts", IMPORT_ONLY_MAIN),
+        ],
+        "/main.ts",
+        ModuleKind::Preserve,
+    );
+    assert_eq!(
+        codes(&diagnostics),
+        vec![IMPORT_IS_A_TYPE],
+        "a pure type through two plain re-export hops must be TS1484, got: {diagnostics:?}"
+    );
+}
+
+/// Renamed on import (`Foo as Baz`) through a plain hop — the chain follow
+/// keys off the resolved target, not the local binding name — still TS1484.
+#[test]
+fn renamed_plain_reexport_of_interface_import_is_ts1484() {
+    let diagnostics = check(
+        &[
+            ("/impl.ts", "export interface Foo {}\n"),
+            ("/reexport.ts", "export { Foo } from \"./impl\";\n"),
+            (
+                "/main.ts",
+                "import { Foo as Baz } from \"./reexport\";\nexport type Y = Baz;\n",
+            ),
+        ],
+        "/main.ts",
+        ModuleKind::Preserve,
+    );
+    assert_eq!(
+        codes(&diagnostics),
+        vec![IMPORT_IS_A_TYPE],
+        "a renamed pure-type import through a plain hop must be TS1484, got: {diagnostics:?}"
+    );
+}
+
+/// Control (single-file boundary): a directly imported `export type` alias is
+/// a pure type — TS1484. Guards the picker's common single-hop path.
+#[test]
+fn direct_type_alias_import_is_ts1484() {
+    let diagnostics = check(
+        &[
+            ("/m.ts", "export type T = number;\n"),
+            (
+                "/main.ts",
+                "import { T } from \"./m\";\nexport type Y = T;\n",
+            ),
+        ],
+        "/main.ts",
+        ModuleKind::Preserve,
+    );
+    assert_eq!(
+        codes(&diagnostics),
+        vec![IMPORT_IS_A_TYPE],
+        "a direct `export type` alias import must be TS1484, got: {diagnostics:?}"
+    );
+}
+
+/// Regression guard: an uninstantiated (type-only) namespace import carries no
+/// runtime value, so it is TS1484 — even though `lookup_imported_target_flags`
+/// treats the module declaration as value-bearing, the absence of a crossed
+/// `export type` boundary keeps the split on TS1484. Uses the global-index
+/// harness (like the real driver) because the cross-file namespace-member
+/// resolution behind the type-only gate needs the declaring-file index.
+#[test]
+fn type_only_namespace_import_is_ts1484() {
+    let diagnostics = check_multi_file_with_global_index(
+        &[
+            ("/m.ts", "export namespace NS { export type X = number; }\n"),
+            (
+                "/main.ts",
+                "import { NS } from \"./m\";\nexport type Y = NS.X;\n",
+            ),
+        ],
+        "/main.ts",
+        CheckerOptions {
+            module: ModuleKind::Preserve,
+            strict: true,
+            verbatim_module_syntax: true,
+            ..CheckerOptions::default()
+        },
+    );
+    assert_eq!(
+        codes(&diagnostics),
+        vec![IMPORT_IS_A_TYPE],
+        "an uninstantiated namespace import must be TS1484, got: {diagnostics:?}"
+    );
+}
+
+// ===========================================================================
+// CommonJS double-report: TS1295 alongside the type-only diagnostic
+// ===========================================================================
+
+/// In a CommonJS file, a type-only named import reports BOTH the ESM-in-CJS
+/// syntax error (TS1295) and the type-only-import diagnostic (TS1484) at the
+/// same anchor — the early-return after TS1295 previously dropped the latter.
+#[test]
+fn commonjs_type_import_reports_ts1295_and_ts1484() {
+    let diagnostics = check(
+        &[
+            ("/impl.ts", "export interface Foo {}\n"),
+            ("/reexport.ts", "export { Foo } from \"./impl\";\n"),
+            ("/main.ts", IMPORT_ONLY_MAIN),
+        ],
+        "/main.ts",
+        ModuleKind::CommonJS,
+    );
+    let cs = codes(&diagnostics);
+    assert!(
+        cs.contains(&ESM_IMPORTS_EXPORTS_IN_COMMONJS) && cs.contains(&IMPORT_IS_A_TYPE),
+        "commonjs type import must report both TS1295 and TS1484, got: {diagnostics:?}"
+    );
+}
+
+/// The commonjs double-report keeps the picker's TS1485 branch too: a value
+/// reached across an `export type` boundary reports TS1295 + TS1485.
+#[test]
+fn commonjs_type_import_through_export_type_to_class_reports_ts1295_and_ts1485() {
+    let diagnostics = check(
+        &[
+            ("/impl.ts", "export class Foo {}\n"),
+            ("/reexport.ts", "export type { Foo } from \"./impl\";\n"),
+            ("/main.ts", IMPORT_ONLY_MAIN),
+        ],
+        "/main.ts",
+        ModuleKind::CommonJS,
+    );
+    let cs = codes(&diagnostics);
+    assert!(
+        cs.contains(&ESM_IMPORTS_EXPORTS_IN_COMMONJS)
+            && cs.contains(&IMPORT_RESOLVES_TO_TYPE_ONLY_DECLARATION),
+        "commonjs value-through-export-type import must report TS1295 and TS1485, got: {diagnostics:?}"
+    );
+}
+
+/// The export side mirrors it: a plain re-export of a type in a CommonJS file
+/// reports BOTH TS1205 (re-exporting a type) and TS1295 at the same anchor.
+#[test]
+fn commonjs_plain_reexport_of_type_reports_ts1205_and_ts1295() {
+    let diagnostics = check(
+        &[
+            ("/impl.ts", "export interface Foo {}\n"),
+            ("/reexport.ts", "export { Foo } from \"./impl\";\n"),
+        ],
+        "/reexport.ts",
+        ModuleKind::CommonJS,
+    );
+    let cs = codes(&diagnostics);
+    assert!(
+        cs.contains(&RE_EXPORTING_A_TYPE) && cs.contains(&ESM_IMPORTS_EXPORTS_IN_COMMONJS),
+        "commonjs plain re-export of a type must report both TS1205 and TS1295, got: {diagnostics:?}"
+    );
+}
+
+/// Control: an explicit `export type { Foo }` re-export in a CommonJS file is
+/// fully type-only (erased), so it reports neither TS1205 nor TS1295 — the
+/// fall-through must not manufacture a diagnostic where tsc stays silent.
+#[test]
+fn commonjs_export_type_reexport_is_clean() {
+    let diagnostics = check(
+        &[
+            ("/impl.ts", "export class Foo {}\n"),
+            ("/reexport.ts", "export type { Foo } from \"./impl\";\n"),
+        ],
+        "/reexport.ts",
+        ModuleKind::CommonJS,
+    );
+    let cs = codes(&diagnostics);
+    assert!(
+        !cs.contains(&RE_EXPORTING_A_TYPE) && !cs.contains(&ESM_IMPORTS_EXPORTS_IN_COMMONJS),
+        "an `export type` re-export in commonjs must stay clean, got: {diagnostics:?}"
+    );
+}

--- a/docs/how-tsz-works/internals/checker-declarations-modules.md
+++ b/docs/how-tsz-works/internals/checker-declarations-modules.md
@@ -406,11 +406,15 @@ Two files split these checks by direction:
 - **Imports** — `import/verbatim.rs` (`check_verbatim_module_syntax_imports`):
   TS1295 (ESM `import` syntax in a CJS+VMS file, anchored at the binding name),
   TS1484 ("X is a type and must be imported using a type-only import") for a
-  directly-typed import, and TS1485 ("X resolves to a type-only declaration")
-  for an alias/re-export chain. The TS1484-vs-TS1485 split keys on whether the
-  source export is a direct type declaration
-  (`is_import_specifier_type_only && !is_import_specifier_alias_reexport`) or an
-  alias.
+  target that carries no runtime value, and TS1485 ("X resolves to a type-only
+  declaration") for a target that keeps its value but was reached across an
+  explicit `import type`/`export type` boundary. Mirroring tsc's
+  `checkAliasSymbol`, the TS1484-vs-TS1485 split keys on the *fully resolved*
+  target's value-ness (`lookup_imported_target_flags`, which follows the whole
+  re-export chain) and whether that chain crossed a type-only boundary
+  (`is_export_type_only_syntax_across_binders`) — not on whether the immediate
+  export happens to be a re-export alias. In a CJS+VMS file these type-only
+  diagnostics fire *alongside* TS1295 at the same anchor, not instead of it.
 - **Exports** — `module_checker/verbatim_module_syntax.rs`
   (`check_verbatim_module_syntax_named_exports`): TS1205 ("Re-exporting a type
   when '{0}' is enabled requires using 'export type'") and TS1448 (the


### PR DESCRIPTION
The `verbatimModuleSyntax` type-only-import / re-export diagnostic family did
not traverse a re-export chain uniformly. This closes tsz-org/tsz#17098 on two
independent axes, both oracle-verified against pinned `typescript@7.0.2`.

## Structural rule

**TS1484 vs TS1485.** When a non-type-only named import resolves — through the
whole re-export chain — to a target with no runtime value, tsc reports TS1484
(`'X' is a type…`), *even when the chain crossed an explicit `export type`
boundary*; only a target that still carries a value but was reached across such
a boundary is TS1485 (`'X' resolves to a type-only declaration…`). tsc does
this in `checkAliasSymbol` via `isType = !(getSymbolFlags(target) & Value)`.
tsz instead keyed the split off whether *this module's immediate export* was a
re-export alias (`is_import_specifier_alias_reexport`), which mislabeled a pure
type reached through a plain `export { Foo }` hop, or across an `export type`
hop, as TS1485 — and never followed multi-hop plain chains at all.

**CommonJS double-report.** When a CommonJS file carries a type-only named
import or re-export, tsc reports the type-only diagnostic (TS1484/TS1485 on the
import, TS1205 on the re-export) at the same anchor *alongside* the ESM-in-CJS
syntax error TS1295. tsz emitted TS1295 and `return`ed, dropping the type-only
diagnostic entirely.

## What changed (owner layer: checker)

- `check_verbatim_module_syntax_imports` (`declarations/import/verbatim.rs`):
  the type-only gate is unchanged; only the message split now keys on the
  fully-resolved target's value-ness (`lookup_imported_target_flags`, which
  follows the chain via `follow_reexport_alias_chain` — the same helper the
  sibling `export =` TS1282/TS1291 picker already uses) and the crossed
  boundary (`is_export_type_only_syntax_across_binders`). Removes the now-unused
  `is_import_specifier_alias_reexport`.
- The CommonJS early-`return` in both the import check and the named-export
  check (`declarations/module_checker/verbatim_module_syntax.rs`) now falls
  through to the per-specifier loop under `verbatimModuleSyntax`; the
  `module: preserve` + `isolatedModules` path still returns, since
  TS1484/TS1485/TS1205-via-VMS are verbatimModuleSyntax-exclusive there.

## Adjacent-case matrix (all oracle-matched: commonjs, esnext, preserve)

| chain | target | tsc import code | before | after |
| --- | --- | --- | --- | --- |
| plain `export { Foo }` | interface | TS1484 | TS1485 | TS1484 |
| `export type { Foo }` | interface | TS1484 | TS1485 | TS1484 |
| `export type { Foo }` | class | TS1485 | TS1485 | TS1485 |
| plain `export { Foo }` | class | clean | clean | clean |
| two-hop plain | interface | TS1484 | (none) | TS1484 |
| direct `export type T` | type alias | TS1484 | TS1484 | TS1484 |
| uninstantiated namespace | — | TS1484 | TS1484 | TS1484 |

CommonJS rows additionally gain the TS1295-alongside-TS1484/TS1485 (import) and
TS1205-alongside-TS1295 (export) double-report. Renamed (`Foo as Baz`) binders
covered; `export type` re-export in CJS stays clean (negative control).

Known out-of-scope, pre-existing and untouched: for a multi-specifier import in
a CJS file tsc anchors one TS1295 per specifier while tsz anchors one at the
clause — unrelated to this family.

## Goal
Goal: hold

## Verification
- Oracle diff vs `typescript@7.0.2` on the #17098 repro across `--module
  {commonjs,esnext,preserve}`: all rows match exactly (was 4 diverging codes).
- New unit module `verbatim_module_syntax_reexport_chain_ts1484_ts1485_tests`
  (13 cases: picker rows + commonjs double-report + controls).
- `cargo nextest run -p tsz-checker --lib`: 11039 passed, 0 failed (full lib
  suite — no regressions from the picker change).
- `cargo clippy --profile ci-lint -p tsz-checker --lib --tests -- -D warnings`
  clean; `python3 scripts/arch/arch_guard.py` passes. Pre-commit and pre-push
  hooks (clippy + arch guard) green.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01XKknfJBhudBYaBYzscDexu