### PR TITLE
refactor(checker): fold the annotation source-text guard into one predicate

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -157,16 +157,10 @@ impl<'a> CheckerState<'a> {
             if let Some(param) = decl_arena.get_parameter(decl)
                 && param.type_annotation.is_some()
             {
-                if self.annotation_names_type_query_alias(decl_arena, param.type_annotation)
-                    || Self::annotation_is_keyof_over_degenerate_operand(
-                        decl_arena,
-                        param.type_annotation,
-                    )
-                    || Self::annotation_is_canonicalized_structural_type(
-                        decl_arena,
-                        param.type_annotation,
-                    )
-                {
+                if self.annotation_display_must_use_structural_formatter(
+                    decl_arena,
+                    param.type_annotation,
+                ) {
                     return None;
                 }
                 let mut text =
@@ -191,16 +185,10 @@ impl<'a> CheckerState<'a> {
             if let Some(var_decl) = decl_arena.get_variable_declaration(decl)
                 && var_decl.type_annotation.is_some()
             {
-                if self.annotation_names_type_query_alias(decl_arena, var_decl.type_annotation)
-                    || Self::annotation_is_keyof_over_degenerate_operand(
-                        decl_arena,
-                        var_decl.type_annotation,
-                    )
-                    || Self::annotation_is_canonicalized_structural_type(
-                        decl_arena,
-                        var_decl.type_annotation,
-                    )
-                {
+                if self.annotation_display_must_use_structural_formatter(
+                    decl_arena,
+                    var_decl.type_annotation,
+                ) {
                     return None;
                 }
                 return node_text_in_arena(decl_arena, var_decl.type_annotation).and_then(|text| {
@@ -213,16 +201,10 @@ impl<'a> CheckerState<'a> {
             if let Some(prop_decl) = decl_arena.get_property_decl(decl)
                 && prop_decl.type_annotation.is_some()
             {
-                if self.annotation_names_type_query_alias(decl_arena, prop_decl.type_annotation)
-                    || Self::annotation_is_keyof_over_degenerate_operand(
-                        decl_arena,
-                        prop_decl.type_annotation,
-                    )
-                    || Self::annotation_is_canonicalized_structural_type(
-                        decl_arena,
-                        prop_decl.type_annotation,
-                    )
-                {
+                if self.annotation_display_must_use_structural_formatter(
+                    decl_arena,
+                    prop_decl.type_annotation,
+                ) {
                     return None;
                 }
                 return node_text_in_arena(decl_arena, prop_decl.type_annotation).and_then(
@@ -303,15 +285,8 @@ impl<'a> CheckerState<'a> {
         if let Some(param) = decl_arena.get_parameter(decl)
             && param.type_annotation.is_some()
         {
-            if self.annotation_names_type_query_alias(decl_arena, param.type_annotation)
-                || Self::annotation_is_keyof_over_degenerate_operand(
-                    decl_arena,
-                    param.type_annotation,
-                )
-                || Self::annotation_is_canonicalized_structural_type(
-                    decl_arena,
-                    param.type_annotation,
-                )
+            if self
+                .annotation_display_must_use_structural_formatter(decl_arena, param.type_annotation)
             {
                 return None;
             }
@@ -323,16 +298,10 @@ impl<'a> CheckerState<'a> {
         if let Some(var_decl) = decl_arena.get_variable_declaration(decl)
             && var_decl.type_annotation.is_some()
         {
-            if self.annotation_names_type_query_alias(decl_arena, var_decl.type_annotation)
-                || Self::annotation_is_keyof_over_degenerate_operand(
-                    decl_arena,
-                    var_decl.type_annotation,
-                )
-                || Self::annotation_is_canonicalized_structural_type(
-                    decl_arena,
-                    var_decl.type_annotation,
-                )
-            {
+            if self.annotation_display_must_use_structural_formatter(
+                decl_arena,
+                var_decl.type_annotation,
+            ) {
                 return None;
             }
             return node_text_in_arena(decl_arena, var_decl.type_annotation).and_then(|text| {

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/type_query_alias.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/type_query_alias.rs
@@ -250,6 +250,23 @@ impl<'a> CheckerState<'a> {
         false
     }
 
+    /// Whether a declared type annotation is one whose written form `tsc` never
+    /// preserves in diagnostics, so the declared-annotation source-text fallback
+    /// must return `None` and let the caller render the canonical structural
+    /// form instead. Combines the three carve-outs — a `typeof`-alias reference,
+    /// a `keyof` over a degenerate `any`/`unknown`/`never` operand, and an
+    /// inline structural tuple / function / constructor type — into one gate so
+    /// the several echo sites cannot drift when a future carve-out is added.
+    pub(in crate::error_reporter) fn annotation_display_must_use_structural_formatter(
+        &self,
+        arena: &tsz_parser::NodeArena,
+        annotation_idx: NodeIndex,
+    ) -> bool {
+        self.annotation_names_type_query_alias(arena, annotation_idx)
+            || Self::annotation_is_keyof_over_degenerate_operand(arena, annotation_idx)
+            || Self::annotation_is_canonicalized_structural_type(arena, annotation_idx)
+    }
+
     pub(in crate::error_reporter) fn annotation_names_type_query_alias(
         &self,
         arena: &tsz_parser::NodeArena,


### PR DESCRIPTION
Follow-up cleanup to #17112 (merged). Behavior-preserving.

The three "`tsc` renders this annotation canonically, so drop the source-text
echo" carve-outs — a `typeof`-alias reference, a `keyof` over a degenerate
`any`/`unknown`/`never` operand, and an inline structural tuple / function /
constructor type — were invoked as an identical three-way `||` chain at **five**
declared-annotation echo sites in
`error_reporter::core::diagnostic_source`. That is exactly the drift risk worth
removing: a future fourth carve-out (or a fix to one predicate) could be added
to four sites and forgotten in the fifth, silently leaking source text for one
declaration kind.

This consolidates the three into a single
`annotation_display_must_use_structural_formatter` predicate, called once per
site. Net −14 lines; no behavior change (same disjunction, same inputs).

## Goal
Goal: hold

## Verification
- Pre-commit hook on the exact head: **Clippy passed**, **Architecture guard
  passed** (`-p tsz-checker`).
- Pure extraction of an existing boolean disjunction — no diagnostic behavior
  change; the tuple/function annotation display tests added in #17112 continue
  to cover the guarded behavior.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ae6MCzHfpwWVWEmo4wEe8q)_