### PR TITLE
fix(checker): plain re-export chain of a type reports TS1205 at every hop, not TS1448

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -215,6 +215,9 @@ path = "tests/contextual_alias_union_return_inference_tests.rs"
 name = "type_only_import_reexport_tests"
 path = "tests/type_only_import_reexport_tests.rs"
 [[test]]
+name = "ts1205_reexport_chain_code_tests"
+path = "tests/ts1205_reexport_chain_code_tests.rs"
+[[test]]
 name = "variadic_tuple_spread_arity_ts2556_tests"
 path = "tests/variadic_tuple_spread_arity_ts2556_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs
+++ b/crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs
@@ -164,17 +164,30 @@ impl<'a> CheckerState<'a> {
             };
 
             if is_type_only_chain {
-                if option_name == "verbatimModuleSyntax" {
-                    let message = format_message(
-                        diagnostic_messages::RE_EXPORTING_A_TYPE_WHEN_IS_ENABLED_REQUIRES_USING_EXPORT_TYPE,
-                        &[option_name],
-                    );
-                    self.error_at_node(
-                        source_name_idx,
-                        &message,
-                        diagnostic_codes::RE_EXPORTING_A_TYPE_WHEN_IS_ENABLED_REQUIRES_USING_EXPORT_TYPE,
-                    );
-                } else {
+                // tsc (`checkAliasSymbol`) selects the code for a plain
+                // (non-type-only) re-export specifier purely on `isType` —
+                // whether the alias, resolved through the FULL re-export chain,
+                // lands on a declaration carrying no runtime value:
+                //   message = isType ? TS1205 : TS1448.
+                // A plain re-export whose chain ends at a pure type
+                // (interface / type alias) is TS1205 at EVERY hop, no matter how
+                // many re-export hops sit between this specifier and the
+                // original declaration; the `is_inherent_type` fast path above
+                // only catches the first hop, where the target is the
+                // declaration itself, so the deeper hops arrive here. TS1448
+                // ("resolves to a type-only declaration") is reserved for a
+                // target that DOES carry a runtime value but was marked
+                // type-only (`import type` / `export type`) somewhere in the
+                // chain. The flag name (`isolatedModules` /
+                // `verbatimModuleSyntax`) is interpolated identically in both
+                // messages, so the choice is `isType`-driven for both options,
+                // not option-driven.
+                let resolved_has_runtime_value = self.reexport_chain_target_has_runtime_value(
+                    module_specifier_text.as_deref(),
+                    &source_name,
+                );
+
+                if resolved_has_runtime_value {
                     let export_name = self
                         .get_identifier_text_from_idx(specifier.name)
                         .unwrap_or_else(|| source_name.clone());
@@ -186,6 +199,16 @@ impl<'a> CheckerState<'a> {
                         source_name_idx,
                         &message,
                         diagnostic_codes::RESOLVES_TO_A_TYPE_ONLY_DECLARATION_AND_MUST_BE_RE_EXPORTED_USING_A_TYPE_ONLY_RE,
+                    );
+                } else {
+                    let message = format_message(
+                        diagnostic_messages::RE_EXPORTING_A_TYPE_WHEN_IS_ENABLED_REQUIRES_USING_EXPORT_TYPE,
+                        &[option_name],
+                    );
+                    self.error_at_node(
+                        source_name_idx,
+                        &message,
+                        diagnostic_codes::RE_EXPORTING_A_TYPE_WHEN_IS_ENABLED_REQUIRES_USING_EXPORT_TYPE,
                     );
                 }
                 continue;
@@ -311,6 +334,44 @@ impl<'a> CheckerState<'a> {
                 return self.is_export_type_only_syntax_across_binders(module_spec, import_name);
             }
         }
+        false
+    }
+
+    /// Whether the fully-resolved target of a re-exported name carries a
+    /// runtime value, following the re-export / import alias chain to the
+    /// ultimate declaration.
+    ///
+    /// This mirrors tsc's `!isType` (`resolveAlias(symbol).flags &
+    /// SymbolFlags.Value`), the discriminator between TS1205 (re-exporting a
+    /// pure type) and TS1448 (re-exporting a value that was marked type-only
+    /// somewhere in the chain). `module_specifier` is `Some` for
+    /// `export { X } from "..."` and `None` for a bare `export { X }` whose
+    /// `X` is a local alias binding (the only local shape that reaches the
+    /// type-only-chain branch — a bare local type declaration is handled by the
+    /// inherent-type fast path).
+    pub(super) fn reexport_chain_target_has_runtime_value(
+        &self,
+        module_specifier: Option<&str>,
+        name: &str,
+    ) -> bool {
+        use tsz_binder::symbol_flags;
+
+        if let Some(module_spec) = module_specifier {
+            let (_has_type, has_value) = self.lookup_imported_target_flags(module_spec, name);
+            return has_value;
+        }
+
+        if let Some(sym_id) = self.ctx.binder.file_locals.get(name)
+            && let Some(sym) = self.ctx.binder.get_symbol(sym_id)
+            && sym.has_any_flags(symbol_flags::ALIAS)
+            && let Some(module_spec) = sym.import_module()
+        {
+            let import_name = sym.import_name().unwrap_or(name);
+            let (_has_type, has_value) =
+                self.lookup_imported_target_flags(module_spec, import_name);
+            return has_value;
+        }
+
         false
     }
 

--- a/crates/tsz-checker/tests/ts1205_reexport_chain_code_tests.rs
+++ b/crates/tsz-checker/tests/ts1205_reexport_chain_code_tests.rs
@@ -1,0 +1,226 @@
+//! TS1205 vs TS1448 code selection for plain (non-type-only) re-export chains
+//! under `isolatedModules` / `verbatimModuleSyntax`.
+//!
+//! Structural rule (tsc `checkAliasSymbol`): for a plain `export { X } from
+//! "..."` specifier, tsc picks the diagnostic code purely on `isType` —
+//! whether the alias, resolved through the FULL re-export chain, lands on a
+//! declaration carrying no runtime value:
+//!
+//!   message = isType ? TS1205 : TS1448
+//!
+//! A plain re-export whose chain ends at a pure type (interface / type alias)
+//! is **TS1205 at every hop**, no matter how many re-export hops sit between
+//! the specifier and the original declaration. TS1448 ("resolves to a
+//! type-only declaration") is reserved for a target that DOES carry a runtime
+//! value but was marked type-only (`import type` / `export type`) somewhere in
+//! the chain.
+//!
+//! Regression witness: #17101 — tsz reported TS1205 on the first hop but
+//! TS1448 on every hop after it, because the immediate-target fast path only
+//! catches the first hop (where the target is the declaration itself) and the
+//! deeper hops fell through to an unconditional-TS1448 branch.
+
+use std::sync::Arc;
+use tsz_binder::BinderState;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::module_resolution::build_module_resolution_maps;
+use tsz_checker::state::CheckerState;
+use tsz_common::common::ModuleKind;
+use tsz_parser::parser::ParserState;
+use tsz_solver::construction::TypeInterner;
+
+/// Compile a multi-file project checking `files[entry_idx]` as the entry file
+/// and return `(code, message, start)` for each diagnostic. `verbatim`
+/// selects `verbatimModuleSyntax`; otherwise `isolatedModules` is used.
+fn compile(files: &[(&str, &str)], entry_idx: usize, verbatim: bool) -> Vec<(u32, String, u32)> {
+    let mut arenas = Vec::with_capacity(files.len());
+    let mut binders = Vec::with_capacity(files.len());
+    let mut roots = Vec::with_capacity(files.len());
+    let file_names: Vec<String> = files.iter().map(|(name, _)| (*name).to_string()).collect();
+
+    for (name, source) in files {
+        let mut parser = ParserState::new((*name).to_string(), (*source).to_string());
+        let root = parser.parse_source_file();
+        let mut binder = BinderState::new();
+        binder.bind_source_file(parser.get_arena(), root);
+        arenas.push(Arc::new(parser.get_arena().clone()));
+        binders.push(Arc::new(binder));
+        roots.push(root);
+    }
+
+    let (resolved_module_paths, resolved_modules) = build_module_resolution_maps(&file_names);
+
+    let all_arenas = Arc::new(arenas);
+    let all_binders = Arc::new(binders);
+    let types = TypeInterner::new();
+    let options = CheckerOptions {
+        module: ModuleKind::CommonJS,
+        isolated_modules: !verbatim,
+        verbatim_module_syntax: verbatim,
+        ..CheckerOptions::default()
+    };
+
+    let mut checker = CheckerState::new(
+        all_arenas[entry_idx].as_ref(),
+        all_binders[entry_idx].as_ref(),
+        &types,
+        file_names[entry_idx].clone(),
+        options,
+    );
+
+    checker.ctx.set_all_arenas(Arc::clone(&all_arenas));
+    checker.ctx.set_all_binders(Arc::clone(&all_binders));
+    checker.ctx.set_current_file_idx(entry_idx);
+    checker.ctx.set_lib_contexts(Vec::new());
+    checker
+        .ctx
+        .set_resolved_module_paths(Arc::new(resolved_module_paths));
+    checker.ctx.set_resolved_modules(resolved_modules);
+
+    checker.check_source_file(roots[entry_idx]);
+
+    checker
+        .ctx
+        .diagnostics
+        .iter()
+        .map(|d| (d.code, d.message_text.clone(), d.start))
+        .collect()
+}
+
+fn codes(diags: &[(u32, String, u32)]) -> Vec<u32> {
+    diags.iter().map(|(c, _, _)| *c).collect()
+}
+
+/// The three-hop chain from #17101: every hop is a plain re-export of a pure
+/// interface. tsc reports TS1205 at every hop; the deep hops must not be
+/// TS1448.
+fn interface_chain() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("/impl.ts", "export interface Foo {}\n"),
+        ("/a.ts", "export { Foo } from \"./impl\";\n"),
+        ("/b.ts", "export { Foo } from \"./a\";\n"),
+        ("/reexport.ts", "export { Foo } from \"./b\";\n"),
+    ]
+}
+
+#[test]
+fn hop1_plain_reexport_of_interface_is_ts1205() {
+    let diags = compile(&interface_chain(), 1, false);
+    assert!(
+        codes(&diags).contains(&1205),
+        "hop 1 (a.ts) should report TS1205; got {diags:?}"
+    );
+    assert!(
+        !codes(&diags).contains(&1448),
+        "hop 1 (a.ts) must not report TS1448; got {diags:?}"
+    );
+}
+
+#[test]
+fn hop2_plain_reexport_of_interface_is_ts1205_not_ts1448() {
+    let diags = compile(&interface_chain(), 2, false);
+    assert!(
+        codes(&diags).contains(&1205),
+        "hop 2 (b.ts) should report TS1205; got {diags:?}"
+    );
+    assert!(
+        !codes(&diags).contains(&1448),
+        "hop 2 (b.ts) must not report TS1448 — the chain has no `export type`; got {diags:?}"
+    );
+}
+
+#[test]
+fn hop3_plain_reexport_of_interface_is_ts1205_not_ts1448() {
+    let diags = compile(&interface_chain(), 3, false);
+    assert!(
+        codes(&diags).contains(&1205),
+        "hop 3 (reexport.ts) should report TS1205; got {diags:?}"
+    );
+    assert!(
+        !codes(&diags).contains(&1448),
+        "hop 3 (reexport.ts) must not report TS1448; got {diags:?}"
+    );
+}
+
+/// Type-alias variant of the chain — same rule, different type-decl kind,
+/// to prove the fix is structural (not interface-specific).
+#[test]
+fn hop2_plain_reexport_of_type_alias_is_ts1205_not_ts1448() {
+    let files = vec![
+        ("/impl.ts", "export type Bar = number;\n"),
+        ("/a.ts", "export { Bar } from \"./impl\";\n"),
+        ("/b.ts", "export { Bar } from \"./a\";\n"),
+    ];
+    let diags = compile(&files, 2, false);
+    assert!(
+        codes(&diags).contains(&1205),
+        "hop 2 of a type-alias chain should report TS1205; got {diags:?}"
+    );
+    assert!(
+        !codes(&diags).contains(&1448),
+        "hop 2 of a type-alias chain must not report TS1448; got {diags:?}"
+    );
+}
+
+/// Renamed binders at each hop — the fix must not key on the name matching
+/// across hops.
+#[test]
+fn renamed_reexport_chain_is_ts1205_not_ts1448() {
+    let files = vec![
+        ("/impl.ts", "export interface Original {}\n"),
+        ("/a.ts", "export { Original as Mid } from \"./impl\";\n"),
+        ("/b.ts", "export { Mid as Outer } from \"./a\";\n"),
+    ];
+    let diags = compile(&files, 2, false);
+    assert!(
+        codes(&diags).contains(&1205),
+        "renamed hop-2 re-export should report TS1205; got {diags:?}"
+    );
+    assert!(
+        !codes(&diags).contains(&1448),
+        "renamed hop-2 re-export must not report TS1448; got {diags:?}"
+    );
+}
+
+/// Control: a plain re-export chain whose target is a runtime **value**
+/// (`class`) is clean at every hop — no TS1205 and no TS1448.
+#[test]
+fn value_target_reexport_chain_is_clean() {
+    let files = vec![
+        ("/impl.ts", "export class Foo {}\n"),
+        ("/a.ts", "export { Foo } from \"./impl\";\n"),
+        ("/b.ts", "export { Foo } from \"./a\";\n"),
+    ];
+    let diags = compile(&files, 2, false);
+    assert!(
+        !codes(&diags).contains(&1205) && !codes(&diags).contains(&1448),
+        "a value-target re-export chain must be clean; got {diags:?}"
+    );
+}
+
+/// TS1448 discriminator on a DEEP hop: the resolved target carries a runtime
+/// value (`class`), and the chain crosses an explicit `export type` at a hop
+/// *before* this specifier's immediate target. Because the immediate target
+/// here is a plain re-export alias (not itself `export type`), this reaches
+/// the same code-selection branch as the pure-type chain and must resolve to
+/// TS1448, proving the branch keys on the fully-resolved target's runtime
+/// value, not on the nearest hop.
+#[test]
+fn deep_value_target_crossing_export_type_is_ts1448() {
+    let files = vec![
+        ("/impl.ts", "export class Foo {}\n"),
+        ("/a.ts", "export type { Foo } from \"./impl\";\n"),
+        ("/b.ts", "export { Foo } from \"./a\";\n"),
+        ("/c.ts", "export { Foo } from \"./b\";\n"),
+    ];
+    let diags = compile(&files, 3, false);
+    assert!(
+        codes(&diags).contains(&1448),
+        "a value re-exported plainly two hops after crossing `export type` should be TS1448; \
+         got {diags:?}"
+    );
+    assert!(
+        !codes(&diags).contains(&1205),
+        "the deep value-crossing-export-type case must not be TS1205; got {diags:?}"
+    );
+}


### PR DESCRIPTION
When an `export { X } from "..."` specifier's alias resolves — through any number of *plain* (non-type-only) re-export hops — to a pure type (interface / type alias), and no `import type`/`export type` appears anywhere in the chain, tsc reports **TS1205** ("Re-exporting a type when '…' is enabled requires using 'export type'") at *every* hop. tsz reported TS1205 only at the first hop and **TS1448** ("resolves to a type-only declaration and must be re-exported using a type-only re-export") at every hop after it — same anchors, wrong code. Only reproduces at depth ≥ 2, so single-hop fixtures never surfaced it.

**Structural rule:** tsc's `checkAliasSymbol` selects the export-specifier code purely on `isType = !(resolveAlias(symbol).flags & SymbolFlags.Value)` — the *fully-resolved* alias target's runtime-value-ness — as `isType ? TS1205 : TS1448`, identically for `isolatedModules` and `verbatimModuleSyntax` (the flag name is only interpolated into the message). tsz's `is_inherent_type` fast path inspects only the **immediate** re-export target, which for a re-export-of-a-re-export is a plain alias, not the declaration; so hops after the first fell through to a branch that emitted TS1448 unconditionally under isolatedModules.

**Owner layer — checker.** In `check_verbatim_module_syntax_named_exports` (`crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs`) the type-only-chain branch now picks TS1205 vs TS1448 by whether the alias, resolved through the **full** re-export chain, lands on a declaration carrying a runtime value — via a new `reexport_chain_target_has_runtime_value` helper built on the existing `lookup_imported_target_flags` chain resolver (the same resolver that already makes `main.ts` TS1291 fire correctly on this repro). The `is_inherent_type` fast path is untouched, so the *whether-to-fire* gate is unchanged; only the code selection within the branch moves toward parity.

### Adjacent matrix (`isolatedModules`, `--module commonjs`)

| case | before | after / tsc |
| --- | --- | --- |
| 2-hop interface chain (hop 2) | TS1448 | **TS1205** |
| 3-hop interface chain (hops 2–3) | TS1448 ×2 | **TS1205 ×2** |
| type-alias chain (hop 2) | TS1448 | **TS1205** |
| renamed-binder chain (hop 2) | TS1448 | **TS1205** |
| value-target chain (`class`) | clean | clean |
| value target, 2 hops after crossing `export type` | — | **TS1448** (keys on resolved target, not nearest hop) |

**Out of scope / fallback:** the *first-hop* `export type { <value> }` re-exported plainly (`export type { C }` where `C` is a class, re-exported without `type`) still routes through the untouched `is_inherent_type` fast path and reports TS1205 where tsc reports TS1448. That is a distinct fast-path defect, not oracle-verified locally, and deliberately left alone to keep this change's blast radius on the `is_inherent_type` TS1205 emissions at zero. The deep variant of it *is* fixed and tested here, since it reaches the branch this PR changes.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts1205_reexport_chain_code_tests` — 7 pass (2/3-hop interface chains, type-alias chain, renamed chain, value-target clean control, deep value-crossing-`export type` → TS1448).
- No regressions in the isolatedModules/verbatim export family: `isolated_modules_export_default_tests` (8), `type_only_import_reexport_tests` (6), `ambient_module_augmentation_new_export_tests` (5), `wildcard_ambient_module_export_tests` (11), `export_equals_default_import_interop_ts1259_tests` (7) — all pass.
- `cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings` — clean.
- `cargo fmt -p tsz-checker -- --check` — clean.
- `python3 scripts/arch/arch_guard.py` — "Architecture guardrails passed."
- Conformance/emit/fourslash not run locally (TypeScript submodule not checked out); change is confined to the isolatedModules/verbatim export-specifier code-selection branch and is strictly parity-directed for it.

Closes #17101.

## Provenance
Machine: cloud
Assistant: claude-code
Model: Opus 4.8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01BN91xQNHCfG47sbbuZjT9x)_