### PR TITLE
fix(checker): class-decorator TS1238 gains the not-callable elaboration chain, including in ES mode

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -603,6 +603,9 @@ path = "tests/ts1278_ts1279_decorator_arity_elaboration_tests.rs"
 name = "ts1238_experimental_decorator_anchor_tests"
 path = "tests/ts1238_experimental_decorator_anchor_tests.rs"
 [[test]]
+name = "ts1238_class_decorator_not_callable_chain_tests"
+path = "tests/ts1238_class_decorator_not_callable_chain_tests.rs"
+[[test]]
 name = "ts2862_keyof_tparam_tests"
 path = "tests/ts2862_keyof_tparam_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/mod.rs
+++ b/crates/tsz-checker/src/error_reporter/mod.rs
@@ -46,7 +46,7 @@ mod literal_alias_rewrites;
 mod missing_property_declared_here;
 mod name_resolution;
 mod noinfer_diagnostic_display;
-mod operator_errors;
+pub(crate) mod operator_errors;
 mod primitive_intersection_display;
 mod properties;
 mod property_receiver_formatting;

--- a/crates/tsz-checker/src/state/state_checking/class_decorators.rs
+++ b/crates/tsz-checker/src/state/state_checking/class_decorators.rs
@@ -247,13 +247,11 @@ impl<'a> CheckerState<'a> {
 
         if !has_call_signatures {
             // No call signatures at all (e.g., a class used as decorator — has construct
-            // signatures but no call signatures). Emit TS1238.
+            // signatures but no call signatures, or a bare primitive). tsc attaches the
+            // "This expression is not callable." / "Type 'X' has no call signatures."
+            // chain beneath TS1238 (oracle-verified, typescript@7.0.2).
             let anchor = self.decorator_failure_anchor(decorator_node, resolved, 1);
-            self.error_at_node(
-                anchor,
-                diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
-                diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
-            );
+            self.emit_class_decorator_not_callable(anchor, resolved);
             return;
         }
 
@@ -336,6 +334,35 @@ impl<'a> CheckerState<'a> {
 
         let resolved = self.evaluate_type_for_assignability(decorator_type);
         if resolved == TypeId::ERROR || resolved == TypeId::ANY || resolved == TypeId::UNKNOWN {
+            return;
+        }
+
+        // Mirror tsc's `isUntypedFunctionCall`: a decorator typed as the
+        // global `Function` interface has no explicit call signatures but is
+        // still callable (see `check_class_decorator_call_signature`, whose
+        // legacy-mode counterpart of this same check applies the identical
+        // fallback).
+        let Some(resolved) = self.prepare_decorator_callee(resolved) else {
+            return;
+        };
+
+        // No call signature at all (bare primitive, a class used as a
+        // decorator, ...): tsc's TS1238 "not callable" chain fires
+        // identically here as it does under `--experimentalDecorators`
+        // (oracle-verified, typescript@7.0.2). Previously this whole
+        // function only inspected `function_shape`, so any decorator type
+        // without a single-signature function shape (a primitive, a class,
+        // an overloaded callable) silently passed arity validation with no
+        // diagnostic at all.
+        let has_call_signatures =
+            crate::query_boundaries::class_type::has_function_shape(self.ctx.types, resolved)
+                || crate::query_boundaries::common::call_signatures_for_type(
+                    self.ctx.types,
+                    resolved,
+                )
+                .is_some_and(|sigs| !sigs.is_empty());
+        if !has_call_signatures {
+            self.emit_class_decorator_not_callable(decorator_expression, resolved);
             return;
         }
 

--- a/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
@@ -90,6 +90,47 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// tsc's TS1238 "not callable" shape for a class decorator whose resolved
+    /// type carries no call signature at all — a bare primitive, a class
+    /// (construct signatures only, no call signatures), or any other
+    /// non-callable value. `This expression is not callable.` (TS2349) is
+    /// attached as an elaboration chain link beneath TS1238, with `Type 'X'
+    /// has no call signatures.` (TS2757) nested one level deeper. Oracle-
+    /// verified (`typescript@7.0.2`) to render identically under
+    /// `--experimentalDecorators` and ES (TC39 stage-3) class decorators;
+    /// shared by both call sites in `class_decorators.rs`. Chain-link
+    /// entries carry no real position (matching
+    /// [`Self::decorator_arity_related_info`]'s `(0, 0)` convention) since
+    /// `RelatedInformationKind::ChainLink` renders by depth, not location.
+    pub(crate) fn emit_class_decorator_not_callable(
+        &mut self,
+        anchor: NodeIndex,
+        resolved: TypeId,
+    ) {
+        let mut related = vec![Diagnostic::related_message(
+            diagnostic_codes::THIS_EXPRESSION_IS_NOT_CALLABLE,
+            self.ctx.file_name.clone(),
+            0,
+            0,
+            diagnostic_messages::THIS_EXPRESSION_IS_NOT_CALLABLE,
+        )];
+        if let Some(mut detail) = self.invocation_signature_detail(
+            resolved,
+            crate::error_reporter::operator_errors::InvocationSignatureKind::Call,
+            0,
+            0,
+        ) {
+            detail.depth = 1;
+            related.push(detail);
+        }
+        self.error_at_node_with_related(
+            anchor,
+            diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
+            diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
+            related,
+        );
+    }
+
     /// tsc anchors member/parameter decorator failures (TS1239/TS1240/TS1241)
     /// at the decorator's EXPRESSION (one column after the `@`) for
     /// type-mismatch and extra-argument failures, but at the whole DECORATOR

--- a/crates/tsz-checker/tests/ts1238_class_decorator_not_callable_chain_tests.rs
+++ b/crates/tsz-checker/tests/ts1238_class_decorator_not_callable_chain_tests.rs
@@ -1,0 +1,186 @@
+//! TS1238 "not callable" elaboration chain for class decorators.
+//!
+//! Structural rule (oracle-verified, `typescript@7.0.2`): when a class
+//! decorator's resolved type carries no call signature at all — a bare
+//! primitive, a class (construct signatures only), or any other
+//! non-callable value — tsc attaches a two-level elaboration chain beneath
+//! TS1238: `This expression is not callable.` (TS2349) with `Type 'X' has
+//! no call signatures.` (TS2757) nested one level beneath it. This chain is
+//! identical under `--experimentalDecorators` and ES (TC39 stage-3) class
+//! decorators.
+//!
+//! Before this fix:
+//! - `--experimentalDecorators`: `check_class_decorator_call_signature`'s
+//!   "no call signatures at all" branch emitted a bare TS1238 with no
+//!   elaboration.
+//! - ES mode: `check_es_class_decorator_arity` only ever inspected
+//!   `function_shape`, so a decorator type with no function shape at all
+//!   (a primitive, a class, an overloaded callable) silently passed
+//!   validation with **no diagnostic whatsoever** — not even a bare TS1238.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::{check_source_with_libs, load_default_lib_files};
+
+// Loaded with the default libs (matching `invocation_signature_detail_tests.rs`)
+// so a bare primitive source resolves to its boxed wrapper interface
+// (`Number`, `String`, ...) for display, the behavior a real compilation
+// observes and what tsc's own oracle output shows.
+fn check_legacy(source: &str) -> Vec<Diagnostic> {
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            experimental_decorators: true,
+            ..CheckerOptions::default()
+        },
+        &load_default_lib_files(),
+    )
+}
+
+fn check_es(source: &str) -> Vec<Diagnostic> {
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions::default(),
+        &load_default_lib_files(),
+    )
+}
+
+fn ts1238_chain_text(diagnostics: &[Diagnostic]) -> String {
+    let matching: Vec<_> = diagnostics.iter().filter(|d| d.code == 1238).collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected exactly one TS1238, got: {:?}",
+        diagnostics
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    let mut lines = vec![matching[0].message_text.clone()];
+    lines.extend(
+        matching[0]
+            .related_information
+            .iter()
+            .map(|info| info.message_text.clone()),
+    );
+    lines.join("\n")
+}
+
+fn assert_not_callable_chain(text: &str, type_str: &str) {
+    assert!(
+        text.contains("This expression is not callable."),
+        "missing 'not callable' chain link: {text:?}"
+    );
+    assert!(
+        text.contains(&format!("Type '{type_str}' has no call signatures.")),
+        "missing 'has no call signatures' chain link for {type_str:?}: {text:?}"
+    );
+}
+
+// ───────────────────────── --experimentalDecorators ────────────────────────
+
+#[test]
+fn legacy_primitive_decorator_gets_not_callable_chain() {
+    let text = ts1238_chain_text(&check_legacy("const d = 1; @d class C {}"));
+    assert_not_callable_chain(&text, "Number");
+}
+
+#[test]
+fn legacy_class_used_as_decorator_gets_not_callable_chain() {
+    let text = ts1238_chain_text(&check_legacy("class D {} @D class C {}"));
+    assert_not_callable_chain(&text, "typeof D");
+}
+
+#[test]
+fn legacy_string_literal_decorator_gets_not_callable_chain_renamed_binder() {
+    // Anti-hardcoding: a differently-named binder gets the same chain.
+    let text = ts1238_chain_text(&check_legacy(
+        "const notify = \"hi\"; @notify class Widget {}",
+    ));
+    assert_not_callable_chain(&text, "String");
+}
+
+// ─────────────────────────────── ES decorators ──────────────────────────────
+
+#[test]
+fn es_primitive_decorator_now_reports_ts1238_with_chain() {
+    // Previously dropped entirely: no function_shape means the old
+    // check_es_class_decorator_arity silently returned without a diagnostic.
+    let diagnostics = check_es("const d = 1; @d class C {}");
+    let text = ts1238_chain_text(&diagnostics);
+    assert_not_callable_chain(&text, "Number");
+}
+
+#[test]
+fn es_class_used_as_decorator_now_reports_ts1238_with_chain() {
+    let diagnostics = check_es("class D {} @D class C {}");
+    let text = ts1238_chain_text(&diagnostics);
+    assert_not_callable_chain(&text, "typeof D");
+}
+
+#[test]
+fn es_primitive_decorator_anchors_at_expression_not_at_sign() {
+    let source = "const d = 1; @d class C {}";
+    let diagnostics = check_es(source);
+    let expr_start = source.rfind('d').expect("decorator identifier present");
+    let at_sign = source.find('@').expect("@ present");
+    let ts1238 = diagnostics
+        .iter()
+        .find(|d| d.code == 1238)
+        .unwrap_or_else(|| panic!("expected TS1238, got: {diagnostics:?}"));
+    assert_eq!(
+        ts1238.start, expr_start as u32,
+        "expected anchor at the expression ({expr_start}), got {}",
+        ts1238.start
+    );
+    assert_ne!(ts1238.start, at_sign as u32, "must not anchor at `@`");
+}
+
+// ───────────────── controls: unaffected shapes stay unaffected ─────────────
+
+#[test]
+fn es_function_typed_decorator_is_not_flagged() {
+    // tsc's `isUntypedFunctionCall` fallback: a decorator declared as the
+    // global `Function` interface has no explicit call signatures but is
+    // still treated as callable. Regression guard for the
+    // `prepare_decorator_callee` gate added alongside the not-callable check.
+    let codes: Vec<u32> = check_es("declare const d: Function; @d class C {}")
+        .iter()
+        .map(|d| d.code)
+        .collect();
+    assert!(
+        !codes.contains(&1238),
+        "Function-typed decorator must not draw TS1238, got: {codes:?}"
+    );
+}
+
+#[test]
+fn es_too_many_params_decorator_keeps_bare_ts1238_no_not_callable_chain() {
+    // A genuinely callable decorator that just declares too many required
+    // parameters is a distinct failure kind (arity, not callability) and
+    // must not gain the not-callable chain.
+    let diagnostics = check_es(
+        "function d(a: string, b: string, c: string) { return undefined as any; } @d class C {}",
+    );
+    let text = ts1238_chain_text(&diagnostics);
+    assert!(
+        !text.contains("has no call signatures"),
+        "an arity-only failure must not draw the not-callable chain: {text:?}"
+    );
+}
+
+#[test]
+fn legacy_arity_failure_keeps_arity_elaboration_no_not_callable_chain() {
+    let diagnostics = check_legacy("function d(a: string, b: string, c: string) {} @d class C {}");
+    let text = ts1238_chain_text(&diagnostics);
+    assert!(
+        text.contains("the decorator expects"),
+        "expected the pre-existing arity elaboration to survive: {text:?}"
+    );
+    assert!(
+        !text.contains("has no call signatures"),
+        "an arity-only failure must not draw the not-callable chain: {text:?}"
+    );
+}

--- a/crates/tsz-checker/tests/ts1238_tests.rs
+++ b/crates/tsz-checker/tests/ts1238_tests.rs
@@ -136,13 +136,19 @@ class C {
 }
 
 #[test]
-fn ts1238_not_emitted_without_experimental_decorators() {
-    // Without experimentalDecorators, TS1238 should not be emitted.
+fn ts1238_emitted_without_experimental_decorators_for_class_used_as_decorator() {
+    // Oracle-verified (typescript@7.0.2): a class used as an ES (TC39
+    // stage-3) decorator has no call signatures either, so tsc emits the
+    // same TS1238 "not callable" shape it does under `experimentalDecorators`
+    // (see `ts1238_class_used_as_decorator_emits_error` above). Previously
+    // tsz's ES path only ever inspected `function_shape` and silently
+    // dropped the diagnostic entirely for any non-function-shaped decorator
+    // type.
     let codes =
         tsz_checker::test_utils::check_source_codes("class Decorate { }\n@Decorate\nclass C { }");
     assert!(
-        !codes.contains(&1238),
-        "Should not emit TS1238 without experimentalDecorators, got: {codes:?}"
+        codes.contains(&1238),
+        "Expected TS1238 when a class (no call signatures) is used as an ES decorator, got: {codes:?}"
     );
 }
 


### PR DESCRIPTION
Fixes half of #17108.

When a class decorator's resolved type carries no call signature at all — a bare primitive, a class (construct signatures only), or any other non-callable value — tsc attaches a two-level elaboration chain beneath TS1238: `This expression is not callable.` (TS2349) with `Type 'X' has no call signatures.` (TS2757) nested one level beneath it, identically under `--experimentalDecorators` and ES (TC39 stage-3) class decorators (oracle-verified, `typescript@7.0.2`).

**Structural rule:** when a class decorator's resolved type has `NotCallable` shape (no call signature at all), tsc attaches the `This expression is not callable.` / `Type 'X' has no call signatures.` chain beneath TS1238 in both decorator modes; tsz's `experimentalDecorators` path (`check_class_decorator_call_signature` in `crates/tsz-checker/src/state/state_checking/class_decorators.rs`) already detected the shape but emitted a bare TS1238, and its ES-mode counterpart (`check_es_class_decorator_arity`) never checked callability at all — it only ever inspected `function_shape`, so any decorator type without a single-signature function shape (a primitive, a class, an overloaded callable) silently passed validation with **no diagnostic whatsoever**.

Added a shared `emit_class_decorator_not_callable` helper (owner layer: checker, `crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs`) that builds the chain via the existing `invocation_signature_detail` reporter (`error_reporter/operator_errors.rs`, widened to `pub(crate)` for cross-module reuse), reused at both call sites in `class_decorators.rs`. The ES path also gained the `prepare_decorator_callee` "isUntypedFunctionCall" fallback the legacy path already had, so a `Function`-typed decorator still passes cleanly (regression-guarded by a new test).

### Adjacent matrix (`typescript@7.0.2`, oracle-verified)

| decorator type | mode | tsc / tsz (after) |
| --- | --- | --- |
| `number` literal binding | `--experimentalDecorators` | TS1238 + not-callable chain |
| `number` literal binding | ES (stage-3) | TS1238 + not-callable chain (was: **nothing**) |
| class used as decorator | `--experimentalDecorators` | TS1238 + not-callable chain |
| class used as decorator | ES (stage-3) | TS1238 + not-callable chain (was: **nothing**) |
| `string` literal binding (renamed) | `--experimentalDecorators` | TS1238 + not-callable chain |
| `Function`-typed decorator | ES (stage-3) | no error (regression guard) |
| too-many-required-params factory | ES (stage-3) | bare TS1238, unchanged (arity, not callability) |
| too-few-args factory | `--experimentalDecorators` | arity elaboration, unchanged |

**Scope / fallback:** this closes the `NotCallable` half of #17108. The other half — ES mode silently dropping an `ArgumentTypeMismatch` failure (e.g. `function d(a: string, b: string, ...r: string[]) {} @d class C {}` → tsc: `Argument of type 'typeof C' is not assignable to parameter of type 'string'.`) — needs real call resolution against a `ClassDecoratorContext` argument type that doesn't exist yet in tsz (no `resolve_decorator_context_type("ClassDecoratorContext", ...)` today). That's a larger, separate structural change; left open on #17108 for a follow-up session.

**Also found, not fixed here (noted on the board for the next session):** `function d() {} @d class C {}` in ES mode should report **TS1329** ("did you mean to call it first") per the oracle, but tsz's `check_es_class_decorator_arity` `shape.params.is_empty()` branch emits TS1238 instead — a pre-existing, unrelated bug (wrong diagnostic *code*, not a missing-elaboration issue).

## Goal
Goal: hold

## Verification
- New `crates/tsz-checker/tests/ts1238_class_decorator_not_callable_chain_tests.rs` (9 tests, oracle-verified against pinned `typescript@7.0.2`): primitive/class/renamed-binder not-callable chain under both decorator modes, ES anchor position, `Function`-typed control, arity-failure controls (no spurious chain). `cargo test -p tsz-checker --test ts1238_class_decorator_not_callable_chain_tests` → 9/9 pass.
- Corrected `ts1238_tests::ts1238_not_emitted_without_experimental_decorators` → renamed `ts1238_emitted_without_experimental_decorators_for_class_used_as_decorator`: its old assertion ("TS1238 should not be emitted without experimentalDecorators") was itself wrong per the oracle (tsc emits TS1238 for a class-used-as-decorator in ES mode too, same shape as the existing `ts1238_class_used_as_decorator_emits_error` legacy-mode test right above it in the same file).
- 0 regressions across all pre-existing decorator suites: `ts1238_tests` 14/14, `ts1238_generic_decorator_tests` 2/2, `ts1238_experimental_decorator_anchor_tests` 6/6, `ts1278_ts1279_decorator_arity_elaboration_tests` 8/8, `decorator_this_binding_tests` 16/16, `decorator_method_tdz_tests` 10/10, `es_member_decorator_arity_tests` 15/15, `issue_7681_super_decorator_tests` 7/7, `ts2449_parameter_decorator_no_tdz_tests` 2/2, `ts18036_class_decorator_static_private_identifier_tests` 10/10 — plus all 23 lib-level decorator tests (`cargo test -p tsz-checker --lib -- decorator`).
- `cargo clippy -p tsz-checker --lib -- -D warnings` clean; `cargo clippy -p tsz-checker --test ts1238_class_decorator_not_callable_chain_tests -- -D warnings` clean.
- `cargo fmt -p tsz-checker -- --check` clean.
- `python3 scripts/arch/arch_guard.py` → "Architecture guardrails passed."
- Only decorator-signature diagnostics can move (adds elaboration/a previously-missing TS1238; no other diagnostic code touched); the TypeScript corpus submodule was not checked out this session, so no full conformance/emit sweep was run — targeted suites above exercise every affected path.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_014rJdnxNiczfmGam7zVric1)_