### PR TITLE
fix(checker): wire TS1329 zero-arg-factory hint for class decorators

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -603,6 +603,9 @@ path = "tests/ts1278_ts1279_decorator_arity_elaboration_tests.rs"
 name = "ts1238_experimental_decorator_anchor_tests"
 path = "tests/ts1238_experimental_decorator_anchor_tests.rs"
 [[test]]
+name = "ts1329_class_decorator_zero_arg_factory_tests"
+path = "tests/ts1329_class_decorator_zero_arg_factory_tests.rs"
+[[test]]
 name = "ts2862_keyof_tparam_tests"
 path = "tests/ts2862_keyof_tparam_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking/class_decorators.rs
+++ b/crates/tsz-checker/src/state/state_checking/class_decorators.rs
@@ -238,6 +238,15 @@ impl<'a> CheckerState<'a> {
             return;
         };
 
+        // A decorator whose every call signature takes zero parameters is
+        // the "forgot to call the factory" shape (`@d` instead of `@d()`);
+        // tsc reports only the TS1329 hint there, not TS1238 — mirroring the
+        // member/parameter decorator paths in `decorator_signature_checks.rs`.
+        let decorator_expr = self.decorator_expression_anchor(decorator_node);
+        if self.decorator_has_zero_arg_factory_shape(decorator_expr, resolved, decorator_node) {
+            return;
+        }
+
         // Check if the decorator type is callable.
         // TypeData::Function has a single call signature (function declarations/expressions).
         // TypeData::Callable has overloaded call/construct signatures (interfaces).
@@ -313,12 +322,13 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    /// TS1238 for ES decorators: check that a class decorator doesn't require
-    /// more than 2 parameters.
+    /// TS1238/TS1329 for ES decorators: check that a class decorator's arity
+    /// is compatible with the runtime call.
     ///
-    /// ES decorators receive `(value, context)` — at most 2 arguments.
-    /// If the decorator function's call signature has more than 2 required
-    /// parameters, the call will fail. Emit TS1238.
+    /// ES decorators receive `(value, context)` — at most 2 arguments. A
+    /// zero-parameter decorator is the "forgot to call the factory" shape
+    /// (TS1329, see `decorator_has_zero_arg_factory_shape`); one requiring
+    /// more than 2 required parameters can never be satisfied (TS1238).
     pub(super) fn check_es_class_decorator_arity(
         &mut self,
         decorator_node: NodeIndex,
@@ -339,6 +349,15 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
+        // A decorator whose every call signature takes zero parameters is
+        // the "forgot to call the factory" shape (`@d` instead of `@d()`);
+        // tsc reports only the TS1329 hint there, not TS1238 — same rule as
+        // the legacy (`experimentalDecorators`) class-decorator path above.
+        if self.decorator_has_zero_arg_factory_shape(decorator_expression, resolved, decorator_node)
+        {
+            return;
+        }
+
         // Check the function shape for required parameter count
         if let Some(shape) =
             crate::query_boundaries::class_type::function_shape(self.ctx.types, resolved)
@@ -348,21 +367,12 @@ impl<'a> CheckerState<'a> {
                 .iter()
                 .filter(|p| !p.optional && !p.rest)
                 .count();
-            // ES decorators are invoked with `(value, context)`.
-            //
-            // * When the factory has no parameters at all, the runtime call
-            //   `f(value, context)` passes extra args; tsc anchors the error
-            //   at the decorator expression (excluding `@`).
-            // * When the factory requires more than two parameters, the call
-            //   cannot supply them; tsc anchors the error at the whole
-            //   decorator (including `@`).
-            if shape.params.is_empty() {
-                self.error_at_node(
-                    decorator_expression,
-                    diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
-                    diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
-                );
-            } else if required_params > 2 {
+            // ES decorators are invoked with `(value, context)`. When the
+            // factory requires more than two parameters, the call cannot
+            // supply them; tsc anchors the error at the whole decorator
+            // (including `@`). The zero-parameter case is handled above as
+            // the TS1329 decorator-factory hint, not this arity failure.
+            if required_params > 2 {
                 self.error_at_node(
                     decorator_node,
                     diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,

--- a/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
@@ -96,7 +96,7 @@ impl<'a> CheckerState<'a> {
     /// (spanning the `@`) when the failure is missing required arguments —
     /// mirroring call-expression arity anchoring (decoratorOnClassProperty6
     /// vs 7).
-    fn decorator_expression_anchor(&self, decorator_node: NodeIndex) -> NodeIndex {
+    pub(crate) fn decorator_expression_anchor(&self, decorator_node: NodeIndex) -> NodeIndex {
         self.ctx
             .arena
             .get(decorator_node)
@@ -482,8 +482,9 @@ impl<'a> CheckerState<'a> {
     /// hint ("did you mean to call it") instead of the generic
     /// method/property-decorator signature failure. This mirrors tsc's
     /// `isPotentiallyUncalledDecorator` for the common zero-parameter case and
-    /// applies uniformly to method, accessor, and field decorators.
-    fn decorator_has_zero_arg_factory_shape(
+    /// applies uniformly to method, accessor, field, and (see
+    /// `class_decorators.rs`) class decorators.
+    pub(crate) fn decorator_has_zero_arg_factory_shape(
         &mut self,
         decorator_expr: NodeIndex,
         decorator_type: TypeId,

--- a/crates/tsz-checker/tests/ts1329_class_decorator_zero_arg_factory_tests.rs
+++ b/crates/tsz-checker/tests/ts1329_class_decorator_zero_arg_factory_tests.rs
@@ -1,0 +1,129 @@
+//! TS1329 for class decorators (`isPotentiallyUncalledDecorator`).
+//!
+//! When every call signature of a class-decorator expression takes zero
+//! parameters, tsc reports only the "accepts too few arguments... did you
+//! mean to call it first" hint (TS1329), anchored at the whole decorator
+//! (`@`) — not the generic TS1238 signature-resolution failure. This holds
+//! uniformly for a bare zero-arg decorator (`@d`) and a zero-arg factory
+//! call (`@d()`) whose result also takes zero parameters, and in both
+//! `experimentalDecorators` (legacy) and ES (TC39 stage-3) decorator mode.
+//!
+//! tsz previously had this check wired for method/accessor/field/parameter
+//! decorators (`decorator_has_zero_arg_factory_shape` in
+//! `decorator_signature_checks.rs`) but not for class decorators, which fell
+//! through to the generic TS1238 arity-mismatch path in both modes instead.
+//! Oracle-verified against pinned `typescript@7.0.2`.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+
+fn legacy_codes(source: &str) -> Vec<u32> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            experimental_decorators: true,
+            ..CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+fn es_codes(source: &str) -> Vec<u32> {
+    check_source(source, "test.ts", CheckerOptions::default())
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+// =========================================================================
+// Legacy (`experimentalDecorators`) class decorators
+// =========================================================================
+
+#[test]
+fn legacy_bare_zero_arg_class_decorator_emits_ts1329_not_ts1238() {
+    let codes = legacy_codes("function d() {}\n@d class C {}\n");
+    assert!(
+        codes.contains(&1329) && !codes.contains(&1238),
+        "expected TS1329 only for a bare zero-arg class decorator; got: {codes:?}"
+    );
+}
+
+#[test]
+fn legacy_zero_arg_factory_call_class_decorator_emits_ts1329_not_ts1238() {
+    // `d()` is itself called, returning a further zero-arg function — still
+    // the "forgot to call it" shape, just one level deeper.
+    let codes = legacy_codes("function d() { return () => {}; }\n@d() class C {}\n");
+    assert!(
+        codes.contains(&1329) && !codes.contains(&1238),
+        "expected TS1329 only for a zero-arg factory-call class decorator; got: {codes:?}"
+    );
+}
+
+#[test]
+fn legacy_too_few_args_class_decorator_still_emits_ts1238() {
+    // Adjacent case / regression guard for #17109: a decorator declaring
+    // MORE than zero (but still too many) required params is a genuine
+    // TS1238 arity mismatch, not the TS1329 factory hint.
+    let codes = legacy_codes("function d(a: string, b: string, c: string) {}\n@d class C {}\n");
+    assert!(
+        codes.contains(&1238) && !codes.contains(&1329),
+        "expected TS1238 (not TS1329) when the decorator declares required params; got: {codes:?}"
+    );
+}
+
+#[test]
+fn legacy_not_callable_class_decorator_still_emits_ts1238() {
+    let codes = legacy_codes("const d = 1;\n@d class C {}\n");
+    assert!(
+        codes.contains(&1238) && !codes.contains(&1329),
+        "expected TS1238 (not TS1329) for a non-callable decorator; got: {codes:?}"
+    );
+}
+
+// =========================================================================
+// ES (TC39 stage-3) class decorators
+// =========================================================================
+
+#[test]
+fn es_bare_zero_arg_class_decorator_emits_ts1329_not_ts1238() {
+    let codes = es_codes("function d() {}\n@d class C {}\n");
+    assert!(
+        codes.contains(&1329) && !codes.contains(&1238),
+        "expected TS1329 only for a bare zero-arg ES class decorator; got: {codes:?}"
+    );
+}
+
+#[test]
+fn es_zero_arg_factory_call_class_decorator_emits_ts1329_not_ts1238() {
+    let codes = es_codes("function d() { return () => {}; }\n@d() class C {}\n");
+    assert!(
+        codes.contains(&1329) && !codes.contains(&1238),
+        "expected TS1329 only for a zero-arg factory-call ES class decorator; got: {codes:?}"
+    );
+}
+
+#[test]
+fn es_too_many_required_params_class_decorator_still_emits_ts1238() {
+    // Adjacent case: a decorator requiring more than the 2 args ES
+    // decorators supply (`value, context`) is a genuine TS1238 arity
+    // mismatch, not the TS1329 factory hint.
+    let codes = es_codes("function d(a: unknown, b: unknown, c: unknown) {}\n@d class C {}\n");
+    assert!(
+        codes.contains(&1238) && !codes.contains(&1329),
+        "expected TS1238 (not TS1329) when the ES decorator requires more than 2 params; got: {codes:?}"
+    );
+}
+
+#[test]
+fn es_compatible_class_decorator_no_diagnostic() {
+    // Negative control: a decorator matching the `(value, context)` runtime
+    // shape must be clean under both codes.
+    let codes = es_codes("function d(value: unknown, context: unknown) {}\n@d class C {}\n");
+    assert!(
+        !codes.contains(&1238) && !codes.contains(&1329),
+        "compatible ES class decorator must be clean; got: {codes:?}"
+    );
+}


### PR DESCRIPTION
Closes #17113 (reframed — see below).

## Structural rule

When every call signature of a class-decorator expression takes zero
parameters, `tsc` reports only the TS1329 "accepts too few arguments to be
used as a decorator here... did you mean to call it first" hint, anchored at
the whole decorator (`@`) — not the generic TS1238 signature-resolution
failure. tsz does this today for method/accessor/field/parameter decorators
via `decorator_has_zero_arg_factory_shape` (`decorator_signature_checks.rs`),
but never wired it for class decorators, through `owner: checker` /
`state_checking/class_decorators.rs`'s legacy (`experimentalDecorators`) and
ES (stage-3) call-signature checks.

#17113 filed this as a TS1238 anchor off-by-one (`(1,17)` vs `(1,18)`) for
`function d() {} @d class C {}`. Oracle-verified against pinned
`typescript@7.0.2`, that repro actually produces **TS1329**, not TS1238 at
all:

```
$ tsc --strict --experimentalDecorators f.ts
f.ts(1,17): error TS1329: 'd' accepts too few arguments to be used as a
decorator here. Did you mean to call it first and write '@d()'?
```

So the real gap isn't an anchor position — it's a missing diagnostic-family
wiring, identical in shape to the member-decorator TS1329 check that already
exists. Fixing it makes the "too many args" row of #17113's own matrix
correct by construction (a class decorator can only receive "too many args"
when every signature needs 0, which is exactly the zero-arg-factory shape).

## What changed (owner layer: checker)

- `decorator_signature_checks.rs`: bumped `decorator_has_zero_arg_factory_shape`
  and `decorator_expression_anchor` to `pub(crate)` (mirrors the existing
  `decorator_failure_anchor` cross-file-reuse convention).
- `class_decorators.rs`:
  - `check_class_decorator_call_signature` (legacy path): calls the shared
    zero-arg-factory check right after `prepare_decorator_callee`, before the
    call-signature/arity logic.
  - `check_es_class_decorator_arity` (stage-3 path): same check replaces the
    ad-hoc `shape.params.is_empty()` branch that previously emitted TS1238 at
    the decorator expression; the `required_params > 2` TS1238 branch is
    unchanged.

## Adjacent-case matrix (oracle-verified, `typescript@7.0.2`)

| source | mode | tsc | before | after |
| --- | --- | --- | --- | --- |
| `function d() {}`, `@d class C {}` | legacy | TS1329 @ `@` | TS1238 (wrong code) | TS1329 |
| `function d() { return () => {}; }`, `@d() class C {}` | legacy | TS1329 | TS1238 | TS1329 |
| `function d() {}`, `@d class C {}` | ES | TS1329 @ `@` | TS1238 | TS1329 |
| `function d() { return () => {}; }`, `@d() class C {}` | ES | TS1329 | TS1238 | TS1329 |
| `function d(a,b,c) {}`, `@d class C {}` | legacy | TS1238 | TS1238 | TS1238 (unchanged) |
| `const d = 1`, `@d class C {}` | legacy | TS1238 (not callable) | TS1238 | TS1238 (unchanged) |
| `function d(a,b,c: unknown) {}`, `@d class C {}` | ES | TS1238 (>2 required) | TS1238 | TS1238 (unchanged) |
| `function d(value, context: unknown) {}`, `@d class C {}` | ES | clean | clean | clean (unchanged) |

## Goal
Goal: hold

## Verification
- New `ts1329_class_decorator_zero_arg_factory_tests` (8 tests, registered in
  `Cargo.toml` per `autotests = false`): 8/8 pass.
- Adjacent decorator suites re-run for regressions, all green: `ts1238_experimental_decorator_anchor_tests` (6), `ts1238_generic_decorator_tests` (2), `ts1278_ts1279_decorator_arity_elaboration_tests` (8), `ts1239_parameter_decorator_tests` (5), `ts1241_method_decorator_tests` (18), `ts1271_parameter_decorator_return_type_tests` (12), `es_member_decorator_arity_tests` (15), `ts2449_parameter_decorator_no_tdz_tests` (2), `decorator_method_tdz_tests` (10), `ts1240_accessor_decorator_tests` (16), `ts1249_method_overload_decorator_tests` (2), `issue_7681_super_decorator_tests` (7), `decorator_this_binding_tests` (16), `ts18036_class_decorator_static_private_identifier_tests` (10).
- `cargo clippy --profile ci-lint -p tsz-checker --lib --tests -- -D warnings`: clean.
- `python3 scripts/arch/arch_guard.py`: passes.
- `python3 scripts/ci/check-test-file-reachability.py`: 0 new orphans.
- `cargo fmt --check -p tsz-checker`: clean.
- Full `cargo test -p tsz-checker --lib` was started but exceeded this
  container's time budget on its long tail (a handful of named tests take
  20+ min per prior board notes); not run to completion. The diff is narrow
  (2 `src` files) and fully covered by the 15 targeted decorator suites
  above (127 tests, all passing) plus clippy/arch-guard.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01PaLYANkzsdTrV4PXWrXa57)_