### PR TITLE
fix(checker): parenthesized decorator expressions keep generic TS1238/1241 over TS1329

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -612,6 +612,9 @@ path = "tests/ts1238_class_decorator_not_callable_chain_tests.rs"
 name = "ts1329_class_decorator_zero_arg_factory_tests"
 path = "tests/ts1329_class_decorator_zero_arg_factory_tests.rs"
 [[test]]
+name = "ts1329_decorator_parenthesized_expression_gate_tests"
+path = "tests/ts1329_decorator_parenthesized_expression_gate_tests.rs"
+[[test]]
 name = "ts2862_keyof_tparam_tests"
 path = "tests/ts2862_keyof_tparam_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking/class_decorators.rs
+++ b/crates/tsz-checker/src/state/state_checking/class_decorators.rs
@@ -362,7 +362,11 @@ impl<'a> CheckerState<'a> {
         // the legacy (`experimentalDecorators`) class-decorator path above.
         // A type with no call signature at all (the not-callable case just
         // below) has no signatures to inspect here, so this is a no-op for
-        // it and falls through correctly.
+        // it and falls through correctly. `decorator_has_zero_arg_factory_shape`
+        // itself also declines (returns `false`) for a parenthesized decorator
+        // expression (`@(() => {})`), since tsc keeps the generic TS1238 arity
+        // failure there instead — that shape falls through to the
+        // `required_params == 0` arm below.
         if self.decorator_has_zero_arg_factory_shape(decorator_expression, resolved, decorator_node)
         {
             return;
@@ -400,9 +404,10 @@ impl<'a> CheckerState<'a> {
             // ES decorators are invoked with `(value, context)`. When the
             // factory requires more than two parameters, the call cannot
             // supply them; tsc anchors the error at the whole decorator
-            // (including `@`). The zero-parameter case is handled above as
-            // the TS1329 decorator-factory hint, not this arity failure.
-            if required_params > 2 {
+            // (including `@`). Zero required params is normally the TS1329
+            // decorator-factory hint above, but a parenthesized expression
+            // opts out of that hint and still needs the arity failure here.
+            if required_params > 2 || required_params == 0 {
                 self.error_at_node(
                     decorator_node,
                     diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,

--- a/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
@@ -6,7 +6,7 @@ use crate::diagnostics::{
 use crate::query_boundaries::checkers::decorators as decorator_query;
 use crate::query_boundaries::common::CallResult;
 use crate::state::CheckerState;
-use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_solver::TypeId;
 
 /// Decorator-type sentinels that short-circuit signature validation. `ERROR`
@@ -532,6 +532,19 @@ impl<'a> CheckerState<'a> {
         decorator_node: NodeIndex,
     ) -> bool {
         if decorator_type_is_unchecked(decorator_type) {
+            return false;
+        }
+
+        // tsc's `isPotentiallyUncalledDecorator` only substitutes the TS1329
+        // hint for a bare identifier, property-access chain, or call
+        // expression — a parenthesized decorator expression (`@(() => {})`)
+        // keeps the generic TS1238/1239/1240/1241 arity elaboration instead.
+        let is_parenthesized = self
+            .ctx
+            .arena
+            .get(decorator_expr)
+            .is_some_and(|n| n.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION);
+        if is_parenthesized {
             return false;
         }
 

--- a/crates/tsz-checker/tests/ts1329_decorator_parenthesized_expression_gate_tests.rs
+++ b/crates/tsz-checker/tests/ts1329_decorator_parenthesized_expression_gate_tests.rs
@@ -1,0 +1,102 @@
+//! `decorator_has_zero_arg_factory_shape` declines to substitute the TS1329
+//! "did you mean to call it first" hint when the decorator's own expression
+//! is a `ParenthesizedExpression` (`@(() => {})`).
+//!
+//! Oracle-verified against pinned `typescript@7.0.2`: `isPotentiallyUncalledDecorator`
+//! only fires for a bare identifier, property-access chain, or call
+//! expression. A parenthesized decorator expression keeps the generic
+//! TS1238/1239/1240/1241 arity elaboration instead, uniformly across class
+//! and member decorators and both `experimentalDecorators` (legacy) and ES
+//! (TC39 stage-3) decorator mode.
+//!
+//! Regression coverage for #17121, found while merging #17118 on top of
+//! #17120 (the class-decorator PR that first wired this shared helper into
+//! `class_decorators.rs` and exposed the pre-existing member-decorator gap
+//! on that new path too).
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{
+    check_source, check_source_codes, check_source_codes_experimental_decorators,
+};
+
+fn legacy_codes(source: &str) -> Vec<u32> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            experimental_decorators: true,
+            ..CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+// ============================ class decorators ============================
+
+#[test]
+fn es_class_decorator_parenthesized_zero_arg_emits_ts1238_not_ts1329() {
+    let codes = check_source_codes("@(() => {})\nclass C {}\n").to_vec();
+    assert!(
+        codes.contains(&1238) && !codes.contains(&1329),
+        "expected TS1238 (not TS1329) for a parenthesized zero-arg ES class decorator; got: {codes:?}"
+    );
+}
+
+#[test]
+fn legacy_class_decorator_parenthesized_zero_arg_emits_ts1238_not_ts1329() {
+    let codes = legacy_codes("function d() {}\n@(() => {}) class C {}\n");
+    assert!(
+        codes.contains(&1238) && !codes.contains(&1329),
+        "expected TS1238 (not TS1329) for a parenthesized zero-arg legacy class decorator; got: {codes:?}"
+    );
+}
+
+// =========================== member decorators =============================
+
+#[test]
+fn es_method_decorator_parenthesized_zero_arg_emits_ts1241_not_ts1329() {
+    let codes = check_source_codes("class C {\n  @(() => {})\n  method() {}\n}\n").to_vec();
+    assert!(
+        codes.contains(&1241) && !codes.contains(&1329),
+        "expected TS1241 (not TS1329) for a parenthesized zero-arg ES method decorator; got: {codes:?}"
+    );
+}
+
+#[test]
+fn legacy_method_decorator_parenthesized_zero_arg_emits_ts1241_not_ts1329() {
+    let codes =
+        check_source_codes_experimental_decorators("class C {\n  @(() => {})\n  method() {}\n}\n")
+            .to_vec();
+    assert!(
+        codes.contains(&1241) && !codes.contains(&1329),
+        "expected TS1241 (not TS1329) for a parenthesized zero-arg legacy method decorator; got: {codes:?}"
+    );
+}
+
+// ================================ controls ==================================
+
+#[test]
+fn property_access_zero_arg_class_decorator_still_emits_ts1329() {
+    // Negative control: a property-access chain (not parenthesized) is
+    // exactly the shape `isPotentiallyUncalledDecorator` covers — the gate
+    // must not suppress the existing TS1329 behavior for it.
+    let codes = check_source_codes("const obj = { d() {} };\n@obj.d class C {}\n").to_vec();
+    assert!(
+        codes.contains(&1329) && !codes.contains(&1238),
+        "expected TS1329 (not TS1238) for a non-parenthesized property-access zero-arg decorator; got: {codes:?}"
+    );
+}
+
+#[test]
+fn parenthesized_but_callable_class_decorator_stays_clean() {
+    // Adjacent case: parenthesizing a decorator whose call signature already
+    // matches the runtime shape must not itself introduce a diagnostic.
+    let codes =
+        check_source_codes("@((value: unknown, context: unknown) => {})\nclass C {}\n").to_vec();
+    assert!(
+        !codes.contains(&1238) && !codes.contains(&1329),
+        "parenthesized but call-compatible ES class decorator must stay clean; got: {codes:?}"
+    );
+}


### PR DESCRIPTION
Fixes #17121.

## Structural rule

tsc's `isPotentiallyUncalledDecorator` only substitutes the TS1329 "accepts too few arguments to be used as a decorator here... did you mean to call it first" hint when the decorator's own expression is a bare `Identifier`, `PropertyAccessExpression`, or (top-level) `CallExpression` — **not** when it's a `ParenthesizedExpression` (`@(() => {})`), which keeps the generic TS1238/1239/1240/1241 arity elaboration instead. This holds uniformly across class and member decorators and both `experimentalDecorators` (legacy) and ES (TC39 stage-3) decorator mode (oracle-verified, `typescript@7.0.2`).

tsz's `decorator_has_zero_arg_factory_shape` (owner: checker, `crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs`) fired the TS1329 shortcut unconditionally for any zero-required-param decorator type, with no gate on the decorator expression's own syntax. This was a **live regression on `main`** at the time of writing: #17120 (merged the previous hour) newly wired this shared helper into the class-decorator path, which exposed the pre-existing member-decorator gap there too, and flipped `ts1238_tests::ts1238_es_decorator_zero_arity_factory_emits_error` (`@(() => {})\nclass C {}` — parenthesized, zero-arity) from TS1238 to the wrong TS1329.

## What changed (owner layer: checker)

- `decorator_signature_checks.rs`: `decorator_has_zero_arg_factory_shape` now checks the raw decorator-expression node's `NodeIndex` kind and returns `false` (declining the TS1329 shortcut) when it is `syntax_kind_ext::PARENTHESIZED_EXPRESSION`, falling through to each call site's normal call-resolution path.
- `class_decorators.rs` (ES class-decorator arity path, `check_es_class_decorator_arity`): the simplified `function_shape`-based arity check only ever tested `required_params > 2` (relying on the now-declined TS1329 branch to handle the zero case). Extended to `required_params > 2 || required_params == 0` so a parenthesized zero-arity decorator still gets its TS1238 arity failure instead of silently passing with no diagnostic at all.
- The other four call sites (legacy class-decorator call resolution, ES/legacy method-or-accessor, legacy property/field) already do real `resolve_call_with_checker_adapter` calls after the (now-declined) TS1329 shortcut, so they pick up the correct arity-mismatch diagnostic automatically with no further change — verified against the oracle below.

## Adjacent-case matrix (oracle-verified, `typescript@7.0.2`)

| decorator | expression shape | mode | tsc / tsz (after) |
| --- | --- | --- | --- |
| `() => {}` | parenthesized | ES class | TS1238 (was: wrong TS1329) |
| `() => {}` | parenthesized | legacy class | TS1238 (was: wrong TS1329) |
| `() => {}` | parenthesized | ES method | TS1241 (was: wrong TS1329) |
| `() => {}` | parenthesized | legacy method | TS1241 (was: wrong TS1329) |
| `obj.d` (zero-arg) | property access | ES class | TS1329 (unchanged, control) |
| `(value, context) => {}` | parenthesized, call-compatible | ES class | clean (unchanged, control) |

## Goal
Goal: hold

## Verification
- New `crates/tsz-checker/tests/ts1329_decorator_parenthesized_expression_gate_tests.rs` (6 tests, oracle-verified against pinned `typescript@7.0.2`): all 6 adjacent-matrix rows above. `cargo test -p tsz-checker --test ts1329_decorator_parenthesized_expression_gate_tests` → 6/6 pass.
- The specific regression this closes: `cargo test -p tsz-checker --test ts1238_tests` → 14/14 pass (was 13/14, `ts1238_es_decorator_zero_arity_factory_emits_error` red on `main`).
- 0 regressions across all 18 decorator-family suites (137 tests total): `decorator_method_tdz_tests`, `decorator_this_binding_tests`, `es_member_decorator_arity_tests`, `issue_7681_super_decorator_tests`, `ts1238_experimental_decorator_anchor_tests`, `ts1238_generic_decorator_tests`, `ts1238_tests`, `ts1238_class_decorator_not_callable_chain_tests`, `ts1239_parameter_decorator_tests`, `ts1240_accessor_decorator_tests`, `ts1240_tests`, `ts1241_method_decorator_tests`, `ts1249_method_overload_decorator_tests`, `ts1271_parameter_decorator_return_type_tests`, `ts1278_ts1279_decorator_arity_elaboration_tests`, `ts1329_class_decorator_zero_arg_factory_tests`, `ts1329_decorator_parenthesized_expression_gate_tests`, `ts18036_class_decorator_static_private_identifier_tests`, `ts2449_parameter_decorator_no_tdz_tests`.
- `cargo clippy --profile ci-lint -p tsz-checker --lib --tests -- -D warnings`: clean.
- `python3 scripts/arch/arch_guard.py`: passes.
- `python3 scripts/ci/check-test-file-reachability.py`: 0 new orphans.
- `cargo fmt -p tsz-checker -- --check`: clean.
- Only decorator-signature diagnostics can move (adds a missing gate + one arity arm; no other diagnostic code touched); the TypeScript corpus submodule was not checked out this session, so no full conformance/emit sweep was run — the 137-test targeted suite above exercises every affected call site, all four decorator families, and both decorator modes.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude


---
_Generated by [Claude Code](https://claude.ai/code/session_01VC9edQi4cVdUTcJgBSnuH1)_