### PR TITLE
fix(checker): TS6210/TS6236 decorator missing-argument pointer + ES class-decorator arity elaboration

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/class_decorators.rs
+++ b/crates/tsz-checker/src/state/state_checking/class_decorators.rs
@@ -284,6 +284,7 @@ impl<'a> CheckerState<'a> {
             let anchor = self.decorator_failure_anchor(decorator_node, resolved, 1);
             self.emit_decorator_signature_error(
                 anchor,
+                decorator_node,
                 diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                 diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                 &result,
@@ -334,6 +335,10 @@ impl<'a> CheckerState<'a> {
         decorator_type: TypeId,
     ) {
         use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+
+        // ES (TC39 stage-3) class decorators are invoked with exactly two
+        // runtime arguments: `(value, context)`.
+        const ES_CLASS_DECORATOR_ARGS: usize = 2;
 
         if decorator_type == TypeId::ERROR
             || decorator_type == TypeId::ANY
@@ -402,11 +407,32 @@ impl<'a> CheckerState<'a> {
             // supply them; tsc anchors the error at the whole decorator
             // (including `@`). The zero-parameter case is handled above as
             // the TS1329 decorator-factory hint, not this arity failure.
-            if required_params > 2 {
-                self.error_at_node(
+            if required_params > ES_CLASS_DECORATOR_ARGS {
+                // This path never calls `resolve_call_with_checker_adapter`, so
+                // there is no `CallResult` to read; synthesize the equivalent
+                // argument-count mismatch from the shape's own counts so the
+                // shared helper attaches the same TS1278/TS1279 elaboration and
+                // TS6210/TS6236/TS6211 missing-argument pointer the legacy
+                // (`experimentalDecorators`) class-decorator path already gets.
+                // A trailing rest parameter leaves the arity open-ended (no
+                // concrete max), which is what selects the "expects at least N"
+                // (TS1279) wording over the exact-N (TS1278) form.
+                let expected_max = if shape.params.iter().any(|p| p.rest) {
+                    None
+                } else {
+                    Some(shape.params.len())
+                };
+                let result = crate::query_boundaries::common::CallResult::ArgumentCountMismatch {
+                    expected_min: required_params,
+                    expected_max,
+                    actual: ES_CLASS_DECORATOR_ARGS,
+                };
+                self.emit_decorator_signature_error(
+                    decorator_node,
                     decorator_node,
                     diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                     diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
+                    &result,
                 );
             }
         }

--- a/crates/tsz-checker/src/state/state_checking/class_decorators.rs
+++ b/crates/tsz-checker/src/state/state_checking/class_decorators.rs
@@ -409,30 +409,28 @@ impl<'a> CheckerState<'a> {
             // the TS1329 decorator-factory hint, not this arity failure.
             if required_params > ES_CLASS_DECORATOR_ARGS {
                 // This path never calls `resolve_call_with_checker_adapter`, so
-                // there is no `CallResult` to read; synthesize the equivalent
-                // argument-count mismatch from the shape's own counts so the
-                // shared helper attaches the same TS1278/TS1279 elaboration and
+                // there is no `CallResult` to read; the shared
+                // `emit_decorator_arity_count_error` helper synthesizes the
+                // equivalent argument-count mismatch from these counts and
+                // attaches the same TS1278/TS1279 elaboration and
                 // TS6210/TS6236/TS6211 missing-argument pointer the legacy
                 // (`experimentalDecorators`) class-decorator path already gets.
                 // A trailing rest parameter leaves the arity open-ended (no
-                // concrete max), which is what selects the "expects at least N"
-                // (TS1279) wording over the exact-N (TS1278) form.
+                // concrete max), which selects the "expects at least N" (TS1279)
+                // wording over the exact-N (TS1278) form.
                 let expected_max = if shape.params.iter().any(|p| p.rest) {
                     None
                 } else {
                     Some(shape.params.len())
                 };
-                let result = crate::query_boundaries::common::CallResult::ArgumentCountMismatch {
-                    expected_min: required_params,
-                    expected_max,
-                    actual: ES_CLASS_DECORATOR_ARGS,
-                };
-                self.emit_decorator_signature_error(
+                self.emit_decorator_arity_count_error(
                     decorator_node,
                     decorator_node,
                     diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                     diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
-                    &result,
+                    required_params,
+                    expected_max,
+                    ES_CLASS_DECORATOR_ARGS,
                 );
             }
         }

--- a/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
@@ -263,6 +263,32 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Emit a decorator arity error whose `ArgumentCountMismatch` is synthesized
+    /// from raw counts rather than read from a real `CallResult` — the ES
+    /// class-decorator path never calls `resolve_call_with_checker_adapter`, so
+    /// it has no `CallResult`. Constructing it here (where `CallResult` is
+    /// already imported) keeps the direct `query_boundaries::common` reference
+    /// out of the class-decorator module while the elaboration and
+    /// missing-argument pointer are attached identically to the resolve-based
+    /// paths via [`Self::emit_decorator_signature_error`].
+    pub(crate) fn emit_decorator_arity_count_error(
+        &mut self,
+        anchor: NodeIndex,
+        decorator_node: NodeIndex,
+        message: &str,
+        code: u32,
+        expected_min: usize,
+        expected_max: Option<usize>,
+        actual: usize,
+    ) {
+        let result = CallResult::ArgumentCountMismatch {
+            expected_min,
+            expected_max,
+            actual,
+        };
+        self.emit_decorator_signature_error(anchor, decorator_node, message, code, &result);
+    }
+
     /// tsc's TS1238 "not callable" shape for a class decorator whose resolved
     /// type carries no call signature at all — a bare primitive, a class
     /// (construct signatures only, no call signatures), or any other

--- a/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
@@ -3,10 +3,12 @@
 use crate::diagnostics::{
     Diagnostic, DiagnosticRelatedInformation, diagnostic_codes, diagnostic_messages, format_message,
 };
+use crate::error_reporter::DiagnosticAnchorKind;
 use crate::query_boundaries::checkers::decorators as decorator_query;
 use crate::query_boundaries::common::CallResult;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
 
 /// Decorator-type sentinels that short-circuit signature validation. `ERROR`
@@ -35,8 +37,13 @@ impl<'a> CheckerState<'a> {
     /// trailing `...rest: any[]`) and too few arguments were supplied; a
     /// fixed-length rest tuple (`...rest: [string, number]`) still has a
     /// concrete `expected_max` and takes the exact-N wording (TS1278).
+    ///
+    /// When the failure is *too few* arguments, a second cross-location
+    /// pointer is attached at the first parameter the runtime cannot supply
+    /// (see [`Self::decorator_missing_argument_pointer`]).
     fn decorator_arity_related_info(
         &self,
+        decorator_node: NodeIndex,
         result: &CallResult,
     ) -> Vec<DiagnosticRelatedInformation> {
         let &CallResult::ArgumentCountMismatch {
@@ -63,26 +70,192 @@ impl<'a> CheckerState<'a> {
                 )
         };
         let expected_str = expected.to_string();
-        vec![Diagnostic::related_message(
+        let mut related = vec![Diagnostic::related_message(
             code,
             self.ctx.file_name.clone(),
             0,
             0,
             format_message(message_template, &[&expected_str, &actual_str]),
-        )]
+        )];
+        // Only a *too-few-arguments* failure attaches the "argument not
+        // provided" pointer; a "too many" failure supplies every declared
+        // parameter, so tsc adds no second line there.
+        if actual < expected_min
+            && let Some(pointer) = self.decorator_missing_argument_pointer(decorator_node, actual)
+        {
+            related.push(pointer);
+        }
+        related
+    }
+
+    /// Cross-location pointer (`tsc`'s `relatedInformation`) beneath the
+    /// decorator signature-resolution error, anchored at the first declared
+    /// parameter the runtime invocation cannot supply.
+    ///
+    /// Mirrors tsc's `getArgumentArityError`, which — after the primary
+    /// TS1238/1239/1240/1241 and its TS1278/TS1279 elaboration — attaches a
+    /// pointer at `parameters[argCount]` (the first position the fixed decorator
+    /// calling convention leaves unfilled):
+    /// - TS6210 `An argument for '{0}' was not provided.` for an ordinary
+    ///   named parameter,
+    /// - TS6236 `Arguments for the rest parameter '{0}' were not provided.`
+    ///   when that parameter is variadic,
+    /// - TS6211 `An argument matching this binding pattern was not provided.`
+    ///   when it is a destructured (binding-pattern) parameter.
+    ///
+    /// Returns `None` when the decorator does not reference a single locatable
+    /// function-like declaration (an overloaded, imported, factory-call, or
+    /// property-access decorator): tsc anchors at the resolved signature's
+    /// declaration there, but without a unique local one the exact anchor
+    /// cannot be reproduced, so no pointer is attached rather than a wrong one.
+    fn decorator_missing_argument_pointer(
+        &self,
+        decorator_node: NodeIndex,
+        actual: usize,
+    ) -> Option<DiagnosticRelatedInformation> {
+        let params = self.decorator_declaration_value_parameter_nodes(decorator_node)?;
+        let param_idx = *params.get(actual)?;
+        let param_node = self.ctx.arena.get(param_idx)?;
+        let param = self.ctx.arena.get_parameter(param_node)?;
+        let anchor = self.resolve_diagnostic_anchor(param_idx, DiagnosticAnchorKind::Exact)?;
+
+        let name_node = self.ctx.arena.get(param.name);
+        let name_ident = name_node.and_then(|n| self.ctx.arena.get_identifier(n));
+        let (code, message) = if param.dot_dot_dot_token {
+            let name = name_ident?.escaped_text.to_string();
+            (
+                diagnostic_codes::ARGUMENTS_FOR_THE_REST_PARAMETER_WERE_NOT_PROVIDED,
+                format_message(
+                    diagnostic_messages::ARGUMENTS_FOR_THE_REST_PARAMETER_WERE_NOT_PROVIDED,
+                    &[&name],
+                ),
+            )
+        } else if let Some(ident) = name_ident {
+            let name = ident.escaped_text.to_string();
+            (
+                diagnostic_codes::AN_ARGUMENT_FOR_WAS_NOT_PROVIDED,
+                format_message(
+                    diagnostic_messages::AN_ARGUMENT_FOR_WAS_NOT_PROVIDED,
+                    &[&name],
+                ),
+            )
+        } else {
+            // A destructured parameter has no single name to quote.
+            (
+                diagnostic_codes::AN_ARGUMENT_MATCHING_THIS_BINDING_PATTERN_WAS_NOT_PROVIDED,
+                diagnostic_messages::AN_ARGUMENT_MATCHING_THIS_BINDING_PATTERN_WAS_NOT_PROVIDED
+                    .to_string(),
+            )
+        };
+        Some(Diagnostic::related_pointer(
+            code,
+            self.ctx.file_name.clone(),
+            anchor.start,
+            anchor.length,
+            message,
+        ))
+    }
+
+    /// The value-parameter declaration nodes (any leading explicit `this`
+    /// parameter removed, so the list is indexed the way the runtime supplies
+    /// value arguments) of the single function-like declaration a decorator
+    /// expression references, or `None` when the decorator is not a bare
+    /// `@name` bound to exactly one locatable function-like declaration.
+    fn decorator_declaration_value_parameter_nodes(
+        &self,
+        decorator_node: NodeIndex,
+    ) -> Option<Vec<NodeIndex>> {
+        let ident = self.decorator_callee_reference_identifier(decorator_node)?;
+        let sym_id = self.resolve_identifier_symbol_without_tracking(ident)?;
+        let decls = self.ctx.binder.get_symbol(sym_id)?.declarations.clone();
+        let mut found: Option<Vec<NodeIndex>> = None;
+        for decl in decls {
+            if let Some(params) = self.function_like_value_parameter_nodes(decl) {
+                if found.is_some() {
+                    // Overloaded / multiply-declared: the resolved signature is
+                    // ambiguous from the node alone, so decline rather than guess.
+                    return None;
+                }
+                found = Some(params);
+            }
+        }
+        found
+    }
+
+    /// Parameter declaration nodes of a function-like declaration — a function,
+    /// function expression, arrow, or method, or a variable initialized with
+    /// one — with any leading explicit `this` parameter removed.
+    fn function_like_value_parameter_nodes(&self, decl: NodeIndex) -> Option<Vec<NodeIndex>> {
+        let node = self.ctx.arena.get(decl)?;
+        let params = match node.kind {
+            k if k == syntax_kind_ext::FUNCTION_DECLARATION
+                || k == syntax_kind_ext::FUNCTION_EXPRESSION
+                || k == syntax_kind_ext::ARROW_FUNCTION =>
+            {
+                &self.ctx.arena.get_function(node)?.parameters
+            }
+            k if k == syntax_kind_ext::METHOD_DECLARATION => {
+                &self.ctx.arena.get_method_decl(node)?.parameters
+            }
+            k if k == syntax_kind_ext::VARIABLE_DECLARATION => {
+                let init = self.ctx.arena.get_variable_declaration(node)?.initializer;
+                if init.is_none() {
+                    return None;
+                }
+                return self.function_like_value_parameter_nodes(init);
+            }
+            _ => return None,
+        };
+        Some(
+            params
+                .nodes
+                .iter()
+                .copied()
+                .filter(|&p| !self.parameter_is_this(p))
+                .collect(),
+        )
+    }
+
+    /// Whether a parameter declaration is an explicit `this: T` parameter,
+    /// which tsc excludes from the value-argument positions. The `this` name
+    /// parses as a `ThisKeyword` (not an ordinary identifier), so this defers
+    /// to the shared [`Self::is_this_parameter_name`] check.
+    fn parameter_is_this(&self, param_idx: NodeIndex) -> bool {
+        self.ctx
+            .arena
+            .get(param_idx)
+            .and_then(|n| self.ctx.arena.get_parameter(n))
+            .is_some_and(|p| self.is_this_parameter_name(p.name))
+    }
+
+    /// The identifier a decorator expression directly references, for a bare
+    /// `@name` (optionally parenthesized). Property-access (`@ns.dec`),
+    /// factory-call (`@make()`), and other forms return `None`.
+    fn decorator_callee_reference_identifier(
+        &self,
+        decorator_node: NodeIndex,
+    ) -> Option<NodeIndex> {
+        let node = self.ctx.arena.get(decorator_node)?;
+        let expr = self.ctx.arena.get_decorator(node)?.expression;
+        let expr = self.ctx.arena.skip_parenthesized(expr);
+        let expr_node = self.ctx.arena.get(expr)?;
+        (expr_node.kind == tsz_scanner::SyntaxKind::Identifier as u16).then_some(expr)
     }
 
     /// Emit a decorator signature-resolution error, attaching
     /// [`Self::decorator_arity_related_info`] when `result` is an
-    /// argument-count mismatch.
+    /// argument-count mismatch. `decorator_node` is the `@`-decorator syntax
+    /// node, used to locate the declared parameter the missing-argument pointer
+    /// anchors at.
     pub(crate) fn emit_decorator_signature_error(
         &mut self,
         anchor: NodeIndex,
+        decorator_node: NodeIndex,
         message: &str,
         code: u32,
         result: &CallResult,
     ) {
-        let related = self.decorator_arity_related_info(result);
+        let related = self.decorator_arity_related_info(decorator_node, result);
         if related.is_empty() {
             self.error_at_node(anchor, message, code);
         } else {
@@ -228,6 +401,7 @@ impl<'a> CheckerState<'a> {
         if !matches!(result, CallResult::Success(_)) {
             self.emit_decorator_signature_error(
                 self.decorator_failure_anchor(decorator_node, resolved, args.len()),
+                decorator_node,
                 diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_PROPERTY_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                 diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_PROPERTY_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                 &result,
@@ -470,6 +644,7 @@ impl<'a> CheckerState<'a> {
             _ => {
                 self.emit_decorator_signature_error(
                     self.decorator_failure_anchor(decorator_node, resolved, arg_types.len()),
+                    decorator_node,
                     diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_METHOD_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                     diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_METHOD_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                     &result,
@@ -848,6 +1023,7 @@ impl<'a> CheckerState<'a> {
             _ => {
                 self.emit_decorator_signature_error(
                     self.decorator_failure_anchor(decorator_node, resolved, arg_types.len()),
+                    decorator_node,
                     diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_PROPERTY_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                     diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_PROPERTY_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                     &result,
@@ -981,6 +1157,7 @@ impl<'a> CheckerState<'a> {
             _ => {
                 self.emit_decorator_signature_error(
                     self.decorator_failure_anchor(decorator_node, resolved, 3),
+                    decorator_node,
                     diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_PARAMETER_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                     diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_PARAMETER_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                     &result,

--- a/crates/tsz-checker/tests/ts1238_tests.rs
+++ b/crates/tsz-checker/tests/ts1238_tests.rs
@@ -234,18 +234,25 @@ class Example {
 // === ES decorators (experimental_decorators: false) =======================
 //
 // ES decorators call the decorator factory with `(value, context)`.
-// A factory with zero parameters has no slot for `value`, so tsc flags
-// it as TS1238 even though a structural call would succeed by ignoring
-// the extra args. A factory requiring more than two parameters also
-// cannot be satisfied. 1 or 2 required parameters are fine.
+// A factory with zero parameters is the "forgot to call it" shape: tsc's
+// `isPotentiallyUncalledDecorator` fires (0 declared params is fewer than the
+// arguments the decorator convention supplies), so it reports the TS1329
+// call-it-first hint rather than a TS1238 signature failure. A factory
+// requiring more than two parameters cannot be satisfied and draws TS1238.
+// 1 or 2 required parameters are fine.
 
 #[test]
-fn ts1238_es_decorator_zero_arity_factory_emits_error() {
-    // `() => {}` has no parameter to receive the class target.
+fn ts1329_es_decorator_zero_arity_factory_hint_not_ts1238() {
+    // `() => {}` has no parameter to receive the class target, so it reads as
+    // an uncalled factory: TS1329, not the TS1238 signature failure.
     let codes = tsz_checker::test_utils::check_source_codes("@(() => {})\nclass C {}\n");
     assert!(
-        codes.contains(&1238),
-        "Expected TS1238 for zero-arity ES class decorator, got: {codes:?}"
+        codes.contains(&1329),
+        "Expected TS1329 call-it-first hint for zero-arity ES class decorator, got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&1238),
+        "Zero-arity ES class decorator should not also emit TS1238, got: {codes:?}"
     );
 }
 

--- a/crates/tsz-checker/tests/ts1278_ts1279_decorator_arity_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/ts1278_ts1279_decorator_arity_elaboration_tests.rs
@@ -1,27 +1,28 @@
-//! TS1278/TS1279 elaboration for decorator signature-resolution failures.
+//! TS1278/TS1279 elaboration + TS6210/TS6236 missing-argument pointer for
+//! decorator signature-resolution failures.
 //!
 //! Structural rule: when a decorator's call resolution fails specifically
-//! because of an argument-count mismatch, tsc attaches a related-information
-//! chain link to the primary TS1238/1239/1240/1241 ("Unable to resolve
-//! signature of ... decorator when called as an expression."):
+//! because of an argument-count mismatch, tsc attaches, beneath the primary
+//! TS1238/1239/1240/1241 ("Unable to resolve signature of ... decorator when
+//! called as an expression."):
 //! - TS1278 ("The runtime will invoke the decorator with {1} arguments, but
 //!   the decorator expects {0}.") when the decorator's declared arity has a
-//!   concrete upper bound.
-//! - TS1279 ("...but the decorator expects at least {0}.") when too few
-//!   arguments were supplied and the decorator's arity is genuinely
-//!   open-ended (a trailing `...rest: any[]`).
+//!   concrete upper bound, or TS1279 ("...expects at least {0}.") when too few
+//!   arguments were supplied and the arity is open-ended (`...rest: any[]`); and
+//! - a *cross-location pointer* at the first declared parameter the fixed
+//!   decorator calling convention leaves unsupplied — TS6210 ("An argument for
+//!   '{0}' was not provided.") for a named parameter, or TS6236 ("Arguments for
+//!   the rest parameter '{0}' were not provided.") when that parameter is
+//!   variadic. This second line fires only for a *too-few* failure; a *too-many*
+//!   failure supplies every declared parameter and gets only the TS1278 line.
 //!
-//! tsz previously reported only the primary message, with no related
-//! information at all — the elaboration line was silently dropped in both
-//! the too-few and too-many argument shapes, across all five
-//! resolve-call-based decorator-signature-check sites (class, ES member,
-//! method/accessor, legacy property, parameter). A non-arity failure (e.g. an
-//! argument type mismatch) is deliberately left untouched: tsc attaches a
-//! different elaboration there (a `TS2345`-style "not assignable" line) that
-//! this change does not wire, so those diagnostics keep their pre-existing
-//! shape (no related information) rather than attaching the wrong kind.
+//! A non-arity failure (e.g. an argument type mismatch) is deliberately left
+//! untouched: tsc attaches a different elaboration there (a `TS2345`-style "not
+//! assignable" line) that this change does not wire, so those diagnostics keep
+//! their pre-existing shape (no related information).
 //!
-//! Oracle-verified against pinned `typescript@7.0.2` for every shape below.
+//! Oracle-verified against pinned `typescript@7.0.2` for the class-decorator
+//! shapes; the member/parameter shapes reuse the identical shared helper.
 
 use tsz_checker::context::CheckerOptions;
 use tsz_checker::test_utils::check_source;
@@ -48,47 +49,84 @@ fn find(
     diags.iter().find(|d| d.code == code)
 }
 
-// ───────────────────────── class decorator (TS1238, legacy) ─────────────────
+/// Byte offset of the first occurrence of `needle` in `source`, used to check
+/// the missing-argument pointer anchors at the parameter declaration.
+fn offset_of(source: &str, needle: &str) -> u32 {
+    u32::try_from(source.find(needle).expect("needle present in source")).expect("offset fits u32")
+}
+
+/// Assert the primary diagnostic carries exactly the TS1278/TS1279 elaboration
+/// line, then the TS6210/TS6236 pointer at `param_start`.
+fn assert_arity_chain(
+    primary: &tsz_checker::diagnostics::Diagnostic,
+    expect_runtime_code: u32,
+    expect_runtime_message: &str,
+    expect_pointer_code: u32,
+    expect_pointer_message: &str,
+    param_start: u32,
+) {
+    let related = &primary.related_information;
+    assert_eq!(
+        related.len(),
+        2,
+        "expected the runtime-arity line and the missing-argument pointer, got: {related:?}"
+    );
+    assert_eq!(related[0].code, expect_runtime_code);
+    assert_eq!(related[0].message_text, expect_runtime_message);
+    assert_eq!(related[1].code, expect_pointer_code);
+    assert_eq!(related[1].message_text, expect_pointer_message);
+    assert_eq!(
+        related[1].start, param_start,
+        "TS{expect_pointer_code} must anchor at the missing parameter declaration"
+    );
+}
+
+// ───────────────────── class decorator (TS1238, legacy) ─────────────────
 
 #[test]
 fn ts1278_class_decorator_too_few_args_exact() {
     // `classDec` declares 2 required params; a legacy class decorator is
-    // invoked with exactly 1 (the class constructor) -> TS1278 "expects 2".
-    let diags = diagnostics_experimental(
-        r#"
+    // invoked with exactly 1 (the class constructor) -> TS1278 "expects 2",
+    // plus a TS6210 pointer at the unsupplied `extra` parameter.
+    let source = r#"
 function classDec(target: Function, extra: string) {}
 
 @classDec
 class C {}
-"#,
-    );
+"#;
+    let diags = diagnostics_experimental(source);
     let primary = find(&diags, 1238).expect("expected TS1238");
-    assert_eq!(primary.related_information.len(), 1);
-    assert_eq!(primary.related_information[0].code, 1278);
-    assert_eq!(
-        primary.related_information[0].message_text,
-        "The runtime will invoke the decorator with 1 arguments, but the decorator expects 2."
+    assert_arity_chain(
+        primary,
+        1278,
+        "The runtime will invoke the decorator with 1 arguments, but the decorator expects 2.",
+        6210,
+        "An argument for 'extra' was not provided.",
+        offset_of(source, "extra: string"),
     );
 }
 
 #[test]
 fn ts1279_class_decorator_too_few_args_at_least() {
     // A genuinely variadic decorator (`...rest: any[]`) with a required
-    // `name` param that isn't supplied -> TS1279 "expects at least 2".
-    let diags = diagnostics_experimental(
-        r#"
+    // `name` param that isn't supplied -> TS1279 "expects at least 2". The
+    // first unsupplied parameter is the ordinary `name`, so the pointer is
+    // TS6210 (named), not TS6236 (rest).
+    let source = r#"
 function classDec(target: Function, name: string, ...rest: any[]) {}
 
 @classDec
 class C {}
-"#,
-    );
+"#;
+    let diags = diagnostics_experimental(source);
     let primary = find(&diags, 1238).expect("expected TS1238");
-    assert_eq!(primary.related_information.len(), 1);
-    assert_eq!(primary.related_information[0].code, 1279);
-    assert_eq!(
-        primary.related_information[0].message_text,
-        "The runtime will invoke the decorator with 1 arguments, but the decorator expects at least 2."
+    assert_arity_chain(
+        primary,
+        1279,
+        "The runtime will invoke the decorator with 1 arguments, but the decorator expects at least 2.",
+        6210,
+        "An argument for 'name' was not provided.",
+        offset_of(source, "name: string"),
     );
 }
 
@@ -97,20 +135,25 @@ fn ts1278_class_decorator_fixed_length_rest_stays_exact() {
     // A fixed-length tuple rest param (`...rest: [string, number]`) has a
     // concrete max arity, so this stays TS1278 ("expects 3"), not TS1279 --
     // the discriminator is a concrete upper bound, not the presence of `...`.
-    let diags = diagnostics_experimental(
-        r#"
+    // The first unsupplied position is the tuple rest, so the pointer is
+    // TS6236 anchored at it.
+    let source = r#"
 function classDec(target: Function, ...rest: [string, number]) {}
 
 @classDec
 class C {}
-"#,
-    );
+"#;
+    let diags = diagnostics_experimental(source);
     let primary = find(&diags, 1238).expect("expected TS1238");
-    assert_eq!(primary.related_information.len(), 1);
-    assert_eq!(primary.related_information[0].code, 1278);
-    assert_eq!(
-        primary.related_information[0].message_text,
-        "The runtime will invoke the decorator with 1 arguments, but the decorator expects 3."
+    assert_arity_chain(
+        primary,
+        1278,
+        "The runtime will invoke the decorator with 1 arguments, but the decorator expects 3.",
+        6236,
+        "Arguments for the rest parameter 'rest' were not provided.",
+        // tsz's normalized parameter anchor starts at the binding name, past the
+        // `...` rest token.
+        offset_of(source, "rest: [string, number]"),
     );
 }
 
@@ -136,53 +179,174 @@ class C {}
     );
 }
 
-// ───────────────────────── ES member decorator (TS1240) ─────────────────────
+#[test]
+fn ts6210_class_decorator_binder_name_varies() {
+    // The pointer is driven by the decorator's declared parameters, not by any
+    // fixed identifier: a renamed binder still names its own missing parameter.
+    let source = r#"
+function wrap(ctor: Function, label: string) {}
+
+@wrap
+class C {}
+"#;
+    let diags = diagnostics_experimental(source);
+    let primary = find(&diags, 1238).expect("expected TS1238");
+    assert_arity_chain(
+        primary,
+        1278,
+        "The runtime will invoke the decorator with 1 arguments, but the decorator expects 2.",
+        6210,
+        "An argument for 'label' was not provided.",
+        offset_of(source, "label: string"),
+    );
+}
+
+#[test]
+fn ts6210_class_decorator_arrow_const_declaration() {
+    // The declaration is reachable through a `const` initialized with an arrow,
+    // not only a `function` statement.
+    let source = r#"
+const classDec = (target: Function, extra: string) => {};
+
+@classDec
+class C {}
+"#;
+    let diags = diagnostics_experimental(source);
+    let primary = find(&diags, 1238).expect("expected TS1238");
+    assert_arity_chain(
+        primary,
+        1278,
+        "The runtime will invoke the decorator with 1 arguments, but the decorator expects 2.",
+        6210,
+        "An argument for 'extra' was not provided.",
+        offset_of(source, "extra: string"),
+    );
+}
+
+#[test]
+fn ts6210_class_decorator_skips_explicit_this_parameter() {
+    // An explicit `this` parameter is not a value argument, so the pointer must
+    // land on `extra`, not shift by one onto `this`.
+    let source = r#"
+function classDec(this: unknown, target: Function, extra: string) {}
+
+@classDec
+class C {}
+"#;
+    let diags = diagnostics_experimental(source);
+    let primary = find(&diags, 1238).expect("expected TS1238");
+    let pointer = primary
+        .related_information
+        .iter()
+        .find(|r| r.code == 6210)
+        .expect("expected TS6210");
+    assert_eq!(
+        pointer.message_text,
+        "An argument for 'extra' was not provided."
+    );
+    assert_eq!(pointer.start, offset_of(source, "extra: string"));
+}
+
+// ───────────────────── ES class decorator (TS1238, stage-3) ─────────────
+
+#[test]
+fn ts1278_es_class_decorator_too_few_args() {
+    // Gap 2: the ES (stage-3) class-decorator arity path never resolved a
+    // `CallResult`, so it emitted a bare TS1238 with no elaboration. It now
+    // routes through the shared helper: `(value, context)` = 2 supplied args,
+    // a 3-required-param decorator -> TS1278 "expects 3" + TS6210 at the third
+    // parameter (the first the two-argument convention cannot fill).
+    let source = r#"
+function classDec(value: any, context: any, extra: string) {}
+
+@classDec
+class C {}
+"#;
+    let diags = diagnostics_es(source);
+    let primary = find(&diags, 1238).expect("expected TS1238");
+    assert_arity_chain(
+        primary,
+        1278,
+        "The runtime will invoke the decorator with 2 arguments, but the decorator expects 3.",
+        6210,
+        "An argument for 'extra' was not provided.",
+        offset_of(source, "extra: string"),
+    );
+}
+
+#[test]
+fn ts1279_es_class_decorator_variadic_too_few_args() {
+    // ES class decorator with an open-ended arity (`...rest: any[]`) and a
+    // third required parameter -> TS1279 "at least 3" + TS6210 at `extra`.
+    let source = r#"
+function classDec(value: any, context: any, extra: string, ...rest: any[]) {}
+
+@classDec
+class C {}
+"#;
+    let diags = diagnostics_es(source);
+    let primary = find(&diags, 1238).expect("expected TS1238");
+    assert_arity_chain(
+        primary,
+        1279,
+        "The runtime will invoke the decorator with 2 arguments, but the decorator expects at least 3.",
+        6210,
+        "An argument for 'extra' was not provided.",
+        offset_of(source, "extra: string"),
+    );
+}
+
+// ───────────────────── ES member decorator (TS1240) ─────────────────
 
 #[test]
 fn ts1278_es_field_decorator_too_few_args() {
     // ES (TC39) field decorators are invoked with `(value, context)` -- at
     // most 2 synthetic args, capped by `es_member_decorator_argument_count`.
-    // A decorator declaring 3+ required params always underflows that cap
-    // (a 1- or 2-required-param decorator gets exactly the args it declared,
-    // per `min(max(paramCount, 1), 2)`, and never fails on arity alone).
-    let diags = diagnostics_es(
-        r#"
+    // A decorator declaring 3+ required params always underflows that cap.
+    let source = r#"
 function d(value: any, context: any, extra: string): any { return value; }
 class C { @d field = 1; }
-"#,
-    );
+"#;
+    let diags = diagnostics_es(source);
     let primary = find(&diags, 1240).expect("expected TS1240");
-    assert_eq!(primary.related_information.len(), 1);
-    assert_eq!(primary.related_information[0].code, 1278);
-    assert_eq!(
-        primary.related_information[0].message_text,
-        "The runtime will invoke the decorator with 2 arguments, but the decorator expects 3."
+    assert_arity_chain(
+        primary,
+        1278,
+        "The runtime will invoke the decorator with 2 arguments, but the decorator expects 3.",
+        6210,
+        "An argument for 'extra' was not provided.",
+        offset_of(source, "extra: string"),
     );
 }
 
-// ───────────────────────── method/accessor decorator (TS1241) ───────────────
+// ───────────────────── method/accessor decorator (TS1241) ───────────────
 
 #[test]
 fn ts1278_method_decorator_too_few_args() {
-    let diags = diagnostics_es(
-        r#"
+    let source = r#"
 function d(value: any, context: any, extra: string): any { return value; }
 class C { @d method() {} }
-"#,
-    );
+"#;
+    let diags = diagnostics_es(source);
     let primary = find(&diags, 1241).expect("expected TS1241");
-    assert_eq!(primary.related_information.len(), 1);
-    assert_eq!(primary.related_information[0].code, 1278);
+    assert_arity_chain(
+        primary,
+        1278,
+        "The runtime will invoke the decorator with 2 arguments, but the decorator expects 3.",
+        6210,
+        "An argument for 'extra' was not provided.",
+        offset_of(source, "extra: string"),
+    );
 }
 
-// ───────────────────────── legacy property decorator (TS1240) ───────────────
+// ───────────────────── legacy property decorator (TS1240) ───────────────
 
 #[test]
 fn ts1278_legacy_property_decorator_too_many_args() {
     // Legacy field decorators are invoked `(target, propertyKey)`; a
     // 1-parameter decorator overflows -> TS1278 "expects 1" (the "too many"
-    // shape, not "too few" -- proves the exact-vs-at-least split isn't keyed
-    // on which direction the mismatch runs).
+    // shape). A too-many failure supplies every declared parameter, so there
+    // is NO missing-argument pointer -- only the single TS1278 line.
     let diags = diagnostics_experimental(
         r#"
 function propDec(target: any) {}
@@ -202,27 +366,28 @@ class C {
     );
 }
 
-// ───────────────────────── parameter decorator (TS1239) ─────────────────────
+// ───────────────────── parameter decorator (TS1239) ─────────────────
 
 #[test]
 fn ts1278_parameter_decorator_too_few_args() {
     // Parameter decorators are always invoked with 3 args
     // (`target, propertyKey, parameterIndex`); a 4-required-param decorator
-    // underflows -> TS1278 "expects 4".
-    let diags = diagnostics_experimental(
-        r#"
+    // underflows -> TS1278 "expects 4" + TS6210 at the fourth parameter.
+    let source = r#"
 function paramDec(a: any, b: any, c: any, d: any) {}
 
 class C {
   m(@paramDec x: number) {}
 }
-"#,
-    );
+"#;
+    let diags = diagnostics_experimental(source);
     let primary = find(&diags, 1239).expect("expected TS1239");
-    assert_eq!(primary.related_information.len(), 1);
-    assert_eq!(primary.related_information[0].code, 1278);
-    assert_eq!(
-        primary.related_information[0].message_text,
-        "The runtime will invoke the decorator with 3 arguments, but the decorator expects 4."
+    assert_arity_chain(
+        primary,
+        1278,
+        "The runtime will invoke the decorator with 3 arguments, but the decorator expects 4.",
+        6210,
+        "An argument for 'd' was not provided.",
+        offset_of(source, "d: any"),
     );
 }


### PR DESCRIPTION
Closes the two related-information gaps tracked in #17104 on the
TS1238/1239/1240/1241 decorator signature-resolution family.

**Structural rule.** When a decorator's call resolution fails because too few
arguments are supplied (the fixed decorator calling convention cannot fill a
required parameter), tsc attaches — beneath the primary diagnostic and its
TS1278/TS1279 "runtime will invoke the decorator with N arguments" line — a
second, cross-location pointer at the first parameter left unsupplied:
`An argument for '{0}' was not provided.` (TS6210) for a named parameter,
`Arguments for the rest parameter '{0}' were not provided.` (TS6236) for a
variadic one, `An argument matching this binding pattern was not provided.`
(TS6211) for a destructured one. tsz emitted neither code anywhere. Now owned
by the checker's shared `emit_decorator_signature_error`
(`decorator_signature_checks.rs`), so every decorator kind — class (legacy +
ES), method, accessor, property, parameter — gains it uniformly. The pointer is
declined (rather than mis-anchored) when the decorator does not reference a
single locatable function-like declaration.

**ES class-decorator arity elaboration (§2).** `check_es_class_decorator_arity`
never called `resolve_call_with_checker_adapter`, so it had no `CallResult` and
emitted a bare TS1238 with no elaboration — the TS1278/TS1279 fix never reached
it. It now synthesizes the equivalent `ArgumentCountMismatch` from the shape's
own required-parameter/rest counts and routes through the shared helper,
matching the legacy path (`(value, context)` = 2 supplied args). Composes with
#17118's not-callable check, which still runs first.

Also flips a stale `ts1238_tests` case left by #17120: a zero-arity ES class
decorator (`@(() => {})`) reports the TS1329 call-it-first hint, not TS1238
(`isPotentiallyUncalledDecorator` fires — 0 declared params is fewer than the
convention supplies).

## Goal
Goal: hold

## Verification
- New/updated `ts1278_ts1279_decorator_arity_elaboration_tests` (13 cases):
  TS1278/TS1279 + TS6210/TS6236 across class (legacy + ES), method, field and
  parameter paths; the pointer anchors byte-for-byte at the missing parameter
  declaration; binder-name-varies, arrow-`const`, explicit-`this`-skip and
  too-many-args (no pointer) adjacent cases. `ts1238_tests` zero-arity case
  flipped to TS1329. All targeted decorator suites pass on the equivalent local
  base (`ts1278_ts1279…` 13/13, `ts1238_tests` 14/14).
- Anti-hardcoding: the pointer is driven by the decorator's declared parameter
  nodes (via binder symbol → declaration), not by any identifier/file-name
  literal; a renamed binder names its own parameter (covered by a test).
- Conformance-neutral by construction: TS6210/TS6236/TS6211 are cross-location
  `relatedInformation` and TS1278/TS1279 are message-chain links; the
  conformance harness compares only top-level diagnostic lines (indented
  related-info lines are skipped), and the pinned-tsc cache contains none of
  these codes, so the diagnostic **code sets** used for PASS/FAIL are unchanged.
  No emit/DTS surface is touched.
- Environment note: a disk-exhaustion fault in this cloud session blocked local
  `cargo`/`git` after the targeted runs above; the change was rebased onto
  current `main` (preserving #17118's `emit_class_decorator_not_callable`) and
  pushed via the Git API. Relying on this PR's `clippy` + `arch-size` gate for
  final compile/lint validation.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXgiPipfCyWmQBZa7mYfrG)_