### PR TITLE
fix(checker): complete class-decorator TS1238 elaboration — argument mismatch + ES call resolution

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -597,6 +597,9 @@ path = "tests/parameter_initializer_identifier_context_tests.rs"
 name = "decorator_method_tdz_tests"
 path = "tests/decorator_method_tdz_tests.rs"
 [[test]]
+name = "ts1238_class_decorator_signature_tests"
+path = "tests/ts1238_class_decorator_signature_tests.rs"
+[[test]]
 name = "ts1238_generic_decorator_tests"
 path = "tests/ts1238_generic_decorator_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking/class.rs
+++ b/crates/tsz-checker/src/state/state_checking/class.rs
@@ -257,11 +257,17 @@ impl<'a> CheckerState<'a> {
         // TS1042: async modifier cannot be used on class declarations
         self.check_async_modifier_on_declaration(&class.modifiers);
 
-        let mut experimental_class_decorators = Vec::new();
+        let mut class_decorators = Vec::new();
 
         // Evaluate class-level decorator expressions to trigger definite-assignment
         // checks (TS2454) and other diagnostics. tsc evaluates decorator expressions
         // even if the class has other errors.
+        //
+        // The TS1238 call-signature validation itself is deferred until after the
+        // class value side has been refreshed below: it needs the class
+        // constructor type (both the legacy `decorator(classConstructor)` call and
+        // the ES `ClassDecoratorContext<typeof C>` context argument), and doing it
+        // here can see a provisional/re-entrant constructor shape and miss TS1238.
         if let Some(ref modifiers) = class.modifiers {
             for &mod_idx in &modifiers.nodes {
                 if let Some(mod_node) = self.ctx.arena.get(mod_idx)
@@ -272,24 +278,7 @@ impl<'a> CheckerState<'a> {
                     self.check_grammar_decorator(decorator.expression);
 
                     let decorator_type = self.compute_type_of_node(decorator.expression);
-
-                    // TS1238: Validate class decorator call signature.
-                    if self.ctx.compiler_options.experimental_decorators {
-                        // Experimental class decorators receive the class constructor
-                        // value. Save the expression type and validate it after the
-                        // class value side has been refreshed; doing it here can see a
-                        // provisional/re-entrant constructor shape and miss TS1238.
-                        experimental_class_decorators.push((mod_idx, decorator_type));
-                    } else {
-                        // ES decorators: tsc anchors TS1238 at the whole decorator
-                        // (including `@`) when the factory requires too many args, but
-                        // at the expression alone when the factory has zero parameters.
-                        self.check_es_class_decorator_arity(
-                            mod_idx,
-                            decorator.expression,
-                            decorator_type,
-                        );
-                    }
+                    class_decorators.push((mod_idx, decorator.expression, decorator_type));
                 }
             }
         }
@@ -1008,17 +997,18 @@ impl<'a> CheckerState<'a> {
             let _ = self.get_type_of_symbol(sym_id);
         }
 
-        for (decorator_node, decorator_type) in experimental_class_decorators {
-            // Anchor selection (bare identifier vs. call-expression decorator
-            // does NOT matter; tsc anchors both the same way) lives in
-            // `check_class_decorator_call_signature` itself, mirroring the
-            // `decorator_failure_anchor` rule the member/parameter decorator
-            // paths already use.
-            self.check_class_decorator_call_signature(
+        let legacy = self.ctx.compiler_options.experimental_decorators;
+        for (decorator_node, decorator_expr, decorator_type) in class_decorators {
+            // TS1238: validate the class decorator call signature. The anchor
+            // (expression vs. whole decorator) is chosen per failure kind
+            // inside the handler, mirroring tsc's call-node arity anchoring.
+            self.check_class_decorator_signature(
                 decorator_node,
+                decorator_expr,
                 decorator_type,
                 stmt_idx,
                 class,
+                legacy,
             );
         }
     }

--- a/crates/tsz-checker/src/state/state_checking/class_decorators.rs
+++ b/crates/tsz-checker/src/state/state_checking/class_decorators.rs
@@ -2,14 +2,14 @@
 //! accessor-pair decorator rules, ES decorator call-signature/arity checks, and
 //! the decorator grammar check.
 //!
-//! Extracted verbatim from `class.rs` to keep that module under the 2000-LOC
-//! architecture cap; behavior is unchanged. The four helpers called from the
-//! class-declaration/expression paths in `class.rs`
-//! (`first_decorator_in_modifiers`, `check_decorators_on_accessor_pairs`,
-//! `check_class_decorator_call_signature`, `check_es_class_decorator_arity`)
+//! Extracted from `class.rs` to keep that module under the 2000-LOC
+//! architecture cap. The helpers called from the class-declaration path in
+//! `class.rs` (`first_decorator_in_modifiers`,
+//! `check_decorators_on_accessor_pairs`, `check_class_decorator_signature`)
 //! are `pub(super)` so those sibling-module callers keep reaching them; their
 //! visibility was widened only to permit the file split.
 
+use crate::query_boundaries::checkers::decorators as decorator_query;
 use crate::query_boundaries::class_type as class_query;
 use crate::state::CheckerState;
 use rustc_hash::FxHashMap;
@@ -197,26 +197,46 @@ impl<'a> CheckerState<'a> {
         })
     }
 
-    /// TS1238: Check that a class decorator expression has a compatible call signature.
+    /// TS1238: check that a class decorator resolves as a call
+    /// `decorator(value[, context])`, emitting "Unable to resolve signature of
+    /// class decorator when called as an expression." with tsc's full
+    /// elaboration chain on failure.
     ///
-    /// For experimental decorators, the decorator is called as `decoratorExpr(classConstructor)`.
-    /// If the decorator type has no call signatures, or if call resolution against the class
-    /// constructor type fails, emit TS1238.
-    pub(super) fn check_class_decorator_call_signature(
+    /// This is the single owner for both decorator modes:
+    ///
+    /// - **`--experimentalDecorators` (legacy):** the decorator is invoked
+    ///   `decorator(classConstructor)`, and the resolved return type is
+    ///   additionally checked against `void | typeof C` (TS1270).
+    /// - **ES (TC39 stage-3):** the decorator is invoked
+    ///   `decorator(value, context)` where `value: typeof C` and
+    ///   `context: ClassDecoratorContext<typeof C>`, truncated to the
+    ///   decorator's own declared arity (tsc's `getDecoratorArgumentCount`).
+    ///
+    /// A bare-reference zero-argument factory used uncalled (`@d`, `@ns.d`)
+    /// draws the TS1329 "did you mean to call it first" hint; a
+    /// parenthesized/inline factory (`@(() => {})`) instead falls through to
+    /// the arity failure below, matching tsc's `isPotentiallyUncalledDecorator`.
+    /// A callee with no call signatures at all (a non-function value, or a
+    /// class with only construct signatures) reports the not-callable chain
+    /// directly, exactly as tsc's `resolveDecorator` does before it ever
+    /// reaches `resolveCall`.
+    pub(super) fn check_class_decorator_signature(
         &mut self,
         decorator_node: NodeIndex,
+        decorator_expression: NodeIndex,
         decorator_type: TypeId,
         class_idx: NodeIndex,
         class: &tsz_parser::parser::node::ClassData,
+        legacy: bool,
     ) {
-        use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
-        use crate::query_boundaries::common::call_signatures_for_type;
+        use crate::query_boundaries::common::{CallResult, call_signatures_for_type};
 
-        // Skip validation for error types or any — these won't produce meaningful diagnostics
-        if decorator_type == TypeId::ERROR
-            || decorator_type == TypeId::ANY
-            || decorator_type == TypeId::UNKNOWN
-        {
+        // Skip validation for error/any/unknown — these won't produce
+        // meaningful diagnostics.
+        if matches!(
+            decorator_type,
+            TypeId::ERROR | TypeId::ANY | TypeId::UNKNOWN
+        ) {
             return;
         }
 
@@ -224,9 +244,7 @@ impl<'a> CheckerState<'a> {
         // type queries can see the underlying type shape.
         self.ensure_relation_input_ready(decorator_type);
         let resolved = self.evaluate_type_for_assignability(decorator_type);
-
-        // After evaluation, any/unknown/error → skip
-        if resolved == TypeId::ERROR || resolved == TypeId::ANY || resolved == TypeId::UNKNOWN {
+        if matches!(resolved, TypeId::ERROR | TypeId::ANY | TypeId::UNKNOWN) {
             return;
         }
 
@@ -238,69 +256,106 @@ impl<'a> CheckerState<'a> {
             return;
         };
 
-        // A decorator whose every call signature takes zero parameters is
-        // the "forgot to call the factory" shape (`@d` instead of `@d()`);
-        // tsc reports only the TS1329 hint there, not TS1238 — mirroring the
-        // member/parameter decorator paths in `decorator_signature_checks.rs`.
-        let decorator_expr = self.decorator_expression_anchor(decorator_node);
-        if self.decorator_has_zero_arg_factory_shape(decorator_expr, resolved, decorator_node) {
+        // TS1329: a bare-reference zero-argument factory used without its
+        // call. Parenthesized/inline factories are excluded and fall through
+        // to the arity/signature failure below.
+        if self.decorator_expression_is_reference(decorator_expression)
+            && self.decorator_has_zero_arg_factory_shape(
+                decorator_expression,
+                resolved,
+                decorator_node,
+            )
+        {
             return;
         }
 
-        // Check if the decorator type is callable.
-        // TypeData::Function has a single call signature (function declarations/expressions).
-        // TypeData::Callable has overloaded call/construct signatures (interfaces).
+        // No call signatures at all (a non-function value, or a class used as
+        // a decorator — construct signatures but no call signatures). tsc
+        // reports the not-callable chain directly from `resolveDecorator`,
+        // before it ever reaches `resolveCall`, and anchors it at the
+        // decorator expression.
         let has_call_signatures = class_query::has_function_shape(self.ctx.types, resolved)
             || call_signatures_for_type(self.ctx.types, resolved)
                 .is_some_and(|sigs| !sigs.is_empty());
-
         if !has_call_signatures {
-            // No call signatures at all (e.g., a class used as decorator — has construct
-            // signatures but no call signatures, or a bare primitive). tsc attaches the
-            // "This expression is not callable." / "Type 'X' has no call signatures."
-            // chain beneath TS1238 (oracle-verified, typescript@7.0.2).
-            let anchor = self.decorator_failure_anchor(decorator_node, resolved, 1);
-            self.emit_class_decorator_not_callable(anchor, resolved);
+            self.emit_class_decorator_not_callable(
+                self.decorator_expression_anchor(decorator_node),
+                resolved,
+            );
             return;
         }
 
-        // Has call signatures — try to resolve the call with the class constructor type.
-        // resolve_call handles both Function and Callable types internally.
-        // If resolution fails (type mismatch, arity error), emit TS1238.
         let class_constructor_type = self.get_class_constructor_type(class_idx, class);
         if class_constructor_type == TypeId::ERROR {
             return;
         }
 
-        let (result, _, _) = self.resolve_call_with_checker_adapter(
-            resolved,
-            &[class_constructor_type],
-            false,
-            None,
-            None,
-        );
+        let args = self.class_decorator_argument_types(resolved, class_constructor_type, legacy);
+        let (result, _, _) =
+            self.resolve_call_with_checker_adapter(resolved, &args, false, None, None);
 
-        let crate::query_boundaries::common::CallResult::Success(return_type) = &result else {
-            let anchor = self.decorator_failure_anchor(decorator_node, resolved, 1);
-            self.emit_decorator_signature_error(
-                anchor,
-                diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
-                diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
-                &result,
-            );
+        let CallResult::Success(return_type) = &result else {
+            self.emit_class_decorator_signature_error(decorator_node, &result, resolved);
             return;
         };
 
-        let return_type = self.evaluate_type_for_assignability(*return_type);
+        if legacy {
+            self.check_legacy_class_decorator_return_type(
+                decorator_node,
+                class_constructor_type,
+                *return_type,
+            );
+        }
+    }
+
+    /// The runtime argument list a class decorator is invoked with:
+    /// `[classConstructor]` under `--experimentalDecorators`, or the ES
+    /// `[value, ClassDecoratorContext<typeof C>]` truncated to the decorator's
+    /// own declared arity (tsc's `getDecoratorArgumentCount`, so a
+    /// single-parameter ES decorator receives only `value`).
+    fn class_decorator_argument_types(
+        &mut self,
+        resolved: TypeId,
+        class_constructor_type: TypeId,
+        legacy: bool,
+    ) -> Vec<TypeId> {
+        if legacy {
+            return vec![class_constructor_type];
+        }
+        // A single-parameter ES decorator receives only `value`, so skip the
+        // `ClassDecoratorContext<typeof C>` lib lookup entirely when the
+        // context argument would be truncated away.
+        if self.es_member_decorator_argument_count(resolved) <= 1 {
+            return vec![class_constructor_type];
+        }
+        let context = self
+            .resolve_decorator_context_type("ClassDecoratorContext", vec![class_constructor_type])
+            .unwrap_or(TypeId::OBJECT);
+        vec![class_constructor_type, context]
+    }
+
+    /// TS1270 for legacy class decorators: the resolved return type must be
+    /// assignable to `void | typeof C`. `any`/`unknown`/error short-circuit.
+    fn check_legacy_class_decorator_return_type(
+        &mut self,
+        decorator_node: NodeIndex,
+        class_constructor_type: TypeId,
+        return_type: TypeId,
+    ) {
+        use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+
+        let return_type = self.evaluate_type_for_assignability(return_type);
         if matches!(return_type, TypeId::ERROR | TypeId::ANY | TypeId::UNKNOWN) {
             return;
         }
 
-        let expected_return = self
-            .ctx
-            .types
-            .factory()
-            .union2(TypeId::VOID, class_constructor_type);
+        // The legacy class decorator may return `void` or a replacement
+        // constructor (`typeof C`); reuse the shared `void | replacement`
+        // builder rather than open-coding the union.
+        let expected_return = decorator_query::decorator_void_or_replacement_type(
+            self.ctx.types,
+            class_constructor_type,
+        );
         if !self
             .return_relation_outcome(return_type, expected_return)
             .related
@@ -311,104 +366,11 @@ impl<'a> CheckerState<'a> {
                 diagnostic_messages::DECORATOR_FUNCTION_RETURN_TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                 &[&return_str, &expected_str],
             );
-            let anchor = self.decorator_failure_anchor(decorator_node, resolved, 1);
             self.error_at_node(
-                anchor,
+                decorator_node,
                 &message,
                 diagnostic_codes::DECORATOR_FUNCTION_RETURN_TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
             );
-        }
-    }
-
-    /// TS1238/TS1329 for ES decorators: check that a class decorator's arity
-    /// is compatible with the runtime call.
-    ///
-    /// ES decorators receive `(value, context)` — at most 2 arguments. A
-    /// zero-parameter decorator is the "forgot to call the factory" shape
-    /// (TS1329, see `decorator_has_zero_arg_factory_shape`); one requiring
-    /// more than 2 required parameters can never be satisfied (TS1238).
-    pub(super) fn check_es_class_decorator_arity(
-        &mut self,
-        decorator_node: NodeIndex,
-        decorator_expression: NodeIndex,
-        decorator_type: TypeId,
-    ) {
-        use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-
-        if decorator_type == TypeId::ERROR
-            || decorator_type == TypeId::ANY
-            || decorator_type == TypeId::UNKNOWN
-        {
-            return;
-        }
-
-        let resolved = self.evaluate_type_for_assignability(decorator_type);
-        if resolved == TypeId::ERROR || resolved == TypeId::ANY || resolved == TypeId::UNKNOWN {
-            return;
-        }
-
-        // Mirror tsc's `isUntypedFunctionCall`: a decorator typed as the
-        // global `Function` interface has no explicit call signatures but is
-        // still callable (see `check_class_decorator_call_signature`, whose
-        // legacy-mode counterpart of this same check applies the identical
-        // fallback).
-        let Some(resolved) = self.prepare_decorator_callee(resolved) else {
-            return;
-        };
-
-        // A decorator whose every call signature takes zero parameters is
-        // the "forgot to call the factory" shape (`@d` instead of `@d()`);
-        // tsc reports only the TS1329 hint there, not TS1238 — same rule as
-        // the legacy (`experimentalDecorators`) class-decorator path above.
-        // A type with no call signature at all (the not-callable case just
-        // below) has no signatures to inspect here, so this is a no-op for
-        // it and falls through correctly.
-        if self.decorator_has_zero_arg_factory_shape(decorator_expression, resolved, decorator_node)
-        {
-            return;
-        }
-
-        // No call signature at all (bare primitive, a class used as a
-        // decorator, ...): tsc's TS1238 "not callable" chain fires
-        // identically here as it does under `--experimentalDecorators`
-        // (oracle-verified, typescript@7.0.2). Previously this whole
-        // function only inspected `function_shape`, so any decorator type
-        // without a single-signature function shape (a primitive, a class,
-        // an overloaded callable) silently passed arity validation with no
-        // diagnostic at all.
-        let has_call_signatures =
-            crate::query_boundaries::class_type::has_function_shape(self.ctx.types, resolved)
-                || crate::query_boundaries::common::call_signatures_for_type(
-                    self.ctx.types,
-                    resolved,
-                )
-                .is_some_and(|sigs| !sigs.is_empty());
-        if !has_call_signatures {
-            self.emit_class_decorator_not_callable(decorator_expression, resolved);
-            return;
-        }
-
-        // Check the function shape for required parameter count
-        if let Some(shape) =
-            crate::query_boundaries::class_type::function_shape(self.ctx.types, resolved)
-        {
-            let required_params = shape
-                .params
-                .iter()
-                .filter(|p| !p.optional && !p.rest)
-                .count();
-            // ES decorators are invoked with `(value, context)`. When the
-            // factory requires more than two parameters, the call cannot
-            // supply them; tsc anchors the error at the whole decorator
-            // (including `@`). The zero-parameter case is handled above as
-            // the TS1329 decorator-factory hint, not this arity failure.
-            if required_params > 2 {
-                self.error_at_node(
-                    decorator_node,
-                    diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
-                    diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
-                );
-            }
         }
     }
 

--- a/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
@@ -72,6 +72,24 @@ impl<'a> CheckerState<'a> {
         )]
     }
 
+    /// Emit `message`/`code` at `anchor`, attaching `related` as an
+    /// elaboration chain only when it is non-empty. Centralizes the
+    /// "diagnostic with optional related information" branch shared by every
+    /// decorator signature-error emitter.
+    fn error_at_node_maybe_related(
+        &mut self,
+        anchor: NodeIndex,
+        message: &str,
+        code: u32,
+        related: Vec<DiagnosticRelatedInformation>,
+    ) {
+        if related.is_empty() {
+            self.error_at_node(anchor, message, code);
+        } else {
+            self.error_at_node_with_related(anchor, message, code, related);
+        }
+    }
+
     /// Emit a decorator signature-resolution error, attaching
     /// [`Self::decorator_arity_related_info`] when `result` is an
     /// argument-count mismatch.
@@ -83,30 +101,27 @@ impl<'a> CheckerState<'a> {
         result: &CallResult,
     ) {
         let related = self.decorator_arity_related_info(result);
-        if related.is_empty() {
-            self.error_at_node(anchor, message, code);
-        } else {
-            self.error_at_node_with_related(anchor, message, code, related);
-        }
+        self.error_at_node_maybe_related(anchor, message, code, related);
     }
 
-    /// tsc's TS1238 "not callable" shape for a class decorator whose resolved
-    /// type carries no call signature at all — a bare primitive, a class
-    /// (construct signatures only, no call signatures), or any other
-    /// non-callable value. `This expression is not callable.` (TS2349) is
-    /// attached as an elaboration chain link beneath TS1238, with `Type 'X'
-    /// has no call signatures.` (TS2757) nested one level deeper. Oracle-
-    /// verified (`typescript@7.0.2`) to render identically under
-    /// `--experimentalDecorators` and ES (TC39 stage-3) class decorators;
-    /// shared by both call sites in `class_decorators.rs`. Chain-link
-    /// entries carry no real position (matching
-    /// [`Self::decorator_arity_related_info`]'s `(0, 0)` convention) since
-    /// `RelatedInformationKind::ChainLink` renders by depth, not location.
-    pub(crate) fn emit_class_decorator_not_callable(
+    /// Related-information chain for a decorator whose callee has no call
+    /// signatures, mirroring tsc's `invocationErrorDetails` beneath the
+    /// TS1238/TS1239/TS1240/TS1241 head:
+    ///
+    /// ```text
+    ///   This expression is not callable.
+    ///     Type 'X' has no call signatures.
+    /// ```
+    ///
+    /// The callee is rendered as its apparent type, exactly like tsc's
+    /// `typeToString(getApparentType(type))` (`number` -> `Number`,
+    /// `typeof D` -> `typeof D`). When the apparent-type note is unavailable
+    /// (`any`/error), only the "not callable" headline is returned so the
+    /// primary diagnostic still gains its first elaboration line.
+    fn decorator_not_callable_related_info(
         &mut self,
-        anchor: NodeIndex,
         resolved: TypeId,
-    ) {
+    ) -> Vec<DiagnosticRelatedInformation> {
         let mut related = vec![Diagnostic::related_message(
             diagnostic_codes::THIS_EXPRESSION_IS_NOT_CALLABLE,
             self.ctx.file_name.clone(),
@@ -120,15 +135,161 @@ impl<'a> CheckerState<'a> {
             0,
             0,
         ) {
+            // tsc nests the "has no call signatures" note one indent level
+            // deeper than the "not callable" headline.
             detail.depth = 1;
             related.push(detail);
         }
-        self.error_at_node_with_related(
+        related
+    }
+
+    /// Related-information line for a decorator whose call fails because an
+    /// argument type is not assignable to the corresponding parameter: tsc's
+    /// `TS2345`-shaped "Argument of type '{0}' is not assignable to parameter
+    /// of type '{1}'." chained beneath the primary TS1238/… head. Returns
+    /// empty for every other [`CallResult`] shape so the arity and
+    /// not-callable paths keep ownership of theirs.
+    fn decorator_argument_mismatch_related_info(
+        &mut self,
+        result: &CallResult,
+    ) -> Vec<DiagnosticRelatedInformation> {
+        let &CallResult::ArgumentTypeMismatch {
+            expected, actual, ..
+        } = result
+        else {
+            return Vec::new();
+        };
+        let actual_str = self.format_type_diagnostic(actual);
+        let expected_str = self.format_type_diagnostic(expected);
+        vec![Diagnostic::related_message(
+            diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE,
+            self.ctx.file_name.clone(),
+            0,
+            0,
+            format_message(
+                diagnostic_messages::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE,
+                &[&actual_str, &expected_str],
+            ),
+        )]
+    }
+
+    /// Emit a class-decorator signature-resolution failure (TS1238) with the
+    /// full tsc elaboration for the specific [`CallResult`] shape:
+    ///
+    /// - argument-count mismatch -> TS1278/TS1279 ("The runtime will invoke
+    ///   the decorator with {1} arguments, but the decorator expects {0}[ at
+    ///   least].");
+    /// - non-callable callee -> the not-callable / no-call-signatures chain;
+    /// - argument type mismatch -> the TS2345 "not assignable" line.
+    ///
+    /// Any other shape falls back to the bare primary message. The class-
+    /// decorator sites feed the *real* value/context argument types
+    /// (`typeof C`, `ClassDecoratorContext<typeof C>`), so the rendered
+    /// argument-mismatch type matches tsc exactly — unlike the legacy member
+    /// paths, which supply synthetic placeholders and therefore keep using
+    /// [`Self::emit_decorator_signature_error`] (arity elaboration only).
+    pub(crate) fn emit_class_decorator_signature_error(
+        &mut self,
+        decorator_node: NodeIndex,
+        result: &CallResult,
+        resolved: TypeId,
+    ) {
+        let anchor = self.class_decorator_failure_anchor(decorator_node, result);
+        // Each failure shape owns exactly one elaboration; dispatch directly
+        // rather than probing each helper in turn.
+        let related = match result {
+            CallResult::ArgumentCountMismatch { .. }
+            | CallResult::OverloadArgumentCountMismatch { .. } => {
+                self.decorator_arity_related_info(result)
+            }
+            CallResult::ArgumentTypeMismatch { .. } => {
+                self.decorator_argument_mismatch_related_info(result)
+            }
+            CallResult::NotCallable { .. } => self.decorator_not_callable_related_info(resolved),
+            _ => Vec::new(),
+        };
+        self.error_at_node_maybe_related(
             anchor,
             diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
             diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
             related,
         );
+    }
+
+    /// The anchor tsc uses for a class-decorator call failure, keyed on the
+    /// failure kind rather than a parameter-count heuristic: the whole
+    /// decorator (spanning the leading `@`) only when the decorator was given
+    /// *too few* arguments (`decorator(classConstructor[, context])` cannot
+    /// supply a required parameter), and the decorator expression alone for a
+    /// too-many-arguments count, an argument type mismatch, or a non-callable
+    /// callee. This mirrors tsc's call-node anchoring and, unlike the
+    /// parameter-count heuristic used for member decorators, is not fooled by
+    /// a rest parameter inflating the declared count on a type-mismatch
+    /// failure.
+    fn class_decorator_failure_anchor(
+        &self,
+        decorator_node: NodeIndex,
+        result: &CallResult,
+    ) -> NodeIndex {
+        let too_few = match result {
+            CallResult::ArgumentCountMismatch {
+                expected_min,
+                actual,
+                ..
+            } => actual < expected_min,
+            CallResult::OverloadArgumentCountMismatch {
+                actual,
+                expected_low,
+                ..
+            } => actual < expected_low,
+            _ => false,
+        };
+        if too_few {
+            decorator_node
+        } else {
+            self.decorator_expression_anchor(decorator_node)
+        }
+    }
+
+    /// Build the not-callable elaboration chain for a class decorator whose
+    /// callee has no call signatures at all (so the call is never resolved —
+    /// tsc reports this directly from `resolveDecorator`, not through
+    /// `resolveCall`). Emits the primary TS1238 anchored at `anchor` with the
+    /// "This expression is not callable." / "Type 'X' has no call signatures."
+    /// chain beneath it.
+    pub(crate) fn emit_class_decorator_not_callable(
+        &mut self,
+        anchor: NodeIndex,
+        resolved: TypeId,
+    ) {
+        let related = self.decorator_not_callable_related_info(resolved);
+        self.error_at_node_maybe_related(
+            anchor,
+            diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
+            diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
+            related,
+        );
+    }
+
+    /// Whether a decorator expression is a bare referenceable entity — an
+    /// identifier or a (possibly nested) property-access chain — rather than a
+    /// parenthesized or inline function expression.
+    ///
+    /// Observed tsc behavior (oracle-verified against `typescript@7.0.2`): the
+    /// TS1329 "did you mean to call it first" hint fires only for
+    /// referenceable decorators (`@d`, `@ns.d`), where writing `@d()` is a
+    /// meaningful suggestion. A parenthesized/inline factory (`@(() => {})`,
+    /// `@(d)`) instead reports the plain arity/signature failure. The class
+    /// path gates the shared zero-argument-factory check
+    /// ([`Self::decorator_has_zero_arg_factory_shape`]) on this predicate; the
+    /// member/parameter paths do not front-guard it, so this deliberately does
+    /// not attempt to unify their (separate) handling.
+    pub(crate) fn decorator_expression_is_reference(&self, expr: NodeIndex) -> bool {
+        use tsz_parser::parser::syntax_kind_ext;
+        self.ctx.arena.get(expr).is_some_and(|node| {
+            node.kind == tsz_scanner::SyntaxKind::Identifier as u16
+                || node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+        })
     }
 
     /// tsc anchors member/parameter decorator failures (TS1239/TS1240/TS1241)
@@ -147,9 +308,7 @@ impl<'a> CheckerState<'a> {
             .unwrap_or(decorator_node)
     }
 
-    /// Shared with the class-decorator TS1238 path in `class_decorators.rs`,
-    /// which anchors legacy class-decorator call failures the same way.
-    pub(crate) fn decorator_failure_anchor(
+    fn decorator_failure_anchor(
         &self,
         decorator_node: NodeIndex,
         resolved: TypeId,
@@ -365,7 +524,7 @@ impl<'a> CheckerState<'a> {
     /// fixed synthetic argument list cannot reproduce, so the longer 2-argument
     /// form is supplied rather than risk dropping an argument a wider overload
     /// requires.
-    fn es_member_decorator_argument_count(&self, decorator_type: TypeId) -> usize {
+    pub(crate) fn es_member_decorator_argument_count(&self, decorator_type: TypeId) -> usize {
         // `min(max(paramCount, 1), 2)` for a single declared signature; an
         // unknown shape or an overload set falls back to the full two-argument
         // call so exotic callees behave as they did before.
@@ -523,8 +682,7 @@ impl<'a> CheckerState<'a> {
     /// hint ("did you mean to call it") instead of the generic
     /// method/property-decorator signature failure. This mirrors tsc's
     /// `isPotentiallyUncalledDecorator` for the common zero-parameter case and
-    /// applies uniformly to method, accessor, field, and (see
-    /// `class_decorators.rs`) class decorators.
+    /// applies uniformly to method, accessor, and field decorators.
     pub(crate) fn decorator_has_zero_arg_factory_shape(
         &mut self,
         decorator_expr: NodeIndex,
@@ -613,7 +771,11 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    fn resolve_decorator_context_type(&mut self, name: &str, args: Vec<TypeId>) -> Option<TypeId> {
+    pub(crate) fn resolve_decorator_context_type(
+        &mut self,
+        name: &str,
+        args: Vec<TypeId>,
+    ) -> Option<TypeId> {
         let lib_binders = self.get_lib_binders();
         let sym_id = self
             .ctx

--- a/crates/tsz-checker/tests/ts1238_class_decorator_signature_tests.rs
+++ b/crates/tsz-checker/tests/ts1238_class_decorator_signature_tests.rs
@@ -1,0 +1,249 @@
+//! TS1238 class-decorator signature resolution across both decorator modes
+//! (issue #17108).
+//!
+//! Structural rule: a class decorator is resolved as the call
+//! `decorator(value[, context])` — `decorator(classConstructor)` under
+//! `--experimentalDecorators`, and `decorator(typeof C,
+//! ClassDecoratorContext<typeof C>)` (truncated to the decorator's declared
+//! arity) in TC39 stage-3 ES mode. When that resolution fails, tsc reports
+//! TS1238 ("Unable to resolve signature of class decorator when called as an
+//! expression.") with an elaboration keyed on the failure kind:
+//!
+//! - non-callable callee -> "This expression is not callable." /
+//!   "Type 'X' has no call signatures.";
+//! - argument type mismatch -> the TS2345 "Argument of type X is not
+//!   assignable to parameter of type Y." line;
+//! - too few / too many arguments -> the TS1278/TS1279 arity line.
+//!
+//! A bare-reference zero-argument factory used uncalled (`@d`, `@ns.d`) draws
+//! TS1329 instead; a parenthesized/inline factory falls through to the arity
+//! failure.
+//!
+//! tsz previously (a) dropped the diagnostic *entirely* in ES mode for
+//! non-arity failures, and (b) emitted only the bare TS1238 (no elaboration)
+//! under `--experimentalDecorators`. Oracle-verified against pinned
+//! `typescript@7.0.2` in both modes.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_source;
+
+fn es(source: &str) -> Vec<Diagnostic> {
+    check_source(source, "test.ts", CheckerOptions::default())
+}
+
+fn legacy(source: &str) -> Vec<Diagnostic> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            experimental_decorators: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn find(diags: &[Diagnostic], code: u32) -> Option<&Diagnostic> {
+    diags.iter().find(|d| d.code == code)
+}
+
+fn codes(diags: &[Diagnostic]) -> Vec<u32> {
+    diags.iter().map(|d| d.code).collect()
+}
+
+// ───────────────────────── ES mode: non-arity failures ──────────────────────
+//
+// These were the headline #17108 symptom: nothing at all was emitted.
+
+#[test]
+fn es_non_callable_value_emits_ts1238_with_chain() {
+    // A non-function value used as an ES class decorator.
+    let diags = es("const deco = 1;\n@deco\nclass C {}\n");
+    let primary = find(&diags, 1238).expect("expected TS1238 in ES mode");
+    assert_eq!(primary.related_information.len(), 2);
+    assert_eq!(primary.related_information[0].code, 2349);
+    assert_eq!(
+        primary.related_information[0].message_text,
+        "This expression is not callable."
+    );
+    assert_eq!(primary.related_information[1].code, 2757);
+    assert_eq!(primary.related_information[1].depth, 1);
+}
+
+#[test]
+fn es_argument_type_mismatch_emits_ts1238_with_argument_line() {
+    // A rest parameter must not mask the argument type mismatch: `value`
+    // (`typeof C`) is not assignable to the `string` first parameter.
+    let diags = es("function deco(a: string, b: string, ...r: string[]) {}\n@deco\nclass C {}\n");
+    let primary = find(&diags, 1238).expect("expected TS1238 in ES mode");
+    assert_eq!(primary.related_information.len(), 1);
+    assert_eq!(primary.related_information[0].code, 2345);
+    assert_eq!(
+        primary.related_information[0].message_text,
+        "Argument of type 'typeof C' is not assignable to parameter of type 'string'."
+    );
+}
+
+#[test]
+fn es_second_argument_is_checked_against_context_parameter() {
+    // The ES decorator receives a *second* `context` argument, so a `number`
+    // second parameter — which the first argument (`typeof C`) satisfies —
+    // still fails on the context argument. (The full lib renders the context
+    // as `ClassDecoratorContext<typeof C>`, oracle-verified; the reduced
+    // unit-test lib falls back to `{}`, so this asserts the stable target
+    // parameter type rather than the context type's rendered name.)
+    let diags = es("function deco(a: typeof C, b: number) {}\n@deco\nclass C {}\n");
+    let primary = find(&diags, 1238).expect("expected TS1238 in ES mode");
+    assert_eq!(primary.related_information.len(), 1);
+    assert_eq!(primary.related_information[0].code, 2345);
+    assert!(
+        primary.related_information[0]
+            .message_text
+            .ends_with("is not assignable to parameter of type 'number'."),
+        "expected the context argument to fail against the number parameter, got: {}",
+        primary.related_information[0].message_text
+    );
+}
+
+#[test]
+fn es_class_used_as_decorator_is_not_callable() {
+    // A class has construct signatures but no call signatures.
+    let diags = es("class Deco {}\n@Deco\nclass C {}\n");
+    let primary = find(&diags, 1238).expect("expected TS1238 in ES mode");
+    assert_eq!(primary.related_information.len(), 2);
+    assert_eq!(primary.related_information[0].code, 2349);
+    assert_eq!(primary.related_information[1].code, 2757);
+}
+
+// ───────────────────────── ES mode: arity vs TS1329 ─────────────────────────
+
+#[test]
+fn es_bare_reference_zero_arg_factory_is_ts1329_not_ts1238() {
+    // A bare-reference zero-parameter factory draws the "did you mean to call
+    // it first" hint, not the arity TS1238.
+    let diags = es("function deco() {}\n@deco\nclass C {}\n");
+    assert!(codes(&diags).contains(&1329), "got: {:?}", codes(&diags));
+    assert!(!codes(&diags).contains(&1238), "got: {:?}", codes(&diags));
+}
+
+#[test]
+fn es_property_access_zero_arg_factory_is_ts1329() {
+    // The reference form covers property-access chains too (`@ns.deco`).
+    let diags = es("const ns = { deco: () => {} };\n@ns.deco\nclass C {}\n");
+    assert!(codes(&diags).contains(&1329), "got: {:?}", codes(&diags));
+    assert!(!codes(&diags).contains(&1238), "got: {:?}", codes(&diags));
+}
+
+#[test]
+fn es_parenthesized_zero_arg_factory_is_ts1238_not_ts1329() {
+    // A parenthesized/inline factory is NOT a bare reference, so tsc reports
+    // the arity TS1238 rather than the TS1329 call-it-first hint.
+    let diags = es("@(() => {})\nclass C {}\n");
+    assert!(codes(&diags).contains(&1238), "got: {:?}", codes(&diags));
+    assert!(!codes(&diags).contains(&1329), "got: {:?}", codes(&diags));
+}
+
+#[test]
+fn es_too_many_required_params_emits_ts1238_arity() {
+    // Three required parameters cannot be satisfied by the two-argument ES
+    // decorator ABI.
+    let diags = es("function deco(a: any, b: any, c: any) {}\n@deco\nclass C {}\n");
+    let primary = find(&diags, 1238).expect("expected TS1238 in ES mode");
+    assert_eq!(primary.related_information.len(), 1);
+    assert_eq!(primary.related_information[0].code, 1278);
+    assert_eq!(
+        primary.related_information[0].message_text,
+        "The runtime will invoke the decorator with 2 arguments, but the decorator expects 3."
+    );
+}
+
+#[test]
+fn es_one_or_two_param_decorator_is_accepted() {
+    // 1- and 2-parameter `any` decorators satisfy the ES ABI with no error.
+    for source in [
+        "function deco(a: any) {}\n@deco\nclass C {}\n",
+        "function deco(a: any, b: any) {}\n@deco\nclass C {}\n",
+    ] {
+        let diags = es(source);
+        assert!(
+            !codes(&diags).contains(&1238) && !codes(&diags).contains(&1329),
+            "expected no decorator-signature diagnostic for {source:?}, got: {:?}",
+            codes(&diags)
+        );
+    }
+}
+
+// ───────────────────────── legacy mode: non-arity failures ──────────────────
+
+#[test]
+fn legacy_non_callable_value_emits_ts1238_with_chain() {
+    let diags = legacy("const deco = 1;\n@deco\nclass C {}\n");
+    let primary = find(&diags, 1238).expect("expected TS1238 (legacy)");
+    assert_eq!(primary.related_information.len(), 2);
+    assert_eq!(primary.related_information[0].code, 2349);
+    assert_eq!(primary.related_information[1].code, 2757);
+    assert_eq!(primary.related_information[1].depth, 1);
+}
+
+#[test]
+fn legacy_argument_type_mismatch_emits_ts1238_with_argument_line() {
+    let diags = legacy("function deco(target: string) {}\n@deco\nclass C {}\n");
+    let primary = find(&diags, 1238).expect("expected TS1238 (legacy)");
+    assert_eq!(primary.related_information.len(), 1);
+    assert_eq!(primary.related_information[0].code, 2345);
+    assert_eq!(
+        primary.related_information[0].message_text,
+        "Argument of type 'typeof C' is not assignable to parameter of type 'string'."
+    );
+}
+
+#[test]
+fn legacy_bare_reference_zero_arg_factory_is_ts1329() {
+    // A zero-parameter legacy class decorator factory used uncalled.
+    let diags = legacy("function deco() {}\n@deco\nclass C {}\n");
+    assert!(codes(&diags).contains(&1329), "got: {:?}", codes(&diags));
+    assert!(!codes(&diags).contains(&1238), "got: {:?}", codes(&diags));
+}
+
+#[test]
+fn legacy_too_few_args_keeps_arity_elaboration() {
+    // Regression guard: the legacy too-few arity elaboration still fires.
+    let diags = legacy("function deco(target: Function, extra: string) {}\n@deco\nclass C {}\n");
+    let primary = find(&diags, 1238).expect("expected TS1238 (legacy)");
+    assert_eq!(primary.related_information.len(), 1);
+    assert_eq!(primary.related_information[0].code, 1278);
+}
+
+#[test]
+fn legacy_well_typed_decorator_has_no_signature_diagnostic() {
+    // Positive control: a `(target: Function) => void` decorator is valid.
+    let diags = legacy("function deco(target: Function) {}\n@deco\nclass C {}\n");
+    assert!(
+        !codes(&diags).contains(&1238) && !codes(&diags).contains(&1270),
+        "got: {:?}",
+        codes(&diags)
+    );
+}
+
+// ───────────────────────── renamed-binder invariance ────────────────────────
+
+#[test]
+fn behavior_is_independent_of_decorator_and_class_names() {
+    // Anti-hardcoding: the same non-callable failure must fire regardless of
+    // the identifiers chosen for the decorator and the class.
+    for (deco, class) in [("deco", "C"), ("wrap", "Widget"), ("qqq", "ZZZ")] {
+        let source = format!("const {deco} = 42;\n@{deco}\nclass {class} {{}}\n");
+        let es_diags = es(&source);
+        let legacy_diags = legacy(&source);
+        assert!(
+            codes(&es_diags).contains(&1238),
+            "ES: expected TS1238 for {source:?}, got: {:?}",
+            codes(&es_diags)
+        );
+        assert!(
+            codes(&legacy_diags).contains(&1238),
+            "legacy: expected TS1238 for {source:?}, got: {:?}",
+            codes(&legacy_diags)
+        );
+    }
+}

--- a/crates/tsz-checker/tests/ts1278_ts1279_decorator_arity_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/ts1278_ts1279_decorator_arity_elaboration_tests.rs
@@ -15,11 +15,18 @@
 //! information at all — the elaboration line was silently dropped in both
 //! the too-few and too-many argument shapes, across all five
 //! resolve-call-based decorator-signature-check sites (class, ES member,
-//! method/accessor, legacy property, parameter). A non-arity failure (e.g. an
-//! argument type mismatch) is deliberately left untouched: tsc attaches a
-//! different elaboration there (a `TS2345`-style "not assignable" line) that
-//! this change does not wire, so those diagnostics keep their pre-existing
-//! shape (no related information) rather than attaching the wrong kind.
+//! method/accessor, legacy property, parameter).
+//!
+//! For the **class-decorator** sites (both `--experimentalDecorators` and ES
+//! modes), the non-arity failures now carry their tsc elaboration too (issue
+//! #17108): the TS2345-shaped "Argument of type X is not assignable to
+//! parameter of type Y." line for an argument type mismatch, and the
+//! "This expression is not callable." / "Type 'X' has no call signatures."
+//! chain for a non-callable callee. This is safe there because the class
+//! sites feed the *real* value/context argument types (`typeof C`,
+//! `ClassDecoratorContext<typeof C>`), so the rendered types match tsc. The
+//! member/parameter sites still supply synthetic placeholder arguments, so
+//! their non-arity failures keep the arity-only elaboration.
 //!
 //! Oracle-verified against pinned `typescript@7.0.2` for every shape below.
 
@@ -115,11 +122,12 @@ class C {}
 }
 
 #[test]
-fn ts1238_class_decorator_type_mismatch_stays_unelaborated() {
-    // Control: a non-arity failure (wrong parameter type, not wrong count)
-    // must not gain related information -- tsc's elaboration there is a
-    // different, not-yet-wired shape ("Argument of type X is not assignable
-    // to parameter of type Y."), so this stays exactly as before.
+fn ts1238_class_decorator_type_mismatch_elaborates_argument() {
+    // A non-arity class-decorator failure (wrong parameter type, not wrong
+    // count) attaches tsc's TS2345-shaped "Argument of type X is not
+    // assignable to parameter of type Y." line. The class-decorator sites
+    // feed the real class constructor type (`typeof C`), so the rendered
+    // argument type matches tsc exactly (issue #17108).
     let diags = diagnostics_experimental(
         r#"
 function classDec(target: string) {}
@@ -129,10 +137,47 @@ class C {}
 "#,
     );
     let primary = find(&diags, 1238).expect("expected TS1238");
+    assert_eq!(primary.related_information.len(), 1);
+    assert_eq!(primary.related_information[0].code, 2345);
+    assert_eq!(
+        primary.related_information[0].message_text,
+        "Argument of type 'typeof C' is not assignable to parameter of type 'string'."
+    );
+}
+
+#[test]
+fn ts1238_class_decorator_non_callable_elaborates_chain() {
+    // A non-callable class decorator (a non-function value) attaches tsc's
+    // two-line "This expression is not callable." / "Type 'X' has no call
+    // signatures." chain beneath the primary TS1238 (issue #17108).
+    let diags = diagnostics_experimental(
+        r#"
+const d = 1;
+
+@d
+class C {}
+"#,
+    );
+    let primary = find(&diags, 1238).expect("expected TS1238");
+    assert_eq!(primary.related_information.len(), 2);
+    assert_eq!(primary.related_information[0].code, 2349);
+    assert_eq!(
+        primary.related_information[0].message_text,
+        "This expression is not callable."
+    );
+    // The "has no call signatures" note nests one level deeper (depth 1).
+    // Its rendered type is the callee's apparent type — `Number` against the
+    // full lib the CLI/oracle use, but the reduced unit-test lib renders the
+    // bare `number` primitive, so match on the stable structure rather than
+    // the primitive's casing.
+    assert_eq!(primary.related_information[1].code, 2757);
+    assert_eq!(primary.related_information[1].depth, 1);
     assert!(
-        primary.related_information.is_empty(),
-        "expected no related info for a type-mismatch failure, got: {:?}",
-        primary.related_information
+        primary.related_information[1]
+            .message_text
+            .ends_with("has no call signatures."),
+        "unexpected note: {}",
+        primary.related_information[1].message_text
     );
 }
 


### PR DESCRIPTION
Completes #17108 on top of the recent class-decorator work (#17118 not-callable chain, #17120 TS1329, #6de113f anchoring).

**Structural rule:** When a class decorator's call cannot be resolved, `tsc` reports `TS1238` ("Unable to resolve signature of class decorator when called as an expression.") with an elaboration chain keyed on the failure kind. Two shapes were still missing in tsz, both owned by the checker's class-decorator path:

- **ES (TC39 stage-3) mode never resolved the call.** It only inspected `function_shape` for `required_params > 2`, so an argument type mismatch (`function d(a: string) {} @d class C {}`) produced *no diagnostic at all*, and a too-many-parameters failure produced a bare `TS1238` with no `TS1278`/`TS1279` arity line.
- **Neither mode attached the `TS2345` argument line** ("Argument of type X is not assignable to parameter of type Y.") that `tsc` chains beneath `TS1238` for an argument type mismatch.

**Fix (owner: checker → solver call-resolution boundary):** Unify both decorator modes onto one handler, `check_class_decorator_signature`, that resolves `decorator(value[, context])` — `[classConstructor]` under `--experimentalDecorators`, `[typeof C, ClassDecoratorContext<typeof C>]` truncated to the decorator's declared arity in ES mode — and routes every `CallResult` failure shape through `tsc`'s elaboration:

| Failure | Elaboration |
| --- | --- |
| non-callable callee | "This expression is not callable." / "Type 'X' has no call signatures." |
| argument type mismatch | `TS2345` "Argument of type X is not assignable to parameter of type Y." |
| too few / too many arguments | `TS1278`/`TS1279` arity line |

Failure anchoring is keyed on the `CallResult` kind (the whole decorator only for a genuine too-few-arguments failure, the decorator expression otherwise), fixing a rest-parameter argument-mismatch case the param-count anchor heuristic mis-anchored. The zero-argument-factory `TS1329` hint is now gated on a referenceable decorator expression (`@d`, `@ns.d`); a parenthesized/inline factory (`@(() => {})`) falls through to the arity `TS1238`, matching `tsc` (previously it drew `TS1329`).

Adjacent-case matrix (oracle-verified vs pinned `typescript@7.0.2`, both modes): non-callable value, class-as-decorator, argument type mismatch on value and on context, too-few / too-many arity, bare-reference vs parenthesized zero-arg factory, renamed binders, and positive (well-typed) controls.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts1238_class_decorator_signature_tests --test ts1238_tests --test ts1278_ts1279_decorator_arity_elaboration_tests --test ts1238_generic_decorator_tests` — 40 pass; plus member/parameter decorator suites (`ts1239`/`ts1240`/`ts1241`/`ts1271`/`ts1249`/`es_member_decorator_arity`) green (no regressions).
- Arch test `decorator_return_diagnostics_use_relation_outcome_boundary` passes (return-relation routing preserved).
- `cargo clippy -p tsz-checker` clean (pre-commit hook).
- Conformance snapshot (`--workers 12`): removes the spurious `TS1238` on `potentiallyUncalledDecorators.ts`; no decorator regressions. (Other churn in the run — module-syntax/ambient/template-literal tests — is unrelated to this decorator-only diff and is known non-determinism, #16309.)
- Oracle spot-checks (`scripts/conformance/oracle.sh`) confirm exact `tsc` parity for each shape in both decorator modes.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_013TntBrWR8mgm2zBA8cuZSB)_