### PR TITLE
fix(checker): TS1329's "did you mean to call it first" hint requires a plain reference decorator expression

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -612,6 +612,9 @@ path = "tests/ts1238_class_decorator_not_callable_chain_tests.rs"
 name = "ts1329_class_decorator_zero_arg_factory_tests"
 path = "tests/ts1329_class_decorator_zero_arg_factory_tests.rs"
 [[test]]
+name = "ts1329_decorator_expression_shape_gate_tests"
+path = "tests/ts1329_decorator_expression_shape_gate_tests.rs"
+[[test]]
 name = "ts2862_keyof_tparam_tests"
 path = "tests/ts2862_keyof_tparam_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking/class_decorators.rs
+++ b/crates/tsz-checker/src/state/state_checking/class_decorators.rs
@@ -368,6 +368,23 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
+        // A decorator with zero total parameters that ISN'T a plain
+        // identifier/property-access reference doesn't qualify for the
+        // TS1329 "did you mean to call it first" hint above (see
+        // `decorator_expression_is_call_target_reference`), but tsc still
+        // reports the ordinary TS1238 arity failure here — an inline
+        // zero-param function/arrow literal (`@(() => {})`) genuinely can't
+        // be invoked with the runtime's 2 arguments either (oracle-verified,
+        // typescript@7.0.2).
+        if Self::decorator_signature_accepts_no_arguments(self.ctx.types, resolved) {
+            self.error_at_node(
+                decorator_node,
+                diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
+                diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
+            );
+            return;
+        }
+
         // No call signature at all (bare primitive, a class used as a
         // decorator, ...): tsc's TS1238 "not callable" chain fires
         // identically here as it does under `--experimentalDecorators`

--- a/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
@@ -535,7 +535,9 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        if Self::decorator_signature_accepts_no_arguments(self.ctx.types, decorator_type) {
+        if Self::decorator_signature_accepts_no_arguments(self.ctx.types, decorator_type)
+            && self.decorator_expression_is_call_target_reference(decorator_expr)
+        {
             let name = self.get_decorator_expression_name(decorator_expr);
             let msg = diagnostic_messages::ACCEPTS_TOO_FEW_ARGUMENTS_TO_BE_USED_AS_A_DECORATOR_HERE_DID_YOU_MEAN_TO_CALL_IT
                 .replace("{0}", &name);
@@ -559,12 +561,32 @@ impl<'a> CheckerState<'a> {
     /// it first" hint for these, so every other decorator diagnostic that
     /// would otherwise fall out of the failed call — the signature failure and
     /// the return-type check alike — must stand down.
-    fn decorator_signature_accepts_no_arguments(
+    pub(crate) fn decorator_signature_accepts_no_arguments(
         db: &dyn tsz_solver::construction::TypeDatabase,
         decorator_type: TypeId,
     ) -> bool {
         Self::decorator_signature_param_counts(db, decorator_type)
             .is_some_and(|counts| !counts.is_empty() && counts.iter().all(|&n| n == 0))
+    }
+
+    /// False only when `expr` is written as a parenthesized expression — the
+    /// one syntactic shape tsc's `isPotentiallyUncalledDecorator` heuristic
+    /// excludes from the TS1329/TS1239/TS1240/TS1241 "did you mean to call
+    /// it first" hint. An identifier (`@d`), a property-access chain
+    /// (`@obj.d`), and a call expression (`@d()`, even when its own callee
+    /// is parenthesized) all still get the hint; only wrapping the
+    /// decorator's own top-level expression in parens — an inline function/
+    /// arrow/class literal (`@(() => {})`) or a parenthesized reference
+    /// (`@(d)`) — suppresses it in favor of the ordinary arity/not-callable
+    /// failure. Oracle-verified (`typescript@7.0.2`) on the same zero-param
+    /// decorator: `@d`, `@obj.d`, and `@d()` all get TS1329, but `@(d)`,
+    /// `@(obj.d)`, and `@(() => {})` get the generic signature failure
+    /// instead.
+    fn decorator_expression_is_call_target_reference(&self, expr: NodeIndex) -> bool {
+        let Some(node) = self.ctx.arena.get(expr) else {
+            return false;
+        };
+        node.kind != tsz_parser::parser::syntax_kind_ext::PARENTHESIZED_EXPRESSION
     }
 
     fn es_method_or_accessor_decorator_args(

--- a/crates/tsz-checker/tests/ts1329_decorator_expression_shape_gate_tests.rs
+++ b/crates/tsz-checker/tests/ts1329_decorator_expression_shape_gate_tests.rs
@@ -1,0 +1,99 @@
+//! TS1329's "did you mean to call it first" hint only fires for a decorator
+//! expression written as exactly an identifier or a property-access chain
+//! ending in one — not for any other syntactic shape at the decorator site,
+//! even one that resolves to the exact same zero-parameter callee.
+//!
+//! Oracle-verified (`typescript@7.0.2`): for the same zero-param decorator,
+//! `@d` and `@obj.d` get TS1329, but `@(d)`, `@(obj.d)`, and `@(() => {})`
+//! all get the ordinary TS1238/TS1241 signature-failure diagnostic instead —
+//! parenthesizing (or writing a function literal inline) isn't the "forgot
+//! to call it" shape the hint is for.
+//!
+//! `decorator_has_zero_arg_factory_shape` previously gated only on the
+//! callee's parameter count, so it fired TS1329 for `@(() => {})` too — and
+//! since the ES class-decorator arity check had no fallback for a
+//! zero-param, non-reference decorator, that shape silently passed with no
+//! diagnostic at all once TS1329 stood down.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+
+fn legacy_codes(source: &str) -> Vec<u32> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            experimental_decorators: true,
+            ..CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+fn es_codes(source: &str) -> Vec<u32> {
+    check_source(source, "test.ts", CheckerOptions::default())
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+#[test]
+fn es_parenthesized_identifier_zero_arg_decorator_emits_ts1238_not_ts1329() {
+    let codes = es_codes("function d() { return undefined as any; }\n@(d)\nclass C {}\n");
+    assert!(
+        codes.contains(&1238) && !codes.contains(&1329),
+        "a parenthesized identifier is not a 'forgot to call it' reference; got: {codes:?}"
+    );
+}
+
+#[test]
+fn legacy_parenthesized_identifier_zero_arg_decorator_emits_ts1238_not_ts1329() {
+    let codes = legacy_codes("function d() { return undefined as any; }\n@(d)\nclass C {}\n");
+    assert!(
+        codes.contains(&1238) && !codes.contains(&1329),
+        "a parenthesized identifier is not a 'forgot to call it' reference; got: {codes:?}"
+    );
+}
+
+#[test]
+fn es_inline_arrow_zero_param_decorator_emits_ts1238_not_ts1329() {
+    let codes = es_codes("@(() => {})\nclass C {}\n");
+    assert!(
+        codes.contains(&1238) && !codes.contains(&1329),
+        "an inline zero-param arrow decorator gets the generic arity failure, not the hint; got: {codes:?}"
+    );
+}
+
+#[test]
+fn es_property_access_zero_arg_decorator_still_emits_ts1329() {
+    // Positive control: a property-access chain IS a plausible "forgot to
+    // call it" reference, same as a bare identifier.
+    let codes = es_codes("const obj = { d() { return undefined as any; } };\n@obj.d\nclass C {}\n");
+    assert!(
+        codes.contains(&1329) && !codes.contains(&1238),
+        "a property-access reference should still get the TS1329 hint; got: {codes:?}"
+    );
+}
+
+#[test]
+fn es_parenthesized_property_access_zero_arg_decorator_emits_ts1238_not_ts1329() {
+    let codes =
+        es_codes("const obj = { d() { return undefined as any; } };\n@(obj.d)\nclass C {}\n");
+    assert!(
+        codes.contains(&1238) && !codes.contains(&1329),
+        "parenthesizing a property-access reference still isn't the hint shape; got: {codes:?}"
+    );
+}
+
+#[test]
+fn es_parenthesized_identifier_zero_arg_method_decorator_emits_ts1241_not_ts1329() {
+    // Same shape rule applies uniformly to member decorators
+    // (`decorator_has_zero_arg_factory_shape` is shared).
+    let codes = es_codes("function d() {}\nclass C { @(d) method(): void {} }\n");
+    assert!(
+        codes.contains(&1241) && !codes.contains(&1329),
+        "a parenthesized identifier method decorator gets TS1241, not the hint; got: {codes:?}"
+    );
+}


### PR DESCRIPTION
Fixes #17123 (found while landing #17118/#17122 earlier this session).

`decorator_has_zero_arg_factory_shape` (added by #17120) gated the TS1329 "did you mean to call it first" hint purely on the decorator callee's parameter count, so it fired for *any* zero-parameter decorator regardless of how the decorator expression is syntactically written.

**Structural rule** (oracle-verified, `typescript@7.0.2`): tsc's `isPotentiallyUncalledDecorator` also depends on the decorator expression's own top-level syntactic shape. An identifier (`@d`), a property-access chain (`@obj.d`), and a call expression (`@d()`, even when its own callee is parenthesized) all still get the TS1329/TS1239/TS1240/TS1241 hint — but a **parenthesized** decorator expression does not, whether it wraps an inline function/arrow/class literal (`@(() => {})`) or a plain reference (`@(d)`, `@(obj.d)`). tsc reports the ordinary arity/not-callable failure there instead. The rule holds identically for class and member decorators, and in both `--experimentalDecorators` and ES (TC39 stage-3) mode.

| decorator expression | shape | tsc |
| --- | --- | --- |
| `@d` | identifier | TS1329 |
| `@obj.d` | property access | TS1329 |
| `@d()` | call expression | TS1329 |
| `@(d)` | parenthesized identifier | TS1238 (generic) |
| `@(obj.d)` | parenthesized property access | TS1238 (generic) |
| `@(() => {})` | parenthesized function literal | TS1238 (generic) |

Added `decorator_expression_is_call_target_reference` (`decorator_signature_checks.rs`) — false only for a top-level `PARENTHESIZED_EXPRESSION` — and gated `decorator_has_zero_arg_factory_shape` on it. Since the ES class-decorator arity check (`check_es_class_decorator_arity`) never had a fallback for a zero-param, non-reference decorator once the TS1329 branch stood down, that shape previously passed with **zero diagnostics at all** (not even a bare TS1238) — added the missing fallback in `class_decorators.rs`, reusing the now-`pub(crate)` `decorator_signature_accepts_no_arguments`.

This also un-reds `ts1238_es_decorator_zero_arity_factory_emits_error` (`@(() => {})\nclass C {}`), which was failing on `main` before this PR (confirmed via `git stash` while landing #17122).

## Goal
Goal: hold

## Verification
- New `crates/tsz-checker/tests/ts1329_decorator_expression_shape_gate_tests.rs` (6 tests, oracle-verified against pinned `typescript@7.0.2`): parenthesized identifier/property-access/inline-arrow for both class and method decorators, in both decorator modes, plus a positive control (bare property access still gets TS1329).
- `ts1238_tests::ts1238_es_decorator_zero_arity_factory_emits_error` now passes (previously failing on `main`, unrelated to this session's other decorator PRs).
- 0 regressions across the full decorator suite: `ts1238_tests` 14/14, `ts1238_generic_decorator_tests` 2/2, `ts1238_experimental_decorator_anchor_tests` 6/6, `ts1278_ts1279_decorator_arity_elaboration_tests` 8/8, `ts1329_class_decorator_zero_arg_factory_tests` 8/8 (including the `@d()` factory-call case, which needed the call-expression allowance in the shape gate), `decorator_this_binding_tests` 16/16, `decorator_method_tdz_tests` 10/10, `es_member_decorator_arity_tests` 15/15, `issue_7681_super_decorator_tests` 7/7, `ts2449_parameter_decorator_no_tdz_tests` 2/2, `ts18036_class_decorator_static_private_identifier_tests` 10/10, `ts1238_class_decorator_not_callable_chain_tests` 9/9 — plus all 23 lib-level decorator tests (`cargo test -p tsz-checker --lib -- decorator`).
- `cargo clippy -p tsz-checker --lib -- -D warnings` clean; clippy on touched test files clean.
- `cargo fmt -p tsz-checker -- --check` clean.
- `python3 scripts/arch/arch_guard.py` → "Architecture guardrails passed."
- Pre-commit hook's own clippy + arch-guard verification passed on commit.
- Only decorator-signature diagnostics can move (adds/redirects a previously-missing or misrouted TS1238/TS1329 family; no other diagnostic code touched); the TypeScript corpus submodule was not checked out this session, so no full conformance/emit sweep was run — targeted suites above exercise every affected path.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeT


---
_Generated by [Claude Code](https://claude.ai/code/session_01AxDLaSjt6ptqQfr99SU2JS)_