### PR TITLE
fix(checker): TS2687 modifier-agreement check for merged interface declarations

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2857,5 +2857,8 @@ path = "tests/ts7023_self_recursive_var_reassigned_return_tests.rs"
 name = "ts1339_bare_typeof_import_no_value_tests"
 path = "tests/ts1339_bare_typeof_import_no_value_tests.rs"
 [[test]]
+name = "ts2687_merged_interface_declaration_tests"
+path = "tests/ts2687_merged_interface_declaration_tests.rs"
+[[test]]
 name = "ts2694_typeof_import_qualified_type_only_member_tests"
 path = "tests/ts2694_typeof_import_qualified_type_only_member_tests.rs"

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_followup.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_followup.rs
@@ -340,6 +340,10 @@ impl<'a> CheckerState<'a> {
     ///
     /// - TS2717: Subsequent property declarations with the same name must have identical types.
     /// - TS2413: Merged index signatures must be compatible.
+    /// - TS2687: Property signatures sharing a name across merged declarations
+    ///   must agree on `readonly` / optional (`?`) modifiers (method
+    ///   signatures are exempt — `tsc` only runs this check from
+    ///   `checkVariableLikeDeclaration`, which does not visit methods).
     pub(crate) fn check_merged_interface_declaration_diagnostics(
         &mut self,
         declarations: &[NodeIndex],
@@ -396,6 +400,15 @@ impl<'a> CheckerState<'a> {
             // and method across merged declarations, tsc emits TS2300
             // "Duplicate identifier" on both declarations.
             let mut merged_properties: FxHashMap<String, (TypeId, bool, NodeIndex)> =
+                FxHashMap::default();
+            // TS2687: property-signature nodes (never methods — tsc's
+            // `checkVariableLikeDeclaration` is not run for method signatures)
+            // sharing a canonical name across every declaration in this merged
+            // scope, in source order. `report_property_modifier_disagreements`
+            // (shared with the single-body interface and type-literal paths)
+            // flags every entry whose `readonly`/optional flags disagree with
+            // the first (declarations_in_scope is already position-sorted).
+            let mut merged_property_signatures: FxHashMap<String, Vec<NodeIndex>> =
                 FxHashMap::default();
 
             for &decl_idx in &declarations_in_scope {
@@ -465,6 +478,12 @@ impl<'a> CheckerState<'a> {
                         } else {
                             TypeId::ANY
                         };
+                        if !is_method {
+                            merged_property_signatures
+                                .entry(name.clone())
+                                .or_default()
+                                .push(member_idx);
+                        }
                         local_properties.push((
                             name,
                             sig.name,
@@ -709,6 +728,13 @@ impl<'a> CheckerState<'a> {
                 }
 
                 self.pop_type_parameters(updates);
+            }
+
+            for member_nodes in merged_property_signatures.into_values() {
+                if member_nodes.len() < 2 {
+                    continue;
+                }
+                self.report_property_modifier_disagreements(member_nodes[0], &member_nodes);
             }
         }
     }

--- a/crates/tsz-checker/tests/ts2687_merged_interface_declaration_tests.rs
+++ b/crates/tsz-checker/tests/ts2687_merged_interface_declaration_tests.rs
@@ -1,0 +1,100 @@
+//! TS2687 for merged interface declarations that disagree on the `readonly`
+//! or optional (`?`) property modifier.
+//!
+//! Structural rule: when two or more top-level `interface` declarations with
+//! the same name merge into one symbol, `tsc`'s `checkVariableLikeDeclaration`
+//! requires every property signature sharing a name across the merged group to
+//! carry identical `readonly`/optional flags, or it reports TS2687 ("All
+//! declarations of '{0}' must have identical modifiers.") on every disagreeing
+//! declaration. `check_merged_interface_declaration_diagnostics`
+//! (`duplicate_identifiers_followup.rs`) already checked TS2717 (differing
+//! types) and TS2413 (index signatures) across the merged group but never
+//! TS2687 — a same-typed property that only disagrees on `?` produced no
+//! diagnostic at all. Oracle-verified against `typescript@7.0.2`
+//! (`conformance/compiler/duplicateIdentifierDifferentModifiers.ts`).
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn ts2687_count(source: &str) -> usize {
+    check_source_diagnostics(source)
+        .iter()
+        .filter(|d| d.code == 2687)
+        .count()
+}
+
+/// The exact conformance witness: two merged `interface B` declarations whose
+/// `x` member disagrees only on the optional token.
+#[test]
+fn merged_interface_optional_disagreement_emits_ts2687() {
+    let source = "interface B { x: any; }\ninterface B { x?: any; }\n";
+    let diags = check_source_diagnostics(source);
+    let hits: Vec<_> = diags.iter().filter(|d| d.code == 2687).collect();
+    assert_eq!(
+        hits.len(),
+        2,
+        "expected TS2687 on both merged declarations, got: {diags:?}"
+    );
+    assert!(
+        hits.iter().all(|d| d.message_text.contains("'x'")),
+        "TS2687 should name the disagreeing member 'x'; got {hits:?}"
+    );
+}
+
+/// `readonly` disagreement across a merged interface pair is the same family.
+#[test]
+fn merged_interface_readonly_disagreement_emits_ts2687() {
+    let source = "interface R { y: string; }\ninterface R { readonly y: string; }\n";
+    assert_eq!(ts2687_count(source), 2);
+}
+
+/// Three-way merge: only the odd one out (and the reference) are flagged,
+/// matching the single-interface-body convention already covered by
+/// `report_property_modifier_disagreements`.
+#[test]
+fn merged_interface_three_way_only_disagreeing_pair_flagged() {
+    let source =
+        "interface M { z: number; }\ninterface M { z: number; }\ninterface M { z?: number; }\n";
+    assert_eq!(ts2687_count(source), 2);
+}
+
+/// Renamed binder: the check must not key off any specific identifier.
+#[test]
+fn merged_interface_optional_disagreement_renamed_binder() {
+    let source = "interface Zzyzx { w: any; }\ninterface Zzyzx { w?: any; }\n";
+    assert_eq!(ts2687_count(source), 2);
+}
+
+/// Method signatures are exempt: `tsc` only runs this check from
+/// `checkVariableLikeDeclaration`, which never visits method signatures — an
+/// overload-shaped merge must stay silent on TS2687 regardless of any
+/// (nonsensical, but syntactically legal) modifier-looking difference.
+#[test]
+fn merged_interface_method_signatures_are_not_flagged() {
+    let source = "interface F { m(): void; }\ninterface F { m(x: number): void; }\n";
+    assert_eq!(ts2687_count(source), 0);
+}
+
+/// Negative control: identical modifiers across a merged pair stay clean.
+#[test]
+fn merged_interface_matching_modifiers_stay_clean() {
+    let source = "interface N { a: string; }\ninterface N { a: string; b: number; }\n";
+    assert_eq!(ts2687_count(source), 0);
+}
+
+/// A single (non-merged) interface body already reports TS2687 through the
+/// sibling `check_duplicate_interface_members` path; this locks in that the
+/// new merged-declaration path does not double-report when everything lives
+/// in one declaration.
+#[test]
+fn single_interface_body_disagreement_still_single_owner() {
+    let source = "interface S { s: any; s?: any; }\n";
+    // Duplicate-in-body is TS2300 territory (and its own TS2687 pairing) —
+    // just confirm the merged-declaration path adds nothing extra beyond
+    // what the single-body path already emits for a solitary declaration.
+    let diags = check_source_diagnostics(source);
+    let hits = diags.iter().filter(|d| d.code == 2687).count();
+    assert_eq!(
+        hits, 2,
+        "single-body path should still emit its own pair: {diags:?}"
+    );
+}


### PR DESCRIPTION
## Structural rule

When two or more top-level `interface X { ... }` declarations merge into one
symbol, `tsc`'s `checkVariableLikeDeclaration` requires every property
signature sharing a canonical name across the merged group to carry identical
`readonly`/optional (`?`) flags, or it reports TS2687 ("All declarations of
'{0}' must have identical modifiers.") on every disagreeing declaration.
Method signatures are exempt (`checkVariableLikeDeclaration` never runs on
them).

tsz's `check_merged_interface_declaration_diagnostics`
(`crates/tsz-checker/src/types/type_checking/duplicate_identifiers_followup.rs`)
already implemented TS2717 (differing types across the merged group) and
TS2413 (incompatible merged index signatures) for this same declaration-merge
path, but never TS2687 — a same-typed property that only disagreed on `?`/
`readonly` across two merged `interface` declarations produced **no
diagnostic at all**. (The sibling paths — a single interface body via
`check_duplicate_interface_members`, an object type literal via
`check_type_literal_duplicate_properties`, and a class+interface merge via
`check_merged_class_interface_declaration_diagnostics` — already had their own
TS2687 coverage; only the interface-declaration-merge path was missing it.)

Found via `scripts/conformance/conformance-detail.json`'s tracked failure for
`conformance/compiler/duplicateIdentifierDifferentModifiers.ts` (tsc expects
TS2687, tsz emitted nothing).

## Owner layer

Checker (`duplicate_identifiers_followup.rs`), reusing the existing
`report_property_modifier_disagreements` helper (already shared by the
type-literal and single-interface-body paths in
`duplicate_property_modifiers.rs`) rather than reimplementing the
flag-comparison logic a third time.

## What changed

- Collect each merged declaration's `PROPERTY_SIGNATURE` member nodes (method
  signatures excluded, matching `tsc`) into a per-canonical-name group across
  every declaration in the merge scope, in source-position order (the scope's
  declarations are already position-sorted).
- After the existing per-declaration TS2717/TS2413 pass, route each name group
  with 2+ property signatures through `report_property_modifier_disagreements`,
  which flags the source-order-first declaration as the reference and every
  later declaration whose `readonly`/optional flags disagree.

## Adjacent-case matrix (oracle-verified, `typescript@7.0.2`)

| case | tsc | tsz (after) |
| --- | --- | --- |
| `interface B { x: any; } interface B { x?: any; }` (issue witness) | 2× TS2687 | 2× TS2687 |
| `readonly` disagreement (`interface R { y: string; } interface R { readonly y: string; }`) | 2× TS2687 | 2× TS2687 |
| three-way merge, only one odd member out | 2× TS2687 (+ TS2717) | 2× TS2687 (+ TS2717) |
| renamed binder (`Zzyzx`) | 2× TS2687 | 2× TS2687 |
| method-signature "overload" merge | clean | clean |
| matching modifiers across a merged pair | clean | clean |
| single (non-merged) interface body, negative control | 2× TS2687 (+ TS2300, pre-existing path) | 2× TS2687 (+ TS2300, unchanged) |

## Goal
Goal: hold

## Verification
- New `crates/tsz-checker/tests/ts2687_merged_interface_declaration_tests.rs`
  (7 tests, each independently oracle-verified against pinned
  `typescript@7.0.2` — see matrix above): `cargo test -p tsz-checker --test
  ts2687_merged_interface_declaration_tests` → 7/7 pass.
- Regression sweep over the touched family: `cargo test -p tsz-checker --lib
  -- duplicate_identifiers duplicate_member merged_interface interface_checks
  ts2687 ts2717 ts2413 ts2300` → 151/151 pass, 0 regressions.
- `cargo clippy --profile ci-lint -p tsz-checker --lib --tests -- -D
  warnings`: clean.
- `cargo fmt -p tsz-checker -- --check`: clean.
- `python3 scripts/arch/arch_guard.py`: passes.
- `python3 scripts/ci/check-test-file-reachability.py`: 0 new orphans.
- Pre-commit hook's own clippy + arch-guard + affected-crate verification:
  passed.
- Only TS2687 diagnostics on the interface-declaration-merge path can move (no
  other diagnostic code touched, and the new path only *adds* diagnostics
  where none fired before); the TypeScript corpus submodule was not checked
  out this session (fresh cloud container), so no full
  conformance/emit/fourslash sweep was run — the oracle-pinned matrix above
  covers every declared-modifier-shape branch the change touches, and the
  targeted 151-test regression sweep covers every neighboring diagnostic path
  in the same file family.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE


---
_Generated by [Claude Code](https://claude.ai/code/session_014zeQZQATyK29Tt4AczxpMw)_