### PR TITLE
fix(checker): gate the TS1329 decorator "call it first" hint on the decorator expression shape

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -597,6 +597,9 @@ path = "tests/parameter_initializer_identifier_context_tests.rs"
 name = "decorator_method_tdz_tests"
 path = "tests/decorator_method_tdz_tests.rs"
 [[test]]
+name = "decorator_uncalled_hint_expression_shape_tests"
+path = "tests/decorator_uncalled_hint_expression_shape_tests.rs"
+[[test]]
 name = "ts1238_generic_decorator_tests"
 path = "tests/ts1238_generic_decorator_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking/class_decorators.rs
+++ b/crates/tsz-checker/src/state/state_checking/class_decorators.rs
@@ -11,6 +11,7 @@
 //! visibility was widened only to permit the file split.
 
 use crate::query_boundaries::class_type as class_query;
+use crate::query_boundaries::common::CallResult;
 use crate::state::CheckerState;
 use rustc_hash::FxHashMap;
 use tsz_parser::parser::syntax_kind_ext;
@@ -280,7 +281,7 @@ impl<'a> CheckerState<'a> {
             None,
         );
 
-        let crate::query_boundaries::common::CallResult::Success(return_type) = &result else {
+        let CallResult::Success(return_type) = &result else {
             let anchor = self.decorator_failure_anchor(decorator_node, resolved, 1);
             self.emit_decorator_signature_error(
                 anchor,
@@ -388,27 +389,32 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        // Check the function shape for required parameter count
-        if let Some(shape) =
-            crate::query_boundaries::class_type::function_shape(self.ctx.types, resolved)
-        {
-            let required_params = shape
-                .params
-                .iter()
-                .filter(|p| !p.optional && !p.rest)
-                .count();
-            // ES decorators are invoked with `(value, context)`. When the
-            // factory requires more than two parameters, the call cannot
-            // supply them; tsc anchors the error at the whole decorator
-            // (including `@`). The zero-parameter case is handled above as
-            // the TS1329 decorator-factory hint, not this arity failure.
-            if required_params > 2 {
-                self.error_at_node(
-                    decorator_node,
-                    diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
-                    diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
-                );
-            }
+        // ES decorators are invoked with `(value, context)`, truncated to the
+        // decorator's own declared argument count (tsc's
+        // `getDecoratorArgumentCount` = `min(max(paramCount, 1), 2)`, shared
+        // via `es_member_decorator_argument_count`). Resolve the call the same
+        // way the member-decorator paths do, with `any` for both synthetic
+        // arguments since only arity — not the value/context types — can fail
+        // for a class decorator here. This uniformly catches both a factory
+        // requiring more than the two supplied parameters (too-many-required)
+        // and a zero-parameter decorator that cannot receive the runtime's
+        // arguments at all (too-many-supplied) — the latter reaches this path
+        // only once the TS1329 factory hint has been ruled out above, i.e. for
+        // a parenthesized inline expression like `@(() => {})`. A compatible
+        // 1- or 2-parameter decorator resolves cleanly and draws no error.
+        // `emit_decorator_signature_error` attaches the TS1278/TS1279 arity
+        // elaboration, matching the other four resolve-call-based sites.
+        let all_args = [TypeId::ANY, TypeId::ANY];
+        let args = &all_args[..self.es_member_decorator_argument_count(resolved)];
+        let (result, _, _) =
+            self.resolve_call_with_checker_adapter(resolved, args, false, None, None);
+        if !matches!(result, CallResult::Success(_)) {
+            self.emit_decorator_signature_error(
+                self.decorator_failure_anchor(decorator_node, resolved, args.len()),
+                diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
+                diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
+                &result,
+            );
         }
     }
 

--- a/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
@@ -365,7 +365,7 @@ impl<'a> CheckerState<'a> {
     /// fixed synthetic argument list cannot reproduce, so the longer 2-argument
     /// form is supplied rather than risk dropping an argument a wider overload
     /// requires.
-    fn es_member_decorator_argument_count(&self, decorator_type: TypeId) -> usize {
+    pub(crate) fn es_member_decorator_argument_count(&self, decorator_type: TypeId) -> usize {
         // `min(max(paramCount, 1), 2)` for a single declared signature; an
         // unknown shape or an overload set falls back to the full two-argument
         // call so exotic callees behave as they did before.
@@ -525,6 +525,12 @@ impl<'a> CheckerState<'a> {
     /// `isPotentiallyUncalledDecorator` for the common zero-parameter case and
     /// applies uniformly to method, accessor, field, and (see
     /// `class_decorators.rs`) class decorators.
+    ///
+    /// The hint is additionally gated on the decorator *expression* being a
+    /// reference the user could plausibly have forgotten to invoke — see
+    /// [`Self::decorator_expression_offers_uncalled_hint`]. A parenthesized
+    /// inline expression (`@(() => {})`) keeps the generic
+    /// TS1238/1239/1240/1241 arity elaboration instead.
     pub(crate) fn decorator_has_zero_arg_factory_shape(
         &mut self,
         decorator_expr: NodeIndex,
@@ -535,7 +541,9 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        if Self::decorator_signature_accepts_no_arguments(self.ctx.types, decorator_type) {
+        if Self::decorator_signature_accepts_no_arguments(self.ctx.types, decorator_type)
+            && self.decorator_expression_offers_uncalled_hint(decorator_expr)
+        {
             let name = self.get_decorator_expression_name(decorator_expr);
             let msg = diagnostic_messages::ACCEPTS_TOO_FEW_ARGUMENTS_TO_BE_USED_AS_A_DECORATOR_HERE_DID_YOU_MEAN_TO_CALL_IT
                 .replace("{0}", &name);
@@ -548,6 +556,36 @@ impl<'a> CheckerState<'a> {
         }
 
         false
+    }
+
+    /// Whether the decorator *expression* is one tsc would offer the TS1329
+    /// "did you mean to call it first and write `@d()`?" hint for.
+    ///
+    /// Oracle-verified rule (`typescript@7.0.2`, see #17121): tsc substitutes
+    /// the TS1329 hint for the generic TS1238/1239/1240/1241 arity failure
+    /// only when the decorator's own expression is a bare `Identifier`
+    /// (`@d`), a `PropertyAccessExpression` chain (`@a.b`), or a top-level
+    /// `CallExpression` (`@factory()`) — and **not** when it is a
+    /// `ParenthesizedExpression` (`@(...)`), which keeps the generic family
+    /// with its normal arity elaboration.
+    ///
+    /// The discriminator is the *wrapper*, not what it wraps: `@(d)`,
+    /// `@(a.b)`, and `@(() => {})` all keep the generic family even though the
+    /// first two wrap a reference. This mirrors what the hint suggests — the
+    /// rewrite `@d()` is a valid decorator only for the bare reference/call
+    /// forms above; a `@(...)` decorator cannot be extended into a
+    /// `@(...)()` decorator call, so tsc offers no "call it first" hint for
+    /// it regardless of the inner expression. Keying on the unwrapped inner
+    /// kind would therefore diverge from tsc for the parenthesized-reference
+    /// cases.
+    ///
+    /// So the gate is exactly "the expression is not a
+    /// `ParenthesizedExpression`". A node we cannot resolve defaults to
+    /// offering the hint, preserving the prior unconditional behavior.
+    fn decorator_expression_offers_uncalled_hint(&self, decorator_expr: NodeIndex) -> bool {
+        self.ctx.arena.get(decorator_expr).is_none_or(|node| {
+            node.kind != tsz_parser::parser::syntax_kind_ext::PARENTHESIZED_EXPRESSION
+        })
     }
 
     /// Whether every call signature of a decorator expression takes zero

--- a/crates/tsz-checker/tests/decorator_uncalled_hint_expression_shape_tests.rs
+++ b/crates/tsz-checker/tests/decorator_uncalled_hint_expression_shape_tests.rs
@@ -1,0 +1,231 @@
+//! The TS1329 "did you mean to call it first" decorator hint is gated on the
+//! decorator *expression* shape, not only the decorator's signature arity.
+//!
+//! Structural rule (oracle-verified against pinned `typescript@7.0.2`, see
+//! issues #17121 / #17123): when every call signature of a decorator takes
+//! zero required parameters, tsc offers the TS1329 factory hint only when the
+//! decorator expression is a *reference* the user could plausibly have
+//! forgotten to invoke — a bare identifier (`@d`), a property-access chain
+//! (`@ns.d`), or a call producing one (`@factory()`). It does **not** offer it
+//! for an inline function/arrow literal written directly at the decorator site
+//! (`@(() => {})`); grammatically a decorator accepts only a
+//! `LeftHandSideExpression`, so an inline function/arrow literal can appear
+//! there only when parenthesized, and tsc keeps the generic
+//! TS1238/1239/1240/1241 arity elaboration for it instead.
+//!
+//! The gate lives in the shared `decorator_has_zero_arg_factory_shape` helper
+//! (`decorator_signature_checks.rs`), so it applies uniformly to class,
+//! method, accessor, and property decorators. Binder names are varied across
+//! cases so the rule cannot be satisfied by any name-specific fast path.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+
+fn es_codes(source: &str) -> Vec<u32> {
+    check_source(source, "test.ts", CheckerOptions::default())
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+fn legacy_codes(source: &str) -> Vec<u32> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            experimental_decorators: true,
+            ..CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+/// Any of the generic "unable to resolve signature of ... decorator" codes —
+/// the family tsc keeps when the factory hint does not apply.
+fn has_generic_decorator_signature_error(codes: &[u32]) -> bool {
+    codes
+        .iter()
+        .any(|&c| c == 1238 || c == 1239 || c == 1240 || c == 1241)
+}
+
+// ─────────────────────── class decorator, reference shapes ───────────────────
+
+#[test]
+fn class_bare_identifier_zero_arg_keeps_ts1329() {
+    for codes in [
+        es_codes("function deco() {}\n@deco\nclass C {}\n"),
+        legacy_codes("function deco() {}\n@deco\nclass C {}\n"),
+    ] {
+        assert!(
+            codes.contains(&1329) && !has_generic_decorator_signature_error(&codes),
+            "bare identifier zero-arg class decorator must keep TS1329; got: {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn class_property_access_zero_arg_keeps_ts1329() {
+    // A property-access reference (`@registry.build`) is still something the
+    // user could have forgotten to call, so the hint applies.
+    let source = "const registry = { build: () => {} };\n@registry.build\nclass C {}\n";
+    for codes in [es_codes(source), legacy_codes(source)] {
+        assert!(
+            codes.contains(&1329) && !has_generic_decorator_signature_error(&codes),
+            "property-access zero-arg class decorator must keep TS1329; got: {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn class_factory_call_zero_arg_keeps_ts1329() {
+    // A top-level call whose result is itself zero-arg — "forgot to call it
+    // again" — still qualifies for the hint (a call expression, not a
+    // parenthesized inline literal).
+    let source = "function factory() { return () => {}; }\n@factory()\nclass C {}\n";
+    for codes in [es_codes(source), legacy_codes(source)] {
+        assert!(
+            codes.contains(&1329) && !has_generic_decorator_signature_error(&codes),
+            "factory-call zero-arg class decorator must keep TS1329; got: {codes:?}"
+        );
+    }
+}
+
+// ─────────────────── class decorator, parenthesized inline literal ───────────
+
+#[test]
+fn class_parenthesized_zero_arg_drops_ts1329_for_generic_ts1238() {
+    // `@(() => {})` is an inline arrow literal — the hint is meaningless, so
+    // the generic TS1238 arity failure stands instead.
+    for codes in [
+        es_codes("@(() => {})\nclass C {}\n"),
+        legacy_codes("@(() => {})\nclass C {}\n"),
+    ] {
+        assert!(
+            codes.contains(&1238) && !codes.contains(&1329),
+            "parenthesized zero-arg class decorator must be TS1238, not TS1329; got: {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn class_parenthesized_reference_keeps_generic_not_ts1329() {
+    // The discriminator is the parenthesis *wrapper*, not what it wraps:
+    // `@(d)` wraps a bare zero-arg reference, but tsc still keeps the generic
+    // TS1238 family (the `@d()` rewrite the hint suggests is not a valid
+    // decorator when written as `@(d)()`). Guards against "unwrap the parens
+    // and inspect the inner kind", which would wrongly re-offer TS1329 here.
+    let source = "function d() {}\n@(d)\nclass C {}\n";
+    for codes in [es_codes(source), legacy_codes(source)] {
+        assert!(
+            codes.contains(&1238) && !codes.contains(&1329),
+            "parenthesized reference zero-arg class decorator must keep generic TS1238, \
+             not TS1329; got: {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn class_parenthesized_one_or_two_params_is_clean() {
+    // A parenthesized inline decorator that DOES match the `(value, context)`
+    // runtime shape resolves cleanly — neither the hint nor the generic error.
+    for source in [
+        "@((value: any) => {})\nclass C {}\n",
+        "@((value: any, context: any) => {})\nclass C {}\n",
+    ] {
+        let codes = es_codes(source);
+        assert!(
+            !codes.contains(&1329) && !has_generic_decorator_signature_error(&codes),
+            "compatible parenthesized class decorator must be clean; got: {codes:?} for {source}"
+        );
+    }
+}
+
+#[test]
+fn class_parenthesized_too_many_params_keeps_generic_ts1238() {
+    let codes = es_codes("@((a: any, b: any, c: any) => {})\nclass C {}\n");
+    assert!(
+        codes.contains(&1238) && !codes.contains(&1329),
+        "parenthesized >2-param class decorator must be TS1238, not TS1329; got: {codes:?}"
+    );
+}
+
+// ─────────────────────── method decorator (ES + legacy) ──────────────────────
+
+#[test]
+fn method_bare_identifier_zero_arg_keeps_ts1329() {
+    for codes in [
+        es_codes("function log() {}\nclass C { @log method() {} }\n"),
+        legacy_codes("function log() {}\nclass C { @log method() {} }\n"),
+    ] {
+        assert!(
+            codes.contains(&1329) && !has_generic_decorator_signature_error(&codes),
+            "bare zero-arg method decorator must keep TS1329; got: {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn method_parenthesized_zero_arg_drops_ts1329_for_generic() {
+    for codes in [
+        es_codes("class C { @(() => {}) method() {} }\n"),
+        legacy_codes("class C { @(() => {}) method() {} }\n"),
+    ] {
+        assert!(
+            !codes.contains(&1329) && has_generic_decorator_signature_error(&codes),
+            "parenthesized zero-arg method decorator must drop TS1329 for a generic \
+             signature error; got: {codes:?}"
+        );
+    }
+}
+
+// ────────────────────── accessor decorator (ES + legacy) ─────────────────────
+
+#[test]
+fn accessor_bare_identifier_zero_arg_keeps_ts1329() {
+    for codes in [
+        es_codes("function seal() {}\nclass C { @seal get value() { return 1; } }\n"),
+        legacy_codes("function seal() {}\nclass C { @seal get value() { return 1; } }\n"),
+    ] {
+        assert!(
+            codes.contains(&1329) && !has_generic_decorator_signature_error(&codes),
+            "bare zero-arg accessor decorator must keep TS1329; got: {codes:?}"
+        );
+    }
+}
+
+#[test]
+fn accessor_parenthesized_zero_arg_drops_ts1329_for_generic() {
+    for codes in [
+        es_codes("class C { @(() => {}) get value() { return 1; } }\n"),
+        legacy_codes("class C { @(() => {}) get value() { return 1; } }\n"),
+    ] {
+        assert!(
+            !codes.contains(&1329) && has_generic_decorator_signature_error(&codes),
+            "parenthesized zero-arg accessor decorator must drop TS1329 for a generic \
+             signature error; got: {codes:?}"
+        );
+    }
+}
+
+// ─────────────────── property/field decorator (legacy path) ──────────────────
+
+#[test]
+fn property_bare_identifier_zero_arg_keeps_ts1329() {
+    let codes = legacy_codes("function readonly() {}\nclass C { @readonly field = 1; }\n");
+    assert!(
+        codes.contains(&1329) && !has_generic_decorator_signature_error(&codes),
+        "bare zero-arg property decorator must keep TS1329; got: {codes:?}"
+    );
+}
+
+#[test]
+fn property_parenthesized_zero_arg_drops_ts1329_for_generic() {
+    let codes = legacy_codes("class C { @(() => {}) field = 1; }\n");
+    assert!(
+        !codes.contains(&1329) && has_generic_decorator_signature_error(&codes),
+        "parenthesized zero-arg property decorator must drop TS1329 for a generic \
+         signature error; got: {codes:?}"
+    );
+}


### PR DESCRIPTION
Fixes #17121 and #17123 (same root cause, same red test).

When a decorator's resolved type has every call signature at zero required params, tsc does **not** unconditionally emit the TS1329 "did you mean to call it first and write `@d()`?" hint; tsz did, through the checker's shared `decorator_has_zero_arg_factory_shape`. Oracle-verified against pinned `typescript@7.0.2`, tsc substitutes TS1329 for the generic TS1238/1239/1240/1241 arity failure **only** when the decorator expression is a bare `Identifier` (`@d`), a `PropertyAccessExpression` chain (`@a.b`), or a top-level `CallExpression` (`@factory()`) — and keeps the generic family with its normal arity elaboration for a `ParenthesizedExpression` (`@(...)`).

## Structural rule

When every call signature of a decorator takes zero required params, tsc offers the "call it first" hint only for the reference/call forms the `@expr()` rewrite is valid for. A `@(...)` decorator cannot be extended into a `@(...)()` decorator call, so the hint never applies to it — regardless of the inner expression. The discriminator is the **wrapper, not what it wraps**: `@(d)` and `@(a.b)` keep the generic family too. tsz through the checker's `decorator_has_zero_arg_factory_shape` now gates the hint on the decorator expression not being a `ParenthesizedExpression`.

## What changed (owner layer: checker)

- `decorator_signature_checks.rs`: new `decorator_expression_offers_uncalled_hint` helper; `decorator_has_zero_arg_factory_shape` now requires both the zero-arity signature shape **and** an expression that offers the hint. The gate lives in this one shared helper, so class / method / accessor / property decorators all inherit it.
- `class_decorators.rs::check_es_class_decorator_arity`: previously delegated the zero-parameter case entirely to the TS1329 hint and only hand-checked `required_params > 2`. With a parenthesized zero-arg decorator now falling through, this path resolves the call the same way the four member/parameter decorator sites already do — truncating the synthetic `(value, context)` args to `getDecoratorArgumentCount` and emitting TS1238 with the shared TS1278/TS1279 arity elaboration on failure. This uniformly catches both too-many-required (>2) and the zero-parameter too-many-supplied case, and removes an incomplete heuristic.

## Adjacent-case matrix

New `decorator_uncalled_hint_expression_shape_tests.rs` (13 tests, binder names varied so no name-specific fast path can satisfy the rule):

| decorator kind | identifier `@d` | property-access `@ns.d` | call `@factory()` | parenthesized `@(() => {})` | parenthesized ref `@(d)` |
| --- | --- | --- | --- | --- | --- |
| class | TS1329 | TS1329 | TS1329 | TS1238 (no 1329) | TS1238 (no 1329) |
| method | TS1329 | — | — | generic (no 1329) | — |
| accessor | TS1329 | — | — | generic (no 1329) | — |
| property | TS1329 | — | — | generic (no 1329) | — |

Plus compatible 1-/2-param and >2-param controls for the class path.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts1238_tests` → 14/14 (was 13/14: `ts1238_es_decorator_zero_arity_factory_emits_error` red on `main`, now green with no test change).
- `cargo test -p tsz-checker --test decorator_uncalled_hint_expression_shape_tests` → 13/13 (new).
- Full decorator regression sweep across all 19 decorator-related test binaries (`ts1238`/`ts1239`/`ts1240`/`ts1241`/`ts1249`/`ts1270`/`ts1271`/`ts1278_ts1279`/`ts1329`/`ts18036`/`ts2449`/`es_member_decorator_arity`/`decorator_*`/`issue_7681_super_decorator`) → all pass, 0 regressions.
- `cargo clippy -p tsz-checker --lib --tests -- -D warnings`: clean.
- `cargo fmt -p tsz-checker -- --check`: clean.
- `python3 scripts/arch/arch_guard.py`: passes (net-zero `query_boundaries::common` reference count).
- Checker-only change; no emitter/DTS files touched, so no emit sweep needed. TypeScript corpus submodule not checked out this session; the change only moves decorator-signature diagnostics between the TS1329 and TS1238/1239/1240/1241 families, verified by the targeted suites above.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUvQ6Q3Uxv8UqhaBaX6ezQ)_