### PR TITLE
fix(checker): inline structural type annotations render expanded, not via a coincidental alias (#17119)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -1459,6 +1459,19 @@ impl<'a> CheckerState<'a> {
             source_str = display;
             source_from_annotation = true;
         }
+        // An inline tuple / function / constructor source annotation
+        // (`[number, string]`, `(a: number) => void`, `new () => T`) carries no
+        // `aliasSymbol`, so tsc renders its expanded structural form rather than
+        // a coincidentally-shaped alias name reached through the reverse
+        // type-to-def lookup (#17119) — the head-line-renderer twin of the guard
+        // in `format_assignment_source_type_for_diagnostic`.
+        if !source_from_annotation
+            && let Some(display) =
+                self.inline_structural_type_annotation_source_display(anchor_idx, source)
+        {
+            source_str = display;
+            source_from_annotation = true;
+        }
         if !source_from_annotation
             && let Some(expr_idx) = expr_idx
             && !self.declared_identifier_has_literal_only_alias_source(expr_idx)

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -1,5 +1,6 @@
 //! Diagnostic source/target expression analysis and formatting.
 
+mod annotation_gated_structural_display;
 mod assignment_annotation_text;
 mod assignment_formatting;
 mod assignment_source_preservation;

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/annotation_gated_structural_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/annotation_gated_structural_display.rs
@@ -1,0 +1,171 @@
+//! Annotation-gated structural display for TS2322-family assignability source
+//! and target types.
+//!
+//! An inline / anonymous type annotation (`{ a: number }`, `[number, string]`,
+//! `(a: number) => void`, `string | number`) carries no `aliasSymbol`, so tsc
+//! renders its structural shape rather than repainting it with a
+//! coincidentally-shaped non-generic type-alias name reached through the
+//! reverse type-to-def lookup. These helpers gate that structural render on the
+//! written annotation node.
+//!
+//! Relocated from `assignment_formatting.rs` to keep that file under the LOC
+//! ceiling, and extended for #17119: the inline tuple/function/constructor
+//! family (`inline_structural_type_annotation_{source,target}_display`) and the
+//! shared `annotation_gated_structural_target_display` (mirroring the source
+//! side) join the existing anonymous-composite and longhand-union helpers.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    /// Structural display for an assignment **target** whose type was written as
+    /// an inline / anonymous composite annotation (`{ a: number }`,
+    /// `{ a: number } | { b: string }`, `{ a: number } & { b: string }`).
+    ///
+    /// Such an annotation carries no `aliasSymbol`, so tsc renders the structural
+    /// shape rather than a coincidentally-shaped non-generic type-alias name
+    /// reached through the reverse type-to-def lookup. Returns `None` when the
+    /// target was not written as an anonymous composite (a named reference, a
+    /// mixed union/intersection, or a non-composite type), leaving the
+    /// established display path untouched. Shared by every renderer that prints a
+    /// top-level assignability target so they cannot drift on alias display.
+    pub(in crate::error_reporter) fn anonymous_composite_annotation_target_display(
+        &mut self,
+        anchor_idx: NodeIndex,
+        target: TypeId,
+    ) -> Option<String> {
+        self.annotation_gated_structural_target_display(
+            anchor_idx,
+            target,
+            Self::annotation_is_anonymous_structural_composite,
+        )
+    }
+
+    /// Structural display for an assignment **target** whose declared type
+    /// annotation node satisfies `annotation_matches` — an inline shape that
+    /// carries no `aliasSymbol` and so should render by its structure rather than
+    /// a coincidentally-shaped alias reached through the reverse type-to-def
+    /// lookup. The target mirror of
+    /// [`Self::annotation_gated_structural_source_display`].
+    pub(super) fn annotation_gated_structural_target_display(
+        &mut self,
+        anchor_idx: NodeIndex,
+        target: TypeId,
+        annotation_matches: fn(&tsz_parser::NodeArena, NodeIndex) -> bool,
+    ) -> Option<String> {
+        let target_expr = self
+            .assignment_target_expression(anchor_idx)
+            .unwrap_or(anchor_idx);
+        let matches = self
+            .declared_type_annotation_node_for_expression(target_expr)
+            .is_some_and(|(arena, annotation_idx)| annotation_matches(arena, annotation_idx));
+        if !matches {
+            return None;
+        }
+        // A non-generic alias reference reaches the formatter as a `Lazy(DefId)`
+        // whose name path bypasses the composite-structural gate; resolve it to
+        // the structural body first so the inline shape renders even when the
+        // checker canonicalized the annotation type.
+        let resolved = self.resolve_lazy_type(target);
+        Some(self.format_type_for_assignability_message_anonymous_composite_structural(resolved))
+    }
+
+    /// Structural display for an assignment **target** written as an inline
+    /// tuple / function / constructor type annotation. The target mirror of
+    /// [`Self::inline_structural_type_annotation_source_display`] (#17119).
+    pub(in crate::error_reporter) fn inline_structural_type_annotation_target_display(
+        &mut self,
+        anchor_idx: NodeIndex,
+        target: TypeId,
+    ) -> Option<String> {
+        self.annotation_gated_structural_target_display(
+            anchor_idx,
+            target,
+            Self::annotation_is_canonicalized_structural_type,
+        )
+    }
+
+    /// Structural display for an assignment **source** whose declared type
+    /// annotation node satisfies `annotation_matches` — an inline shape that
+    /// carries no `aliasSymbol` and so should render by its structure rather than
+    /// a coincidentally-shaped alias reached through the reverse type-to-def
+    /// lookup. Shared by the anonymous-composite and longhand-primitive-union
+    /// source paths, which differ only in that annotation predicate.
+    pub(super) fn annotation_gated_structural_source_display(
+        &mut self,
+        anchor_idx: NodeIndex,
+        source: TypeId,
+        annotation_matches: fn(&tsz_parser::NodeArena, NodeIndex) -> bool,
+    ) -> Option<String> {
+        let expr_idx = self
+            .direct_diagnostic_source_expression(anchor_idx)
+            .or_else(|| self.assignment_source_expression(anchor_idx))?;
+        let matches = self
+            .declared_type_annotation_node_for_expression(expr_idx)
+            .is_some_and(|(arena, annotation_idx)| annotation_matches(arena, annotation_idx));
+        if !matches {
+            return None;
+        }
+        let resolved = self.resolve_lazy_type(source);
+        Some(self.format_type_for_assignability_message_anonymous_composite_structural(resolved))
+    }
+
+    /// Structural display for an assignment **source** written as an inline /
+    /// anonymous composite annotation. The source mirror of
+    /// [`Self::anonymous_composite_annotation_target_display`].
+    pub(in crate::error_reporter) fn anonymous_composite_annotation_source_display(
+        &mut self,
+        anchor_idx: NodeIndex,
+        source: TypeId,
+    ) -> Option<String> {
+        self.annotation_gated_structural_source_display(
+            anchor_idx,
+            source,
+            Self::annotation_is_anonymous_structural_composite,
+        )
+    }
+
+    /// Structural display for an assignment **source** whose declared type was
+    /// written as a longhand primitive-keyword union (`string | number | symbol`,
+    /// `string | number`). Such an inline union carries no `aliasSymbol`, so tsc
+    /// renders it by its members rather than repainting it with a
+    /// coincidentally-shaped non-generic alias (`PropertyKey`, a user `type`)
+    /// reached through the reverse type-to-def lookup (#16610). Returns `None`
+    /// for any other source shape — including a written-through alias reference
+    /// (`: Zed`), which is a `TYPE_REFERENCE`, not a longhand union — leaving the
+    /// established display path untouched.
+    pub(in crate::error_reporter) fn longhand_primitive_union_source_display(
+        &mut self,
+        anchor_idx: NodeIndex,
+        source: TypeId,
+    ) -> Option<String> {
+        self.annotation_gated_structural_source_display(
+            anchor_idx,
+            source,
+            Self::annotation_is_longhand_primitive_keyword_union,
+        )
+    }
+
+    /// Structural display for an assignment **source** written as an inline
+    /// tuple / function / constructor type annotation (`[number, string]`,
+    /// `(a: number) => void`, `new () => T`). Such an inline structural type
+    /// carries no `aliasSymbol`, so tsc renders its expanded structural form
+    /// rather than a coincidentally-shaped non-generic alias reached through the
+    /// reverse type-to-def lookup (#17119). Returns `None` for any other source
+    /// shape — including a written-through alias reference (`: Fn`), which is a
+    /// `TYPE_REFERENCE`, not an inline structural type — leaving the established
+    /// display path untouched. The source mirror of
+    /// [`Self::inline_structural_type_annotation_target_display`].
+    pub(in crate::error_reporter) fn inline_structural_type_annotation_source_display(
+        &mut self,
+        anchor_idx: NodeIndex,
+        source: TypeId,
+    ) -> Option<String> {
+        self.annotation_gated_structural_source_display(
+            anchor_idx,
+            source,
+            Self::annotation_is_canonicalized_structural_type,
+        )
+    }
+}

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
@@ -128,6 +128,18 @@ impl<'a> CheckerState<'a> {
         {
             return display;
         }
+        // An inline tuple / function / constructor source annotation
+        // (`[number, string]`, `(a: number) => void`, `new () => T`) likewise
+        // carries no `aliasSymbol`, so tsc renders its expanded structural form
+        // rather than repainting it with a coincidentally-shaped alias name
+        // reached through the reverse type-to-def lookup (#17119). A
+        // written-through alias reference (`: Fn`) is a `TYPE_REFERENCE`, not an
+        // inline structural type, and is left to the established path.
+        if let Some(display) =
+            self.inline_structural_type_annotation_source_display(anchor_idx, source)
+        {
+            return display;
+        }
         // A longhand primitive-keyword union source annotation
         // (`string | number | symbol`) likewise carries no `aliasSymbol`; render
         // it by its members instead of a coincidentally-shaped alias (#16610).
@@ -909,102 +921,6 @@ impl<'a> CheckerState<'a> {
                 .is_some_and(|value| value.primitive_type_id() == TypeId::STRING)
     }
 
-    /// Structural display for an assignment **target** whose type was written as
-    /// an inline / anonymous composite annotation (`{ a: number }`,
-    /// `{ a: number } | { b: string }`, `{ a: number } & { b: string }`).
-    ///
-    /// Such an annotation carries no `aliasSymbol`, so tsc renders the structural
-    /// shape rather than a coincidentally-shaped non-generic type-alias name
-    /// reached through the reverse type-to-def lookup. Returns `None` when the
-    /// target was not written as an anonymous composite (a named reference, a
-    /// mixed union/intersection, or a non-composite type), leaving the
-    /// established display path untouched. Shared by every renderer that prints a
-    /// top-level assignability target so they cannot drift on alias display.
-    pub(in crate::error_reporter) fn anonymous_composite_annotation_target_display(
-        &mut self,
-        anchor_idx: NodeIndex,
-        target: TypeId,
-    ) -> Option<String> {
-        let target_expr = self
-            .assignment_target_expression(anchor_idx)
-            .unwrap_or(anchor_idx);
-        let is_anonymous_composite = self
-            .declared_type_annotation_node_for_expression(target_expr)
-            .is_some_and(|(arena, annotation_idx)| {
-                Self::annotation_is_anonymous_structural_composite(arena, annotation_idx)
-            });
-        if !is_anonymous_composite {
-            return None;
-        }
-        // A non-generic alias reference reaches the formatter as a `Lazy(DefId)`
-        // whose name path bypasses the composite-structural gate; resolve it to
-        // the structural body first so the inline shape renders even when the
-        // checker canonicalized the annotation type.
-        let resolved = self.resolve_lazy_type(target);
-        Some(self.format_type_for_assignability_message_anonymous_composite_structural(resolved))
-    }
-
-    /// Structural display for an assignment **source** whose declared type
-    /// annotation node satisfies `annotation_matches` — an inline shape that
-    /// carries no `aliasSymbol` and so should render by its structure rather than
-    /// a coincidentally-shaped alias reached through the reverse type-to-def
-    /// lookup. Shared by the anonymous-composite and longhand-primitive-union
-    /// source paths, which differ only in that annotation predicate.
-    pub(super) fn annotation_gated_structural_source_display(
-        &mut self,
-        anchor_idx: NodeIndex,
-        source: TypeId,
-        annotation_matches: fn(&tsz_parser::NodeArena, NodeIndex) -> bool,
-    ) -> Option<String> {
-        let expr_idx = self
-            .direct_diagnostic_source_expression(anchor_idx)
-            .or_else(|| self.assignment_source_expression(anchor_idx))?;
-        let matches = self
-            .declared_type_annotation_node_for_expression(expr_idx)
-            .is_some_and(|(arena, annotation_idx)| annotation_matches(arena, annotation_idx));
-        if !matches {
-            return None;
-        }
-        let resolved = self.resolve_lazy_type(source);
-        Some(self.format_type_for_assignability_message_anonymous_composite_structural(resolved))
-    }
-
-    /// Structural display for an assignment **source** written as an inline /
-    /// anonymous composite annotation. The source mirror of
-    /// [`Self::anonymous_composite_annotation_target_display`].
-    pub(in crate::error_reporter) fn anonymous_composite_annotation_source_display(
-        &mut self,
-        anchor_idx: NodeIndex,
-        source: TypeId,
-    ) -> Option<String> {
-        self.annotation_gated_structural_source_display(
-            anchor_idx,
-            source,
-            Self::annotation_is_anonymous_structural_composite,
-        )
-    }
-
-    /// Structural display for an assignment **source** whose declared type was
-    /// written as a longhand primitive-keyword union (`string | number | symbol`,
-    /// `string | number`). Such an inline union carries no `aliasSymbol`, so tsc
-    /// renders it by its members rather than repainting it with a
-    /// coincidentally-shaped non-generic alias (`PropertyKey`, a user `type`)
-    /// reached through the reverse type-to-def lookup (#16610). Returns `None`
-    /// for any other source shape — including a written-through alias reference
-    /// (`: Zed`), which is a `TYPE_REFERENCE`, not a longhand union — leaving the
-    /// established display path untouched.
-    pub(in crate::error_reporter) fn longhand_primitive_union_source_display(
-        &mut self,
-        anchor_idx: NodeIndex,
-        source: TypeId,
-    ) -> Option<String> {
-        self.annotation_gated_structural_source_display(
-            anchor_idx,
-            source,
-            Self::annotation_is_longhand_primitive_keyword_union,
-        )
-    }
-
     pub(in crate::error_reporter) fn format_assignment_target_type_for_diagnostic(
         &mut self,
         target: TypeId,
@@ -1019,6 +935,17 @@ impl<'a> CheckerState<'a> {
 
         if let Some(display) =
             self.anonymous_composite_annotation_target_display(anchor_idx, target)
+        {
+            return display;
+        }
+
+        // An inline tuple / function / constructor target annotation
+        // (`[number, string]`, `(a: number) => void`) carries no `aliasSymbol`,
+        // so tsc renders its expanded structural form rather than a
+        // coincidentally-shaped alias name (#17119) — the target mirror of the
+        // source-side guard.
+        if let Some(display) =
+            self.inline_structural_type_annotation_target_display(anchor_idx, target)
         {
             return display;
         }

--- a/crates/tsz-checker/src/error_reporter/tuple_annotation_display_tests.rs
+++ b/crates/tsz-checker/src/error_reporter/tuple_annotation_display_tests.rs
@@ -85,6 +85,61 @@ fn constructor_type_annotation_renders_canonical_spacing() {
 }
 
 #[test]
+fn inline_function_source_with_coincidental_alias_expands() {
+    // #17119: `g` is annotated with an INLINE function type, not with `Fn`.
+    // tsc renders the expanded signature for the source, never a coincidental
+    // structurally-identical alias name.
+    let message = ts2322_message(
+        "type Fn = () => string; declare const g: () => string; \
+         type Want = () => number; const bad: Want = g;",
+    );
+    assert!(
+        message.contains("Type '() => string'"),
+        "inline function-type source must expand, not show the coincidental alias: {message}"
+    );
+    assert!(
+        !message.contains("'Fn'"),
+        "must not substitute the coincidental alias `Fn`: {message}"
+    );
+}
+
+#[test]
+fn inline_tuple_source_with_coincidental_alias_expands() {
+    // A tuple annotation is the same family: `t`'s inline `[number, string]`
+    // has no `aliasSymbol`, so it must expand rather than render as `Pair`.
+    let message = ts2322_message(
+        "type Pair = [number, string]; declare const t: [number, string]; \
+         const a: number[] = t;",
+    );
+    assert!(
+        message.contains("Type '[number, string]'"),
+        "inline tuple source must expand, not show the coincidental alias: {message}"
+    );
+    assert!(
+        !message.contains("'Pair'"),
+        "must not substitute the coincidental alias `Pair`: {message}"
+    );
+}
+
+#[test]
+fn inline_tuple_target_with_coincidental_alias_expands() {
+    // The target mirror: `t`'s inline tuple annotation has no `aliasSymbol`, so
+    // the target renders expanded, not as `Pair`.
+    let message = ts2322_message(
+        "type Pair = [number, string]; declare const s: [string, number]; \
+         const t: [number, string] = s;",
+    );
+    assert!(
+        message.contains("type '[number, string]'"),
+        "inline tuple target must expand, not show the coincidental alias: {message}"
+    );
+    assert!(
+        !message.contains("'Pair'"),
+        "must not substitute the coincidental alias `Pair` on the target: {message}"
+    );
+}
+
+#[test]
 fn tuple_type_alias_annotation_keeps_its_name() {
     // A *reference* to a tuple alias must still display the alias name, not the
     // expanded structural form — the fix is scoped to inline structural

--- a/crates/tsz-checker/src/tests/declared_signature_return_literal_display_tests.rs
+++ b/crates/tsz-checker/src/tests/declared_signature_return_literal_display_tests.rs
@@ -395,6 +395,34 @@ const s: string = v;
 }
 
 #[test]
+fn generic_template_literal_signature_source_with_coincidental_alias_expands() {
+    // #17119 (templateLiteralTypes7.ts shape): `v`'s inline generic signature
+    // annotation has no `aliasSymbol`, even though it is structurally
+    // identical to `G1`. tsc renders the expanded signature for the source;
+    // it must never substitute the coincidentally-shaped alias name.
+    let messages = ts2322_messages(
+        r#"
+type NMap = { 1: string; 2: number; 3: boolean };
+type G1 = <T extends 1 | 2 | 3>(x: `${T}`) => NMap[T];
+type G2 = (x: string) => void;
+declare const v: <T extends 1 | 2 | 3>(x: `${T}`) => NMap[T];
+const bad: G2 = v;
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("<T extends 1 | 2 | 3>(x: `${T}`) => NMap[T]")),
+        "generic template-literal signature source must expand, not show the coincidental \
+         alias `G1`, got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("Type 'G1'")),
+        "must not substitute the coincidental alias `G1`, got: {messages:?}"
+    );
+}
+
+#[test]
 fn declared_unit_literal_source_still_widens_control() {
     // A declared *scalar* unit-literal source widens to its base against a
     // non-literal target (unchanged by this fix; literals have no signature).

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -1360,6 +1360,12 @@ impl<'a> TypeFormatter<'a> {
                         | TypeData::Tuple(_)
                         | TypeData::Union(_)
                         | TypeData::Intersection(_)
+                        // An inline function / constructor annotation
+                        // (`(a: number) => void`, `new () => T`) likewise carries
+                        // no `aliasSymbol`, so a coincidentally-shaped alias body
+                        // must not repaint it (#17119).
+                        | TypeData::Callable(_)
+                        | TypeData::Function(_)
                 );
             let skip_alias = if !def_kind_matches_type_shape {
                 true


### PR DESCRIPTION
Fixes #17119.

**What / why.** #17112 ("render tuple/function type annotations canonically in
diagnostics") regressed the TS2322 head line for a type-alias'd inline function
type: it began printing the alias *name* (`G1`) where `tsc` — and tsz before that
PR — prints the expanded signature. `conformance/types/literal/templateLiteralTypes7.ts`
flipped PASS → FAIL, a fingerprint-only regression (TS2322 both sides, message
text changed) invisible to any code-set comparison.

**Structural rule.** When the operand of an assignability diagnostic is written
as an inline tuple / function / constructor type annotation, it carries no
`aliasSymbol`, so `tsc` renders it by its expanded structure via `typeToString`
— never through a coincidentally-shaped alias reached by reverse type-to-def
lookup. tsz was routing such annotations through the structural `TypeFormatter`
(correct for whitespace, #17112) but the formatter then repainted them with a
reverse-lookup `display_alias`. Owner layer: checker error-reporter display
(`error_reporter/core/diagnostic_source/*`, `error_reporter/assignability.rs`)
plus the shared `TypeFormatter`'s `anonymous_composite_structural` gate
(`tsz-solver/src/diagnostics/format`).

**Fix.**
- Extend the formatter's `anonymous_composite_structural` alias-suppression from
  `Object` / `ObjectWithIndex` / `Tuple` / `Union` / `Intersection` to also
  `Callable` / `Function`.
- Add `inline_structural_type_annotation_{source,target}_display`, gated on the
  existing `annotation_is_canonicalized_structural_type` predicate, mirroring the
  established `anonymous_composite_annotation_*` and `longhand_primitive_union_*`
  guards; wire the source guard into both source-display pipelines and the target
  guard into the assignment-target formatter.
- Fold the anonymous-composite target helper into a shared
  `annotation_gated_structural_target_display` (mirroring the source side) and
  relocate the annotation-gated structural-display helpers into a new
  `annotation_gated_structural_display.rs` so `assignment_formatting.rs` stays
  under the 2000-LOC arch ceiling.

**Adjacent-case matrix** (source *and* target, not scoped to the reported shape):
inline function/tuple/constructor annotations with a coincidental alias in scope
render expanded; a written-through alias reference (`: Fn`, `: Pair`) is a
`TYPE_REFERENCE` and keeps its name; #17112's whitespace-canonicalization rows
still hold. Known remaining gap (separate renderer, out of scope): a
function-*typed* target whose head comes from the contravariant
signature-elaboration path (`element_mismatch_message`, which has no annotation
anchor) still shows the alias; object/tuple targets are covered.

**Composes cleanly with #17148** (merged, spacing/literal canonicalization):
an m4-session review measured the full 12-row acceptance matrix (11 spacing
rows from #17148 + this PR's alias row) at 12/12 on the composed tree — the two
mechanisms are independent and this PR gives back none of #17148's rows.

**Regression test added per review request:** the reviewer asked for the
alias row to be pinned directly, since it had been silently traded away three
times across prior PRs precisely because trading it is always green elsewhere.
Added `generic_template_literal_signature_source_with_coincidental_alias_expands`
in `declared_signature_return_literal_display_tests.rs`, using the real
`templateLiteralTypes7.ts` shape — a generic signature `[T extends 1 | 2 | 3](x: \`${T}\`) => NMap[T]`
written with square brackets standing in for angle brackets here (this board strips
real angle brackets on write) — versus a coincidentally-named alias `G1`. Confirmed
red on the pre-fix code via a temporary revert of the production changes, green
with them restored.

## Goal
Goal: hold

## Verification
- Rebased onto current `main` (`7f97336`, includes #17148's spacing work), no conflicts.
- `cargo test -p tsz-checker --lib declared_signature_return_literal_display_tests` — 30/30 (29 pre-existing + 1 new alias-row pin), confirmed the new test is red on pre-fix code (temporary revert of the four production files) and green with the fix restored.
- `cargo test -p tsz-checker --lib -- assignment_formatting annotation_gated_structural_display tuple_annotation_display literal_display` — 56/56 (neighboring display suites, 0 regressions).
- `cargo test -p tsz-solver --lib diagnostics::format` — 251 passed.
- `cargo clippy -p tsz-checker -p tsz-solver --lib -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — green (assignment_formatting.rs split stays under the 2000-LOC ceiling).
- `cargo fmt -p tsz-checker -- --check` — clean.
- conformance/emit run on the nightly lane (not the per-PR clippy + arch-size lane); the `templateLiteralTypes7` shape is now pinned by a unit test tied directly to the real fixture text, not just the general alias-suppression rows.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE