### PR TITLE
fix(checker): JS this[key]= only late-binds a class property for a literal-like key

### DIFF
--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -997,6 +997,8 @@ mod ts2739_alias_unfold_display_tests;
 mod ts7053_apparent_receiver_display_tests;
 #[path = "tests/ts7053_index_reason_chain_tests.rs"]
 mod ts7053_index_reason_chain_tests;
+#[path = "tests/ts7053_js_constructor_element_access_literal_like_tests.rs"]
+mod ts7053_js_constructor_element_access_literal_like_tests;
 #[path = "tests/ts8030_jsdoc_type_tag_message_tests.rs"]
 mod ts8030_jsdoc_type_tag_message_tests;
 #[path = "tests/tuple_spread_flattening_tests.rs"]

--- a/crates/tsz-checker/src/tests/ts7053_js_constructor_element_access_literal_like_tests.rs
+++ b/crates/tsz-checker/src/tests/ts7053_js_constructor_element_access_literal_like_tests.rs
@@ -1,0 +1,249 @@
+//! A `this[key] = value` assignment in a checked-JS constructor only
+//! late-binds an implicit class property when `key` is written as a
+//! syntactically literal node (string, numeric, or no-substitution-template
+//! literal) — tsc's `isLiteralLikeElementAccess`. A `const` reference whose
+//! *type* happens to be a literal (e.g. `const _sym = "s"; this[_sym] = v;`,
+//! or the `Symbol("s")` / `unique symbol` case the real conformance fixtures
+//! use) does not late-bind; it stays an ordinary element access and reports
+//! `TS7053` ("element implicitly has an 'any' type") like any other unmatched
+//! key, exactly as it already does in a plain `.ts` file. Oracle-verified
+//! against `typescript@7.0.2`. Tests here use string/numeric literal consts
+//! rather than `Symbol(...)` because this crate's unit-test harness has no
+//! lib (`Symbol` is unresolved) — the gate is type-agnostic (syntax-only), so
+//! this is full coverage of the mechanism; the exact `Symbol()`/`unique
+//! symbol` fixtures are covered by the TypeScript conformance corpus.
+//!
+//! Two independent owners had to change, both keyed on the same syntactic
+//! literal-like predicate:
+//! - `types/class_type/js_class_properties.rs`'s `extract_this_property_assignment`
+//!   / `extract_jsdoc_this_property_declaration` no longer *synthesize* an
+//!   implicit member from a non-literal element-access key (previously
+//!   derived the property name from the key's evaluated *type*, via
+//!   `literal_property_name`).
+//! - `types/computation/access_helpers.rs`'s `is_direct_expando_element_write_base`
+//!   no longer grants a `this`/`this`-alias write inside a class the generic
+//!   JS "expando object" `TS7053` suppression that plain untyped objects and
+//!   namespace/function statics legitimately get — a class instance is
+//!   nominally typed and tsc never treats it as expando-shaped.
+//!
+//! Witness: `TypeScript/tests/cases/conformance/salsa/lateBoundClassMemberAssignmentJS{,2,3}.ts`.
+
+use crate::CheckerOptions;
+use crate::test_utils::check_js_source_codes_with_options;
+use tsz_common::common::ScriptTarget;
+
+const TS7053: u32 = 7053;
+
+fn strict_js_codes(source: &str) -> Vec<u32> {
+    check_js_source_codes_with_options(
+        source,
+        "test.js",
+        CheckerOptions {
+            strict: true,
+            target: ScriptTarget::ES2015,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn count(codes: &[u32], code: u32) -> usize {
+    codes.iter().filter(|&&c| c == code).count()
+}
+
+#[test]
+fn numeric_literal_typed_const_key_does_not_late_bind() {
+    // TypeScript/tests/cases/conformance/salsa/lateBoundClassMemberAssignmentJS.ts,
+    // with `Symbol("_sym")` (needs lib) swapped for another literal-typed
+    // const the harness can resolve without one; same non-literal-key rule.
+    let codes = strict_js_codes(
+        r#"
+const _sym = 42;
+export class MyClass {
+    constructor() {
+        this[_sym] = "ok";
+    }
+
+    method() {
+        this[_sym] = "yep";
+        const x = this[_sym];
+    }
+}
+"#,
+    );
+    assert_eq!(
+        count(&codes, TS7053),
+        3,
+        "one TS7053 per unmatched this[_sym] site: {codes:?}"
+    );
+}
+
+#[test]
+fn string_literal_typed_const_key_does_not_late_bind() {
+    // TypeScript/tests/cases/conformance/salsa/lateBoundClassMemberAssignmentJS2.ts
+    let codes = strict_js_codes(
+        r#"
+const _sym = "my-fake-sym";
+export class MyClass {
+    constructor() {
+        this[_sym] = "ok";
+    }
+
+    method() {
+        this[_sym] = "yep";
+        const x = this[_sym];
+    }
+}
+"#,
+    );
+    assert_eq!(
+        count(&codes, TS7053),
+        3,
+        "the key's evaluated literal type must not stand in for a written literal: {codes:?}"
+    );
+}
+
+#[test]
+fn this_alias_const_key_does_not_late_bind() {
+    // TypeScript/tests/cases/conformance/salsa/lateBoundClassMemberAssignmentJS3.ts —
+    // `var self = this` alias, same non-literal-key rule applies through the alias.
+    let codes = strict_js_codes(
+        r#"
+const _sym = 42;
+export class MyClass {
+    constructor() {
+        var self = this
+        self[_sym] = "ok";
+    }
+
+    method() {
+        var self = this
+        self[_sym] = "yep";
+        const x = self[_sym];
+    }
+}
+"#,
+    );
+    assert_eq!(
+        count(&codes, TS7053),
+        3,
+        "the this-alias path shares the same literal-like gate: {codes:?}"
+    );
+}
+
+#[test]
+fn renamed_binder_still_does_not_late_bind() {
+    // Same shape as the unique-symbol case with a different identifier, to
+    // prove the gate is syntactic (literal-vs-reference), not name-driven.
+    let codes = strict_js_codes(
+        r#"
+const key = "widget-key";
+export class Widget {
+    constructor() {
+        this[key] = 1;
+    }
+}
+"#,
+    );
+    assert_eq!(count(&codes, TS7053), 1, "{codes:?}");
+}
+
+#[test]
+fn string_literal_key_still_late_binds() {
+    // Positive control: a key written directly as a string literal in the
+    // brackets is exactly tsc's `isLiteralLikeElementAccess` case and must
+    // keep late-binding as it already correctly does.
+    let codes = strict_js_codes(
+        r#"
+export class MyClass {
+    constructor() {
+        this["ok"] = "value";
+    }
+    method() {
+        this["ok"] = "yep";
+        const x = this["ok"];
+    }
+}
+"#,
+    );
+    assert_eq!(count(&codes, TS7053), 0, "{codes:?}");
+}
+
+#[test]
+fn numeric_literal_key_still_late_binds() {
+    let codes = strict_js_codes(
+        r#"
+export class MyClass {
+    constructor() {
+        this[0] = "value";
+    }
+    method() {
+        const x = this[0];
+    }
+}
+"#,
+    );
+    assert_eq!(count(&codes, TS7053), 0, "{codes:?}");
+}
+
+#[test]
+fn no_substitution_template_literal_key_still_late_binds() {
+    let codes = strict_js_codes(
+        r#"
+export class MyClass {
+    constructor() {
+        this[`ok`] = "value";
+    }
+    method() {
+        const x = this[`ok`];
+    }
+}
+"#,
+    );
+    assert_eq!(count(&codes, TS7053), 0, "{codes:?}");
+}
+
+#[test]
+fn jsdoc_annotated_non_literal_key_does_not_late_bind() {
+    // The JSDoc-declaration sibling path (`extract_jsdoc_this_property_declaration`)
+    // shares the same literal-like gate as the plain assignment path.
+    let codes = strict_js_codes(
+        r#"
+const _sym = 42;
+export class MyClass {
+    constructor() {
+        /** @type {string} */
+        this[_sym] = "ok";
+    }
+    method() {
+        const x = this[_sym];
+    }
+}
+"#,
+    );
+    assert_eq!(
+        count(&codes, TS7053),
+        2,
+        "a JSDoc type annotation does not make a const reference literal-like: {codes:?}"
+    );
+}
+
+#[test]
+fn dotted_this_property_assignment_unaffected() {
+    // Regression guard: the ordinary `this.prop = value` (PropertyAccessExpression)
+    // path never went through the element-access literal-like gate and must
+    // keep late-binding exactly as before.
+    let codes = strict_js_codes(
+        r#"
+export class MyClass {
+    constructor() {
+        this.prop = "value";
+    }
+    method() {
+        this.prop = "yep";
+        const x = this.prop;
+    }
+}
+"#,
+    );
+    assert_eq!(count(&codes, TS7053), 0, "{codes:?}");
+}

--- a/crates/tsz-checker/src/types/class_type/js_class_properties.rs
+++ b/crates/tsz-checker/src/types/class_type/js_class_properties.rs
@@ -1045,6 +1045,23 @@ impl CheckerState<'_> {
                 .is_some_and(|d| self.ctx.arena.get_parameter(d).is_some())
     }
 
+    /// tsc's `isLiteralLikeElementAccess`: an element-access assignment onto
+    /// `this` (or a `this` alias) only counts as a special this-property
+    /// declaration when the bracketed key is itself a string, numeric, or
+    /// no-substitution-template literal written at that site — not any
+    /// expression that merely evaluates to a literal type. A `const`
+    /// reference (`this[_sym] = v` for `const _sym = Symbol(...)` or
+    /// `const _sym = "lit"`) does not late-bind; it stays an ordinary
+    /// element access and reports `TS7053` like any other unmatched key.
+    fn element_access_key_is_literal_like(&self, key_idx: NodeIndex) -> bool {
+        let key_idx = self.ctx.arena.skip_parenthesized(key_idx);
+        self.ctx.arena.get(key_idx).is_some_and(|node| {
+            node.kind == SyntaxKind::StringLiteral as u16
+                || node.kind == SyntaxKind::NumericLiteral as u16
+                || node.kind == SyntaxKind::NoSubstitutionTemplateLiteral as u16
+        })
+    }
+
     /// Extract a `this.propName = rhs`, `alias.propName = rhs`,
     /// `this[computed] = rhs`, or `alias[computed] = rhs` pattern
     /// from an expression statement. The `this_aliases` parameter contains
@@ -1096,9 +1113,13 @@ impl CheckerState<'_> {
         }
 
         if is_element_access {
-            // For element access (this[key] = value), evaluate the key expression's
-            // type to get a property name. Handles Symbol keys, string literal keys,
-            // and const variable references.
+            // For element access (this[key] = value), only a syntactically
+            // literal key late-binds a class property (tsc's
+            // `isLiteralLikeElementAccess`); a const/Symbol reference falls
+            // through to ordinary element-access checking (TS7053).
+            if !self.element_access_key_is_literal_like(access.name_or_argument) {
+                return None;
+            }
             let arg_idx = access.name_or_argument;
             let prev = self.ctx.preserve_literal_types;
             self.ctx.preserve_literal_types = true;
@@ -1167,6 +1188,9 @@ impl CheckerState<'_> {
         }
 
         if is_element_access {
+            if !self.element_access_key_is_literal_like(access.name_or_argument) {
+                return None;
+            }
             let prev_preserve = self.ctx.preserve_literal_types;
             self.ctx.preserve_literal_types = true;
             let key_type = self.get_type_of_node(access.name_or_argument);

--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -351,6 +351,49 @@ impl<'a> CheckerState<'a> {
         };
         node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
             && node.kind != syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+            // `this` (and a `var self = this` alias) inside a class is a nominally
+            // typed instance, not an untyped JS namespace/object-literal value —
+            // tsc never grants it expando-write immunity. A non-literal-like key
+            // there stays a checked miss (`TS7053`), and a literal-like key is
+            // already a real synthesized member (`js_class_properties.rs`), so
+            // this path is only reachable for the non-literal case either way.
+            && !(self.ctx.enclosing_class.is_some()
+                && self.expression_resolves_to_this(object_expr_idx))
+    }
+
+    /// Whether `idx` is `this` itself or a local `const`/`let`/`var` bound
+    /// directly to `this` (the common `var self = this;` alias pattern).
+    /// Single-hop only, matching `collect_this_aliases`'s scope.
+    fn expression_resolves_to_this(&self, idx: NodeIndex) -> bool {
+        let Some(node) = self.ctx.arena.get(idx) else {
+            return false;
+        };
+        if node.kind == SyntaxKind::ThisKeyword as u16 {
+            return true;
+        }
+        if node.kind != SyntaxKind::Identifier as u16 {
+            return false;
+        }
+        let Some(sym_id) = self.ctx.binder.resolve_identifier(self.ctx.arena, idx) else {
+            return false;
+        };
+        let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
+            return false;
+        };
+        let decl = symbol.value_declaration;
+        if decl.is_none() {
+            return false;
+        }
+        let Some(decl_node) = self.ctx.arena.get(decl) else {
+            return false;
+        };
+        let Some(var_decl) = self.ctx.arena.get_variable_declaration(decl_node) else {
+            return false;
+        };
+        self.ctx
+            .arena
+            .get(var_decl.initializer)
+            .is_some_and(|init| init.kind == SyntaxKind::ThisKeyword as u16)
     }
 
     pub(crate) fn is_expando_element_access_read(


### PR DESCRIPTION
Fixes the `TS7053` family tracked in `conformance-detail.json`:
`TypeScript/tests/cases/conformance/salsa/lateBoundClassMemberAssignmentJS{,2,3}.ts`.

**Structural rule.** When a checked-JS constructor/method assigns
`this[key] = value` (or through a `var self = this` alias), `tsc`'s
`isLiteralLikeElementAccess` only treats it as an implicit class-property
declaration when `key` is written as a syntactically literal node (string,
numeric, or no-substitution-template literal). A `const` reference whose
*evaluated type* happens to be a string or `unique symbol` literal
(`const _sym = Symbol("s")` / `const _sym = "lit"`; `this[_sym] = v`) does
**not** late-bind — it stays an ordinary element access and reports `TS7053`
("element implicitly has an 'any' type") exactly as it already does in a
plain `.ts` file. tsz was silently accepting these writes end-to-end (no
diagnostic at all) through two independent, over-matching owners:

- `types/class_type/js_class_properties.rs`'s `extract_this_property_assignment`
  / `extract_jsdoc_this_property_declaration` derived the synthesized
  property's name from the key expression's *type*
  (`literal_property_name`/`get_type_of_node`) rather than its syntax, so a
  `const` reference late-bound a real member just like a written literal
  would. Fixed with a new `element_access_key_is_literal_like` syntactic gate
  shared by both element-access branches.
- `types/computation/access_helpers.rs`'s `is_direct_expando_element_write_base`
  granted `this[key] = value` (and the `self` alias) the generic JS "expando
  object" `TS7053` suppression that plain untyped objects and
  namespace/function statics legitimately get in `tsc`. A class instance is
  nominally typed and `tsc` never treats it as expando-shaped, so once the
  first owner stopped synthesizing the member, this second path was still
  silently swallowing the resulting `TS7053` via `is_expando_write`. Fixed by
  excluding `this`/`this`-alias receivers inside an enclosing class
  (`self.ctx.enclosing_class.is_some()`) from expando-write treatment.

Both fixes are needed together — either alone still leaves the element access
silently accepted.

Adjacent-case matrix (oracle-verified against pinned `typescript@7.0.2`):
string/numeric/no-substitution-template literal keys still correctly
late-bind (positive controls, unchanged behavior); a `const` string- or
number-literal-typed key does not (constructor write, method write, and
read — all three sites independently, oracle shows one `TS7053` per site);
the `var self = this` alias shares the same gate; a JSDoc `@type`-annotated
`this[const]` assignment does not exempt a non-literal key either; renamed
binders behave identically (gate is syntactic, not identifier-driven); the
ordinary `this.prop = value` (`PropertyAccessExpression`) path is unaffected
(regression guard). Unit tests use string/numeric literal consts rather than
`Symbol(...)` because this crate's harness has no lib (`Symbol` unresolved);
the gate itself is type-agnostic so this is full mechanism coverage — the
exact `Symbol()`/`unique symbol` fixtures are the TypeScript conformance
corpus witnesses above.

## Goal
Goal: hold

## Verification
- New `ts7053_js_constructor_element_access_literal_like_tests` — 9/9 pass.
- `cargo test -p tsz-checker --lib -- expando ts7008 ts7053 js_class_prop late_bound` —
  124/124 pass, 0 regressions (covers `expando_annotated_receiver_tests`,
  `js_expando_order_sensitivity_tests`, `ts2683_tests` js-expando-`this`
  family, `ts7053_index_reason_chain_tests`, `no_index_element_implicit_any_tests`,
  etc.).
- `cargo build -p tsz-cli --bin tsz` (dev) run directly against all three
  target conformance fixtures — output now matches the pinned `tsc 7.0.2`
  oracle exactly (code, line, column) for all 3 unmatched sites in each file
  (previously 0 diagnostics in all three).
- `cargo clippy -p tsz-checker --lib --no-deps` clean. `cargo fmt --check -p tsz-checker` clean.
  Pre-commit hook's own `cargo test -p tsz-checker` + clippy + arch-guard gate passed at commit time.
- Not run this session: the full `cargo test -p tsz-checker --lib` sweep (a
  pre-existing, unrelated slow test —
  `ts2589_tests::recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589`
  — ran past 5+ minutes without finishing) and the corpus-level
  `conformance.sh`/`compare-to-parent.sh` sweep (no time left in-session).
  Both are test-only-adjacent-risk given the change is scoped to two
  functions gated on a narrow, oracle-verified syntactic predicate, but
  flagging as owed rather than silently skipped — a warm-corpus follow-up
  session can clear this in one pass.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_019YizcFVS59K3c2SA5ptkiE)_