### PR TITLE
fix(checker): overload arity-mismatch diagnostics count expanded spread args

### DIFF
--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution/resolve_signatures.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution/resolve_signatures.rs
@@ -1930,16 +1930,19 @@ impl<'a> CheckerState<'a> {
         // Restore original state if no overload matched
         self.ctx.node_types = original_node_types;
         if all_arg_count_mismatches && !failures.is_empty() {
+            // Expanded count, not `args.len()`: a spread expands to multiple
+            // arguments (`f(1, ...[2, 3])` has 2 `args` nodes but 3 arguments).
+            let actual_count = arg_types.len();
             if !any_has_rest
                 && !exact_expected_counts.is_empty()
-                && !exact_expected_counts.contains(&args.len())
+                && !exact_expected_counts.contains(&actual_count)
             {
                 let mut lower = None;
                 let mut upper = None;
                 for &count in &exact_expected_counts {
-                    if count < args.len() {
+                    if count < actual_count {
                         lower = Some(lower.map_or(count, |prev: usize| prev.max(count)));
-                    } else if count > args.len() {
+                    } else if count > actual_count {
                         upper = Some(upper.map_or(count, |prev: usize| prev.min(count)));
                     }
                 }
@@ -1947,7 +1950,7 @@ impl<'a> CheckerState<'a> {
                     return Some(OverloadResolution {
                         arg_types,
                         result: CallResult::OverloadArgumentCountMismatch {
-                            actual: args.len(),
+                            actual: actual_count,
                             expected_low,
                             expected_high,
                         },
@@ -1967,7 +1970,7 @@ impl<'a> CheckerState<'a> {
                     } else {
                         Some(min_expected)
                     },
-                    actual: args.len(),
+                    actual: actual_count,
                 },
                 selected_type_predicate: None,
             });

--- a/crates/tsz-checker/src/test_module_registry.rs
+++ b/crates/tsz-checker/src/test_module_registry.rs
@@ -747,6 +747,8 @@ mod overlap_relation_helper_routing_arch_tests;
 mod overload_anchor_at_argument_tests;
 #[path = "tests/overload_argument_reason_chain_tests.rs"]
 mod overload_argument_reason_chain_tests;
+#[path = "tests/overload_arity_expanded_spread_count_tests.rs"]
+mod overload_arity_expanded_spread_count_tests;
 #[path = "tests/overload_elaboration_tests.rs"]
 mod overload_elaboration_tests;
 #[path = "tests/overload_generic_wrapper_compat_tests.rs"]

--- a/crates/tsz-checker/src/tests/overload_arity_expanded_spread_count_tests.rs
+++ b/crates/tsz-checker/src/tests/overload_arity_expanded_spread_count_tests.rs
@@ -1,0 +1,99 @@
+//! Regression tests: an overload-set arity-mismatch diagnostic (TS2554/TS2575)
+//! must report the *expanded* argument count (a spread of an array literal
+//! contributes one entry per element), not the raw number of argument
+//! expressions. See `resolve_signatures.rs`'s final "no overload matched on
+//! arity" fallback, which previously used `args.len()` (raw expression count)
+//! instead of the already-correctly-expanded `arg_types.len()`.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn diagnostics_with_code(
+    diagnostics: &[crate::diagnostics::Diagnostic],
+    code: u32,
+) -> Vec<&crate::diagnostics::Diagnostic> {
+    diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == code)
+        .collect()
+}
+
+fn diagnostic_messages<'a>(diagnostics: &[&'a crate::diagnostics::Diagnostic]) -> Vec<&'a str> {
+    diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.message_text.as_str())
+        .collect()
+}
+
+/// Regression: when every overload of a call fails on argument count, tsc's
+/// TS2554 "got N" must count expanded arguments (a spread of an array literal
+/// contributes one entry per element), not raw argument *expressions*.
+/// `f2(1, 2, 3, 4, 5, ...[6, 7])` has 6 argument expressions but supplies 7
+/// arguments. Oracle-verified (`typescript@7.0.2`): "Expected 0-6 arguments,
+/// but got 7." tsz's overload-resolution fallback previously reported "got 6"
+/// here (`args.len()`, the raw expression count) even though the identical
+/// call against a single signature already reported the correct count.
+#[test]
+fn overload_all_arity_mismatch_counts_expanded_spread_arguments() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function f2(): void;
+declare function f2(a: number, b: number): void;
+declare function f2(a: number, b: number, c: number, d: number): void;
+declare function f2(a: number, b: number, c: number, d: number, e: number, f: number): void;
+f2(1, 2, 3, 4, 5, ...[6, 7]);
+"#,
+    );
+
+    let ts2554 = diagnostics_with_code(&diags, 2554);
+    assert_eq!(
+        diagnostic_messages(&ts2554),
+        vec!["Expected 0-6 arguments, but got 7."],
+        "expanded spread elements must count toward the reported argument total"
+    );
+}
+
+/// Sibling of the above at the `OverloadArgumentCountMismatch` ("no overload
+/// expects N, but overloads do exist that expect M or K") reporting path: a
+/// spread landing exactly in the gap between two overloads' exact arities
+/// must also report the expanded count.
+#[test]
+fn overload_gap_arity_mismatch_counts_expanded_spread_arguments() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function g(x: number): void;
+declare function g(x: number, y: number, z: number): void;
+g(1, ...[2]);
+"#,
+    );
+
+    let ts2575 = diagnostics_with_code(&diags, 2575);
+    assert_eq!(
+        diagnostic_messages(&ts2575),
+        vec![
+            "No overload expects 2 arguments, but overloads do exist that expect either 1 or 3 arguments."
+        ],
+        "expanded spread elements must count toward the reported gap total"
+    );
+}
+
+/// Non-spread control: plain-literal too-many-arguments overload failure is
+/// unaffected by the expanded-count fix (raw and expanded counts coincide
+/// when there is no spread).
+#[test]
+fn overload_all_arity_mismatch_plain_arguments_unaffected() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function f2(): void;
+declare function f2(a: number, b: number): void;
+declare function f2(a: number, b: number, c: number, d: number): void;
+declare function f2(a: number, b: number, c: number, d: number, e: number, f: number): void;
+f2(1, 2, 3, 4, 5, 6, 7);
+"#,
+    );
+
+    let ts2554 = diagnostics_with_code(&diags, 2554);
+    assert_eq!(
+        diagnostic_messages(&ts2554),
+        vec!["Expected 0-6 arguments, but got 7."]
+    );
+}


### PR DESCRIPTION
Fixes TS2554/TS2575 undercounting by 1 for `f(1, 2, ...[3, 4])`-shaped calls against an overloaded function whose arity every candidate signature fails.

**Structural rule.** When tsc reports the aggregate "no overload matched on argument count" diagnostic (TS2554 "Expected X-Y arguments, but got N" or TS2575 "No overload expects N arguments..."), N is the *expanded* argument count — a spread of an array literal contributes one entry per element, the same count every per-signature attempt already computes and reports correctly. tsz's `resolve_overloaded_call_with_signatures` final fallback (used only once every individual overload has failed on arity) instead used `args.len()`, the raw number of argument *expressions* — so a trailing spread collapsed to a single expression node regardless of how many elements it carried. `f2(1, 2, 3, 4, 5, ...[6, 7])` has 6 argument expressions but supplies 7 arguments; tsz reported "got 6", tsc (oracle-verified against pinned `typescript@7.0.2`) reports "got 7". The identical call against a non-overloaded single signature already used the correct expanded count (confirmed via `TSZ_LOG=debug` tracing — each per-signature attempt already sees the correct expanded `arg_types`), so this only affected the overload-exhausted aggregation fallback path, owned by the checker's overload-resolution layer (`crates/tsz-checker/src/checkers/call_checker/overload_resolution/resolve_signatures.rs`).

**Fix.** Reuse the already-collected, correctly-expanded `arg_types` (built once up front via `collect_call_argument_types_with_context`) instead of re-deriving the count from the raw `args` node list, in both the `OverloadArgumentCountMismatch` ("gap between two exact arities") and `ArgumentCountMismatch` ("exceeds every arity") branches of the fallback.

**Adjacent-case matrix** (oracle-verified against pinned `typescript@7.0.2`): the TS2554 "exceeds every arity" path (new test), the sibling TS2575 "gap between two exact arities" path that shares the same aggregation code (new test), and a plain-argument (no-spread) control confirming raw and expanded counts coincide there so the fix doesn't touch the common case (new test).

## Goal
Goal: hold

## Verification
- New `overload_arity_expanded_spread_count_tests` (3 tests) — all pass, messages byte-for-byte match the pinned typescript@7.0.2 oracle.
- `cargo test -p tsz-checker --lib -- overload spread arity call` — 1694/1694 pass, 0 regressions.
- `cargo build -p tsz-cli --bin tsz` (dev) run directly against the original conformance-tracked fixture (`functionParameterArityMismatch.ts`) — output now byte-for-byte matches the pinned tsc 7.0.2 oracle (previously diverged only at the one spread-arity line).
- `cargo clippy -p tsz-checker --lib --no-deps` clean. `cargo fmt --check -p tsz-checker` clean. `python3 scripts/arch/arch_guard.py` green (split the 3 new tests into their own file — `overload_arity_expanded_spread_count_tests.rs` — rather than pushing `call_architecture_tests.rs` over the 2000-line ceiling; also trimmed a comment in `resolve_signatures.rs` to stay under the ceiling there).
- Not run this session: the full unsharded `cargo test -p tsz-checker --lib` sweep (a pre-existing, unrelated slow test hangs it past 200s+, per the board's standing note) and the corpus-level `conformance.sh`/`compare-to-parent.sh` sweep. The change is scoped to one aggregation fallback's argument-count source and is oracle-verified at the message level, but flagging both as owed for a warm-corpus follow-up.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE

---
_Generated by [Claude Code](https://claude.ai/code/session_018ksm53GtPwe2eDGoWD4NVu)_