### PR TITLE
fix(checker): merged-interface property/method conflict is TS2300 regardless of order

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2863,5 +2863,8 @@ path = "tests/ts1339_bare_typeof_import_no_value_tests.rs"
 name = "ts2687_merged_interface_declaration_tests"
 path = "tests/ts2687_merged_interface_declaration_tests.rs"
 [[test]]
+name = "ts2300_merged_interface_property_method_conflict_tests"
+path = "tests/ts2300_merged_interface_property_method_conflict_tests.rs"
+[[test]]
 name = "ts2694_typeof_import_qualified_type_only_member_tests"
 path = "tests/ts2694_typeof_import_qualified_type_only_member_tests.rs"

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_followup.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_followup.rs
@@ -536,42 +536,27 @@ impl<'a> CheckerState<'a> {
                         merged_properties.get(name)
                     {
                         // Handle property-vs-method conflicts across merged declarations.
+                        // tsc's binder cannot merge a property-signature symbol with a
+                        // method-signature symbol under the same name (their `SymbolFlags`
+                        // combination is not mergeable), so this is TS2300 duplicate
+                        // identifier on both declarations regardless of which kind was
+                        // declared first — unlike a same-kind property/property mismatch,
+                        // which is a type comparison (TS2717) handled below.
                         if *is_method != existing_is_method {
-                            if *is_method && !existing_is_method {
-                                // Method after property: TS2300 on both declarations.
-                                // tsc treats a method signature conflicting with an
-                                // existing property signature as a duplicate identifier.
-                                let message = crate::diagnostics::format_message(
-                                    crate::diagnostics::diagnostic_messages::DUPLICATE_IDENTIFIER,
-                                    &[name],
-                                );
-                                self.error_at_node(
-                                    existing_name_idx,
-                                    &message,
-                                    diagnostic_codes::DUPLICATE_IDENTIFIER,
-                                );
-                                self.error_at_node(
-                                    *name_idx,
-                                    &message,
-                                    diagnostic_codes::DUPLICATE_IDENTIFIER,
-                                );
-                            } else {
-                                // Property after method: TS2717 comparing property type
-                                // against the method's function type.
-                                if !self.type_contains_error(*property_type)
-                                    && !self.type_contains_error(existing_type)
-                                    && !self
-                                        .duplicate_decl_types_match(existing_type, *property_type)
-                                {
-                                    let existing_type_str = self.format_type(existing_type);
-                                    let property_type_str = self.format_type(*property_type);
-                                    self.error_at_node_msg(
-                                        *name_idx,
-                                        diagnostic_codes::SUBSEQUENT_PROPERTY_DECLARATIONS_MUST_HAVE_THE_SAME_TYPE_PROPERTY_MUST_BE_OF_TYP,
-                                        &[name, &existing_type_str, &property_type_str],
-                                    );
-                                }
-                            }
+                            let message = crate::diagnostics::format_message(
+                                crate::diagnostics::diagnostic_messages::DUPLICATE_IDENTIFIER,
+                                &[name],
+                            );
+                            self.error_at_node(
+                                existing_name_idx,
+                                &message,
+                                diagnostic_codes::DUPLICATE_IDENTIFIER,
+                            );
+                            self.error_at_node(
+                                *name_idx,
+                                &message,
+                                diagnostic_codes::DUPLICATE_IDENTIFIER,
+                            );
                             continue;
                         }
 

--- a/crates/tsz-checker/tests/ts2300_merged_interface_property_method_conflict_tests.rs
+++ b/crates/tsz-checker/tests/ts2300_merged_interface_property_method_conflict_tests.rs
@@ -1,0 +1,101 @@
+//! TS2300 for merged interface declarations whose same-named member disagrees
+//! on signature *kind* (a property signature in one declaration, a method
+//! signature in another).
+//!
+//! Structural rule: when two or more top-level `interface` declarations with
+//! the same name merge into one symbol, `tsc`'s binder cannot merge a
+//! property-signature symbol (`SymbolFlags::Property`) with a method-signature
+//! symbol (`SymbolFlags::Method`) under the same name — that flag combination
+//! is not mergeable, so it reports TS2300 ("Duplicate identifier") on every
+//! conflicting declaration, regardless of which kind was declared first. This
+//! is distinct from a same-kind property/property mismatch, which is a type
+//! comparison (TS2717 "Subsequent property declarations must have the same
+//! type"). `check_merged_interface_declaration_diagnostics`
+//! (`duplicate_identifiers_followup.rs`) previously only recognized the
+//! method-after-property direction as TS2300 and mis-routed the reverse
+//! (property-after-method) through the TS2717 type-comparison branch — the two
+//! branches must be symmetric. Oracle-verified against `typescript@7.0.2`
+//! (`compiler/methodSignatureHandledDeclarationKindForSymbol.ts`).
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn ts2300_count(source: &str) -> usize {
+    check_source_diagnostics(source)
+        .iter()
+        .filter(|d| d.code == 2300)
+        .count()
+}
+
+fn ts2717_count(source: &str) -> usize {
+    check_source_diagnostics(source)
+        .iter()
+        .filter(|d| d.code == 2717)
+        .count()
+}
+
+/// The exact conformance witness: method signature declared first, property
+/// signature second.
+#[test]
+fn merged_interface_method_then_property_emits_ts2300() {
+    let source =
+        "interface Foo {\n    bold(): string;\n}\n\ninterface Foo {\n    bold: string;\n}\n";
+    let diags = check_source_diagnostics(source);
+    let hits: Vec<_> = diags.iter().filter(|d| d.code == 2300).collect();
+    assert_eq!(
+        hits.len(),
+        2,
+        "expected TS2300 on both merged declarations, got: {diags:?}"
+    );
+    assert!(
+        hits.iter().all(|d| d.message_text.contains("'bold'")),
+        "TS2300 should name the disagreeing member 'bold'; got {hits:?}"
+    );
+    assert_eq!(
+        ts2717_count(source),
+        0,
+        "a kind mismatch must not also emit TS2717: {diags:?}"
+    );
+}
+
+/// The reverse direction: property signature declared first, method second.
+/// This is the case the pre-fix code mis-routed to TS2717.
+#[test]
+fn merged_interface_property_then_method_emits_ts2300() {
+    let source =
+        "interface Bar {\n    bold: string;\n}\n\ninterface Bar {\n    bold(): string;\n}\n";
+    assert_eq!(ts2300_count(source), 2);
+    assert_eq!(ts2717_count(source), 0);
+}
+
+/// Renamed binder: the check must not key off any specific identifier.
+#[test]
+fn merged_interface_property_then_method_renamed_binder() {
+    let source = "interface Zzyzx {\n    w: string;\n}\n\ninterface Zzyzx {\n    w(): string;\n}\n";
+    assert_eq!(ts2300_count(source), 2);
+}
+
+/// Negative control: two method signatures with the same name across a merge
+/// are valid overloads, not a duplicate identifier.
+#[test]
+fn merged_interface_method_overloads_stay_clean() {
+    let source = "interface F {\n    m(): void;\n}\ninterface F {\n    m(x: number): void;\n}\n";
+    assert_eq!(ts2300_count(source), 0);
+}
+
+/// Negative control: two property signatures with identical types across a
+/// merge are valid, not a duplicate identifier.
+#[test]
+fn merged_interface_matching_properties_stay_clean() {
+    let source = "interface N {\n    a: string;\n}\ninterface N {\n    a: string;\n}\n";
+    assert_eq!(ts2300_count(source), 0);
+    assert_eq!(ts2717_count(source), 0);
+}
+
+/// Same-kind property/property mismatch is unaffected by this fix — it stays
+/// on the TS2717 type-comparison path, not TS2300.
+#[test]
+fn merged_interface_property_type_mismatch_stays_ts2717() {
+    let source = "interface P {\n    a: string;\n}\ninterface P {\n    a: number;\n}\n";
+    assert_eq!(ts2717_count(source), 1);
+    assert_eq!(ts2300_count(source), 0);
+}


### PR DESCRIPTION
Fixes the `methodSignatureHandledDeclarationKindForSymbol.ts` conformance gap.

**Structural rule.** When two or more top-level `interface` declarations with the same name merge into one symbol, a property-signature member cannot merge with a method-signature member of the same name — `tsc`'s binder cannot combine a `Property`-flagged symbol with a `Method`-flagged symbol under one name, so it reports `TS2300` ("Duplicate identifier") on **every** conflicting declaration, regardless of which kind was declared first:

```ts
interface Foo {
    bold(): string;
}
interface Foo {
    bold: string;
}
```
```
case.ts(2,5): error TS2300: Duplicate identifier 'bold'.
case.ts(6,5): error TS2300: Duplicate identifier 'bold'.
```
(oracle-verified both directions against `typescript@7.0.2`).

`check_merged_interface_declaration_diagnostics` (`crates/tsz-checker/src/types/type_checking/duplicate_identifiers_followup.rs`) only recognized the **method-after-property** direction as `TS2300`. The reverse — **property-after-method** — fell through to the sibling `TS2717` ("Subsequent property declarations must have the same type") branch, which is meant for same-kind property/property type mismatches, not a signature-kind conflict. Unified both directions onto the single `TS2300` branch; the same-kind (property vs property) type-mismatch path is untouched and still reports `TS2717`.

**Adjacent-case matrix** (new tests in `crates/tsz-checker/tests/ts2300_merged_interface_property_method_conflict_tests.rs`): method-then-property (the conformance witness) and property-then-method (the previously mis-routed direction) both emit `TS2300` on both declarations and no `TS2717`; a renamed binder confirms the check isn't identifier-keyed; method/method overloads and identical property/property merges stay clean (negative controls); a genuine property/property type mismatch still reports `TS2717`, not `TS2300` (regression guard for the untouched sibling path).

**Known related gap, out of scope.** A 3+-declaration merge where only the *last* declaration conflicts in kind should broadcast `TS2300` onto every prior declaration of the symbol (tsc's binder groups all mergeable prior declarations before flagging), not just the first-seen canonical one — `check_merged_interface_declaration_diagnostics` only tracks one canonical name node per property name. Not exercised by the failing conformance test (a 2-declaration case), not touched here.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts2300_merged_interface_property_method_conflict_tests` — 6/6 new tests pass.
- `cargo test -p tsz-checker --test ts2687_merged_interface_declaration_tests` — 7/7 pass, no regression on the sibling TS2687 merged-interface path.
- `cargo test -p tsz-checker --lib duplicate_identifier` — 13/13 pass, no regression.
- `cargo clippy -p tsz-checker --lib -- -D warnings` — clean.
- `cargo fmt -p tsz-checker -- --check` — clean.
- `python3 scripts/arch/arch_guard.py` — passed.
- Oracle-verified (`typescript@7.0.2`) both directions plus a 3-way control, matching the fixed behavior exactly.
- No local TypeScript submodule checkout this session, so no corpus-level conformance/emit/fourslash run; this is a scoped single-file `src` change plus test-only additions, verified via the oracle-pinned unit matrix above.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude


---
_Generated by [Claude Code](https://claude.ai/code/session_01TKPNaHWnVoEALtTf1yzPpP)_