### PR TITLE
fix(checker): keyof of a generic key-remapping mapped type is a valid index (spurious TS2536)

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/key_constraints.rs
+++ b/crates/tsz-checker/src/query_boundaries/key_constraints.rs
@@ -1,5 +1,42 @@
 use tsz_solver::TypeId;
-use tsz_solver::construction::TypeDatabase;
+use tsz_solver::construction::{QueryDatabase, TypeDatabase};
+use tsz_solver::def::resolver::TypeResolver;
+
+/// `T[K]` where `K extends keyof S` is a valid index (no `TS2536`) when `keyof S`
+/// is a *deferred generic mapped index* — `S` is a mapped type over a generic
+/// `keyof` (`{ [P in keyof <generic> as? N]: … }`), whether the mapped source is
+/// the object parameter itself or a foreign type parameter. tsc resolves such a
+/// `keyof` to a deferred index (`getIndexTypeForMappedType` →
+/// `getIndexTypeForGenericType`) that its relation worker treats as assignable to
+/// `keyof T` for any object type parameter, so a key-remapping `as` clause stays
+/// valid — the remapped keys never leave the deferred index.
+///
+/// Requires the object and index to be type-parameter-like and the index's
+/// constraint to be `keyof S`; the structural mapped-index decision is owned by
+/// the solver (`mapped_index_source_is_deferred_generic_keyof`, instantiation
+/// only, so a conditional alias body stays a deferred *non-mapped* index and
+/// keeps reporting `TS2536`).
+pub(crate) fn indexed_access_is_deferred_generic_mapped_index<R: TypeResolver>(
+    db: &dyn QueryDatabase,
+    resolver: &R,
+    object_type: TypeId,
+    index_type: TypeId,
+    index_constraint: Option<TypeId>,
+) -> bool {
+    let type_db = db.as_type_database();
+    if !super::common::is_type_parameter_like(type_db, object_type)
+        || !super::common::is_type_parameter_like(type_db, index_type)
+    {
+        return false;
+    }
+    let Some(constraint) = index_constraint else {
+        return false;
+    };
+    let Some(inner) = super::common::keyof_inner_type(type_db, constraint) else {
+        return false;
+    };
+    tsz_solver::type_queries::mapped_index_source_is_deferred_generic_keyof(db, resolver, inner)
+}
 
 pub(crate) fn is_symbol_only_key_constraint(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     if type_id == TypeId::SYMBOL || tsz_solver::type_queries::is_unique_symbol_type(db, type_id) {

--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -1307,6 +1307,25 @@ impl<'a> CheckerState<'a> {
         )
     }
 
+    /// `T[K]` where `K extends keyof S` and `S` is a generic key-remapping
+    /// mapped type is a valid index: tsc keeps `keyof S` a deferred mapped index
+    /// assignable to `keyof T` for any object type parameter `T`. See
+    /// `key_constraints::indexed_access_is_deferred_generic_mapped_index`.
+    pub(crate) fn indexed_access_is_deferred_generic_mapped_index(
+        &self,
+        object_type: TypeId,
+        index_type: TypeId,
+        index_constraint: Option<TypeId>,
+    ) -> bool {
+        crate::query_boundaries::key_constraints::indexed_access_is_deferred_generic_mapped_index(
+            self.ctx.types,
+            &self.ctx,
+            object_type,
+            index_type,
+            index_constraint,
+        )
+    }
+
     /// `T[K]` where `K`'s constraint is `keyof F<T>` (a transform of the object
     /// type parameter `T`) is still a valid index when the transformed key space
     /// is assignable to `keyof T`. Key-preserving transforms keep

--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -561,6 +561,23 @@ impl<'a> CheckerState<'a> {
         }
         let error_anchor = node_idx;
         let concrete_error_anchor = data.index_type;
+        // `T[K]` where `K extends keyof S` and `S` is a generic key-remapping
+        // mapped type (`{ [P in keyof <generic> as? N]: ... }`) is a valid index:
+        // tsc resolves such a `keyof` to a *deferred mapped index*
+        // (`getIndexTypeForMappedType` → `getIndexTypeForGenericType`) that its
+        // relation worker treats as assignable to `keyof T` for any object type
+        // parameter `T`, whether the mapped source is `T` itself or a foreign type
+        // parameter. The remapped keys (`` `N` ``) never leave the deferred index,
+        // so they are never compared structurally against `keyof T`. A
+        // concrete-key mapped type (`[P in "a" | "b"]`, `[P in keyof { a: 1 }]`)
+        // is not deferred and still reports `TS2536`.
+        if self.indexed_access_is_deferred_generic_mapped_index(
+            object_type,
+            index_type,
+            index_constraint,
+        ) {
+            return;
+        }
         if crate::query_boundaries::common::is_type_parameter_like(self.ctx.types, object_type)
             && index_constraint.is_some_and(|constraint| {
                 constraint == object_type

--- a/crates/tsz-checker/tests/indexed_access_keyof_wrapper_ts2536_tests.rs
+++ b/crates/tsz-checker/tests/indexed_access_keyof_wrapper_ts2536_tests.rs
@@ -1,16 +1,25 @@
 //! Regression coverage for issue #14528: indexing a type parameter `T` by a key
 //! parameter whose constraint is `keyof Wrapper<T>` must not draw a spurious
-//! `TS2536` when the wrapper is *key-preserving* (`type Alias<T> = T`,
-//! `NonNullable<T>`, `Readonly<T>`, `Partial<T>`).
+//! `TS2536` when the wrapper's `keyof` stays a *deferred generic mapped index*.
 //!
-//! Structural rule: `T[K]` where `K extends keyof F<T>` is a valid index when
-//! the transformed key space `keyof F<T>` is assignable to `keyof T`. The
-//! structural "the index mentions a transformed `T`" heuristic cannot tell a
-//! key-preserving transform from a key-changing one, so the `TS2536` it raises
-//! is gated on the relation-backed `transformed_index_key_space_indexes_object`
-//! query. Only a key-*changing* transform (a key remap, or a *foreign* type
-//! parameter's keys such as `keyof U` with `U extends T`) yields keys outside
-//! `keyof T` and must keep erroring.
+//! Structural rule (mirrors tsc's `checkIndexedAccessIndexType` →
+//! `getIndexTypeForMappedType`): `T[K]` where `K extends keyof S` is a valid
+//! index when `keyof S` is a deferred mapped index — `S` is a mapped type over a
+//! generic `keyof` (`{ [P in keyof <generic> as? N]: ... }`), whether the mapped
+//! source is `T` itself or a foreign type parameter. tsc resolves such a `keyof`
+//! to a deferred index (`getIndexTypeForGenericType`) that its relation worker
+//! treats as assignable to `keyof T`, so **even a key-remapping `as` clause
+//! stays valid** — the remapped keys (`` `N` ``) never leave the deferred index
+//! and are never compared structurally against `keyof T`. This subsumes the
+//! key-preserving wrappers (`type Alias<T> = T`, `NonNullable<T>`,
+//! `Readonly<T>`, `Partial<T>`) and the key-remapping ones alike.
+//!
+//! Only these still report `TS2536`, because their `keyof` resolves to a
+//! concrete or non-mapped key space that must relate structurally to `keyof T`:
+//! a *bare foreign* type parameter's keys (`keyof U` with `U extends T`), a
+//! *conditional* wrapper (`keyof (T extends … ? … : …)`), a *constant*-key
+//! mapped type (`[P in "a" | "b"]`), and a *concrete-object* keyof mapped type
+//! (`[P in keyof { a: 1 }]`).
 //!
 //! Verified against `tsc` 6.x: the positive cases are clean, the negative
 //! controls report `TS2536`.
@@ -105,14 +114,105 @@ fn foreign_type_parameter_keys_still_report_ts2536() {
 }
 
 #[test]
-fn key_remapping_wrapper_still_reports_ts2536() {
-    // A key remap produces keys outside `keyof T`, so the index is invalid.
+fn key_remapping_wrapper_over_object_param_no_ts2536() {
+    // A key-*remapping* mapped wrapper (`as` clause) over the object type
+    // parameter is still a valid index: `keyof Remap<T>` is a deferred mapped
+    // index assignable to `keyof T` (verified vs tsc 6.x: clean). The remapped
+    // `` `get_${…}` `` keys never leave the deferred index.
     let src = "type Remap<T> = { [P in keyof T as `get_${string & P}`]: T[P] };\n\
-               declare function bad<T, K extends keyof Remap<T>>(o: T, k: K): T[K];";
+               declare function ok<T, K extends keyof Remap<T>>(o: T, k: K): T[K];";
+    assert_eq!(
+        count(src, 2536),
+        0,
+        "keyof of a generic key-remapping mapped type indexes T: {:?}",
+        codes(src)
+    );
+}
+
+#[test]
+fn key_remapping_wrapper_over_constrained_foreign_param_no_ts2536() {
+    // The deferred mapped index is valid even when the mapped type is over a
+    // *foreign* type parameter (`U extends T`): `keyof Remap<U>` still indexes
+    // `T` in tsc.
+    let src = "type Remap<Q> = { [P in keyof Q as `get_${string & P}`]: Q[P] };\n\
+               declare function ok<T, U extends T, K extends keyof Remap<U>>(o: T, k: K): T[K];";
+    assert_eq!(
+        count(src, 2536),
+        0,
+        "keyof of a mapped type over a constrained foreign param indexes T: {:?}",
+        codes(src)
+    );
+}
+
+#[test]
+fn key_remapping_wrapper_over_unrelated_param_no_ts2536() {
+    // ...and even over a *wholly unrelated* type parameter: tsc keeps the
+    // deferred mapped index assignable to `keyof T` regardless of the mapped
+    // source, so `T[K]` with `K extends keyof Wrap<U>` is accepted.
+    let src = "type Wrap<Q> = { [P in keyof Q as `get_${string & P}`]: Q[P] };\n\
+               declare function ok<T, U, K extends keyof Wrap<U>>(o: T, k: K): T[K];";
+    assert_eq!(
+        count(src, 2536),
+        0,
+        "keyof of a mapped type over an unrelated generic param indexes T: {:?}",
+        codes(src)
+    );
+}
+
+#[test]
+fn key_remapping_wrapper_indexes_in_function_body_no_ts2536() {
+    // Expression / computation path (`o[k]` in a body) accepts the remap too.
+    let src = "type Remap<T> = { [P in keyof T as `get_${string & P}`]: T[P] };\n\
+               function read<T, K extends keyof Remap<T>>(o: T, k: K) { return o[k]; }";
+    assert_eq!(
+        count(src, 2536),
+        0,
+        "expression-path indexing of a key-remapping wrapper is valid: {:?}",
+        codes(src)
+    );
+}
+
+#[test]
+fn pick_and_omit_wrapper_keyof_constraint_no_ts2536() {
+    // `Pick`/`Omit` mapped wrappers over a generic `keyof` keep the index valid:
+    // `keyof Pick<T, keyof T>` and `keyof Omit<T, "x">` both index `T`.
+    let src = "declare function pk<T, K extends keyof Pick<T, keyof T>>(o: T, k: K): T[K];\n\
+               declare function om<T, K extends keyof Omit<T, \"x\">>(o: T, k: K): T[K];";
+    assert_eq!(
+        count(src, 2536),
+        0,
+        "Pick/Omit over a generic keyof index T: {:?}",
+        codes(src)
+    );
+}
+
+#[test]
+fn constant_key_mapped_wrapper_still_reports_ts2536() {
+    // A mapped wrapper whose key source is a *constant* (`[P in "zzz"]`) is not a
+    // deferred generic mapped index: its keys are concrete and unrelated to
+    // `keyof T`, so tsc keeps reporting TS2536.
+    let src = "type Const<T> = { [P in \"zzz\"]: T };\n\
+               declare function bad<T, K extends keyof Const<T>>(o: T, k: K): T[K];";
     assert_eq!(
         count(src, 2536),
         1,
-        "a key-changing transform must keep erroring: {:?}",
+        "a constant-key mapped wrapper must keep erroring: {:?}",
+        codes(src)
+    );
+}
+
+#[test]
+fn concrete_object_keyof_mapped_wrapper_still_reports_ts2536() {
+    // A mapped wrapper over the `keyof` of a *concrete* object
+    // (`[P in keyof { a: 1; b: 2 }]`) resolves to a concrete key union not
+    // assignable to `keyof T`, so it keeps erroring — the generic-keyof
+    // discriminator excludes it.
+    let src = "type FromObj<T> = { [P in keyof { a: 1; b: 2 }]: T };\n\
+               declare function bad<T, K extends keyof FromObj<T>>(o: T, k: K): T[K];";
+    assert_eq!(
+        count(src, 2536),
+        1,
+        "a concrete-object-keyof mapped wrapper must keep erroring: {:?}",
         codes(src)
     );
 }

--- a/crates/tsz-solver/src/type_queries/shape_queries.rs
+++ b/crates/tsz-solver/src/type_queries/shape_queries.rs
@@ -187,6 +187,66 @@ pub fn is_generic_mapped_application_db<R: TypeResolver>(
     is_generic_mapped_type_db(db.as_type_database(), instantiated)
 }
 
+/// Returns `true` when `type_id` is a *deferred generic keyof-mapped index
+/// source*: a mapped type — or an `Application` whose aliased body instantiates
+/// to a mapped type — whose key source (the `in` clause) is a *generic* `keyof`
+/// (`{ [P in keyof <generic> as? N]: ... }`).
+///
+/// Mirrors `tsc`'s `getIndexTypeForMappedType`: for such a mapped type, `keyof`
+/// resolves to a *deferred* index (`getIndexTypeForGenericType`) rather than a
+/// concrete key union, and the relation worker treats that deferred mapped index
+/// as assignable to `keyof T` for any object type parameter `T`. The alias body
+/// is reached by *instantiation only* — conditionals are **not** evaluated — so a
+/// conditional alias (`T extends … ? … : …`) that would otherwise reduce to a
+/// mapped type does not qualify (tsc keeps its `keyof` a deferred *non-mapped*
+/// index). A bare-parameter key source (`[P in K]`) or a concrete key source
+/// (`[P in "a" | "b"]`, `[P in keyof { a: 1 }]`) also does not qualify.
+pub fn mapped_index_source_is_deferred_generic_keyof<R: TypeResolver>(
+    db: &dyn crate::construction::QueryDatabase,
+    resolver: &R,
+    type_id: TypeId,
+) -> bool {
+    let Some(mapped) = resolve_alias_body_to_mapped_type(db, resolver, type_id) else {
+        return false;
+    };
+    // The key source must be a *generic* `keyof` — `isGenericIndexType` +
+    // `isMappedTypeWithKeyofConstraintDeclaration` in tsc terms.
+    super::mapped::keyof_inner_type(db.as_type_database(), mapped.constraint).is_some()
+        && contains_type_parameters_db(db.as_type_database(), mapped.constraint)
+}
+
+/// Resolve `type_id` to a mapped type: directly when it already is one, or by
+/// instantiating a generic alias `Application`'s declared body with its type
+/// arguments (no conditional evaluation). Returns `None` otherwise.
+fn resolve_alias_body_to_mapped_type<R: TypeResolver>(
+    db: &dyn crate::construction::QueryDatabase,
+    resolver: &R,
+    type_id: TypeId,
+) -> Option<std::sync::Arc<crate::types::MappedType>> {
+    use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type_cached};
+
+    let type_db = db.as_type_database();
+    if let Some(mapped) = get_mapped_type(type_db, type_id) {
+        return Some(mapped);
+    }
+    if type_id.is_intrinsic() {
+        return None;
+    }
+    let TypeData::Application(app_id) = db.lookup(type_id)? else {
+        return None;
+    };
+    let app = db.type_application(app_id);
+    let def_id = super::classifiers::get_lazy_def_id(db, app.base)?;
+    let type_params = resolver.get_lazy_type_params(def_id)?;
+    if type_params.is_empty() {
+        return None;
+    }
+    let body = resolver.resolve_lazy(def_id, type_db)?;
+    let substitution = TypeSubstitution::from_args(type_db, &type_params, &app.args);
+    let instantiated = instantiate_type_cached(type_db, Some(db), body, &substitution);
+    get_mapped_type(type_db, instantiated)
+}
+
 /// Returns `true` when `type_id` is a generic `Application` whose aliased body
 /// is a mapped type (e.g. `Partial<X>`, `Readonly<X>`, or a user
 /// `type F<T> = { [K in keyof T]... }`), regardless of whether the concrete


### PR DESCRIPTION
Fixes #14528.

`T[K]` where `K extends keyof S` drew a spurious **TS2536** when `S` is a
*key-remapping* mapped wrapper:

```ts
type Remap<T> = { [P in keyof T as `get_${string & P}`]: T[P] };
declare function bad<T, K extends keyof Remap<T>>(o: T, k: K): T[K]; // tsz: TS2536 ; tsc 6.0.2: clean
```

**Structural rule.** When `K extends keyof S` and `S` is a generic mapped type
over a generic `keyof` (`{ [P in keyof <generic> as? N]: … }`), tsc resolves
`keyof S` to a *deferred mapped index* (`checkIndexedAccessIndexType` →
`getIndexTypeForMappedType` → `getIndexTypeForGenericType`) and its relation
worker treats that deferred mapped index as assignable to `keyof T` for **any**
object type parameter `T` — whether the mapped source is `T` itself or a foreign
type parameter. The remapped keys never leave the deferred index, so they are
never compared structurally against `keyof T`. tsz now does the same through the
solver query `mapped_index_source_is_deferred_generic_keyof`, reached via
`query_boundaries::key_constraints::indexed_access_is_deferred_generic_mapped_index`,
which gates the `check_indexed_access` type-node TS2536.

The merged #14537 only suppressed *key-preserving* wrappers
(`Alias`/`NonNullable`/`Readonly`/`Partial`) by evaluating the transformed key
space; a key-remapping `as` clause evaluates to the remapped `` `get_${…}` ``
keys, which never relate to `keyof T`, so tsz kept over-reporting — this issue's
residual, whose #14537 regression test asserted the wrong oracle.

The alias body is reached by **instantiation only** (conditionals stay
deferred), so a conditional wrapper that would reduce to a mapped type does not
qualify; a constant-key (`[P in "zzz"]`) or concrete-object-keyof
(`[P in keyof { a: 1 }]`) mapped type resolves to a concrete key space and keeps
erroring.

Adjacent-case matrix, verified against `tsc` 6.0.2 — clean now: remap over `T`,
over a constrained foreign `U extends T`, over an unrelated `U`, key-preserving
wrappers (unchanged), `Pick<T, keyof T>`, `Omit<T, "x">`, and the expression
path (`o[k]`). Still TS2536: bare foreign `keyof U`, constant-key mapped,
concrete-object-keyof mapped, `Pick<T, "notakey">`, and the direct
transformed-keyof value `k: keyof (T & {})` (`unknownControlFlow` `ff3`).
Renamed binders confirm no logic keys off an identifier; the discriminator is a
purely structural solver query.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test indexed_access_keyof_wrapper_ts2536_tests` — 16 passed (flipped the incorrect `key_remapping_wrapper_still_reports_ts2536` oracle to clean; added remap-over-T / over-constrained-U / over-unrelated-U / body-path / Pick+Omit positives and constant-key / concrete-object-keyof negatives).
- Adjacent indexed-access suites green: `concrete_tuple_generic_index_chain_ts2536`, `deferred_keyof_index_access_assignability`, `class_field_mapped_type_indexed_access`, `deferred_conditional_indexed_access`, `deeply_nested_mapped_types`.
- `clippy` + architecture guard (query-boundary common-reference count + file-size) pass; touched files all < 2000 lines. CI Summary green (clippy + arch-size).
- Conformance snapshot vs baseline (`snapshot --workers 12 --force`, 12043 runnable): **no regression in the touched family** — zero TS2536 / indexed-access / keyof-mapped outcome flips. The only baseline drift is unrelated (decorator TS1238/1240/1241, salsa TS7053, verbatim-module/type-only) from `main` advancing and the documented run-to-run nondeterminism (#16309), so the churned baseline files are not included in this PR.

## Provenance
Machine: cloud
Assistant: claude-code
Model: opus
Effort: high