### PR TITLE
refactor(solver): share alias-body instantiation; de-duplicate deferred-mapped-index docs

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/key_constraints.rs
+++ b/crates/tsz-checker/src/query_boundaries/key_constraints.rs
@@ -3,19 +3,10 @@ use tsz_solver::construction::{QueryDatabase, TypeDatabase};
 use tsz_solver::def::resolver::TypeResolver;
 
 /// `T[K]` where `K extends keyof S` is a valid index (no `TS2536`) when `keyof S`
-/// is a *deferred generic mapped index* — `S` is a mapped type over a generic
-/// `keyof` (`{ [P in keyof <generic> as? N]: … }`), whether the mapped source is
-/// the object parameter itself or a foreign type parameter. tsc resolves such a
-/// `keyof` to a deferred index (`getIndexTypeForMappedType` →
-/// `getIndexTypeForGenericType`) that its relation worker treats as assignable to
-/// `keyof T` for any object type parameter, so a key-remapping `as` clause stays
-/// valid — the remapped keys never leave the deferred index.
-///
-/// Requires the object and index to be type-parameter-like and the index's
-/// constraint to be `keyof S`; the structural mapped-index decision is owned by
-/// the solver (`mapped_index_source_is_deferred_generic_keyof`, instantiation
-/// only, so a conditional alias body stays a deferred *non-mapped* index and
-/// keeps reporting `TS2536`).
+/// is a *deferred generic mapped index*. Gates the object and index to be
+/// type-parameter-like and peels `keyof S` → `S`, then delegates the structural
+/// decision to the solver
+/// (`mapped_index_source_is_deferred_generic_keyof`, which owns the tsc rule).
 pub(crate) fn indexed_access_is_deferred_generic_mapped_index<R: TypeResolver>(
     db: &dyn QueryDatabase,
     resolver: &R,

--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -561,16 +561,10 @@ impl<'a> CheckerState<'a> {
         }
         let error_anchor = node_idx;
         let concrete_error_anchor = data.index_type;
-        // `T[K]` where `K extends keyof S` and `S` is a generic key-remapping
-        // mapped type (`{ [P in keyof <generic> as? N]: ... }`) is a valid index:
-        // tsc resolves such a `keyof` to a *deferred mapped index*
-        // (`getIndexTypeForMappedType` → `getIndexTypeForGenericType`) that its
-        // relation worker treats as assignable to `keyof T` for any object type
-        // parameter `T`, whether the mapped source is `T` itself or a foreign type
-        // parameter. The remapped keys (`` `N` ``) never leave the deferred index,
-        // so they are never compared structurally against `keyof T`. A
-        // concrete-key mapped type (`[P in "a" | "b"]`, `[P in keyof { a: 1 }]`)
-        // is not deferred and still reports `TS2536`.
+        // `T[K]` where `K extends keyof S` and `keyof S` is a deferred generic
+        // mapped index (`{ [P in keyof <generic> as? N]: ... }`) is a valid index
+        // in tsc — accept it before the downstream `TS2536` sites. See the method
+        // and its solver query for the rule.
         if self.indexed_access_is_deferred_generic_mapped_index(
             object_type,
             index_type,

--- a/crates/tsz-solver/src/type_queries/shape_queries.rs
+++ b/crates/tsz-solver/src/type_queries/shape_queries.rs
@@ -149,42 +149,53 @@ pub fn type_parameter_has_mapped_constraint_db(db: &dyn TypeDatabase, type_id: T
     get_type_parameter_constraint(db, type_id).is_some_and(|c| is_generic_mapped_type_db(db, c))
 }
 
+/// Instantiate a generic alias `Application`'s declared body with its type
+/// arguments (no conditional evaluation), returning the instantiated body.
+/// Returns `None` when `type_id` is not a resolvable generic alias
+/// application. Bridges resolver-backed lazy resolution so callers don't
+/// reimplement the substitute-then-classify pattern.
+fn instantiate_application_body<R: TypeResolver>(
+    db: &dyn crate::construction::QueryDatabase,
+    resolver: &R,
+    type_id: TypeId,
+) -> Option<TypeId> {
+    use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type_cached};
+
+    // Cheap precondition: only `Application` types can satisfy the predicate.
+    // Skip the resolver/substitution work otherwise.
+    if type_id.is_intrinsic() {
+        return None;
+    }
+    let TypeData::Application(app_id) = db.lookup(type_id)? else {
+        return None;
+    };
+    let app = db.type_application(app_id);
+    let def_id = super::classifiers::get_lazy_def_id(db, app.base)?;
+    let type_params = resolver.get_lazy_type_params(def_id)?;
+    if type_params.is_empty() {
+        return None;
+    }
+    let type_db = db.as_type_database();
+    let body = resolver.resolve_lazy(def_id, type_db)?;
+    let substitution = TypeSubstitution::from_args(type_db, &type_params, &app.args);
+    Some(instantiate_type_cached(
+        type_db,
+        Some(db),
+        body,
+        &substitution,
+    ))
+}
+
 /// Returns `true` when `type_id` is a generic `Application` whose aliased
 /// body reduces to a generic mapped type after substituting the supplied
-/// type arguments. Bridges resolver-backed lazy resolution so callers
-/// don't need to reimplement the substitute-then-classify pattern.
+/// type arguments.
 pub fn is_generic_mapped_application_db<R: TypeResolver>(
     db: &dyn crate::construction::QueryDatabase,
     resolver: &R,
     type_id: TypeId,
 ) -> bool {
-    use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type_cached};
-
-    // Cheap precondition: only `Application` types can satisfy the
-    // predicate. Skip the resolver/substitution work otherwise.
-    if type_id.is_intrinsic() {
-        return false;
-    }
-    let Some(TypeData::Application(app_id)) = db.lookup(type_id) else {
-        return false;
-    };
-    let app = db.type_application(app_id);
-    let Some(def_id) = super::classifiers::get_lazy_def_id(db, app.base) else {
-        return false;
-    };
-    let Some(type_params) = resolver.get_lazy_type_params(def_id) else {
-        return false;
-    };
-    if type_params.is_empty() {
-        return false;
-    }
-    let Some(body) = resolver.resolve_lazy(def_id, db.as_type_database()) else {
-        return false;
-    };
-    let substitution = TypeSubstitution::from_args(db.as_type_database(), &type_params, &app.args);
-    let instantiated =
-        instantiate_type_cached(db.as_type_database(), Some(db), body, &substitution);
-    is_generic_mapped_type_db(db.as_type_database(), instantiated)
+    instantiate_application_body(db, resolver, type_id)
+        .is_some_and(|body| is_generic_mapped_type_db(db.as_type_database(), body))
 }
 
 /// Returns `true` when `type_id` is a *deferred generic keyof-mapped index
@@ -223,27 +234,11 @@ fn resolve_alias_body_to_mapped_type<R: TypeResolver>(
     resolver: &R,
     type_id: TypeId,
 ) -> Option<std::sync::Arc<crate::types::MappedType>> {
-    use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type_cached};
-
     let type_db = db.as_type_database();
     if let Some(mapped) = get_mapped_type(type_db, type_id) {
         return Some(mapped);
     }
-    if type_id.is_intrinsic() {
-        return None;
-    }
-    let TypeData::Application(app_id) = db.lookup(type_id)? else {
-        return None;
-    };
-    let app = db.type_application(app_id);
-    let def_id = super::classifiers::get_lazy_def_id(db, app.base)?;
-    let type_params = resolver.get_lazy_type_params(def_id)?;
-    if type_params.is_empty() {
-        return None;
-    }
-    let body = resolver.resolve_lazy(def_id, type_db)?;
-    let substitution = TypeSubstitution::from_args(type_db, &type_params, &app.args);
-    let instantiated = instantiate_type_cached(type_db, Some(db), body, &substitution);
+    let instantiated = instantiate_application_body(db, resolver, type_id)?;
     get_mapped_type(type_db, instantiated)
 }
 


### PR DESCRIPTION
Follow-up cleanup to #17142 (issue #14528). **No behavior change** — pure refactor + doc de-duplication.

`#17142` landed the fix for the spurious `TS2536` on `T[K]` with a key-remapping mapped-wrapper index. A `/simplify` review of that diff surfaced two quality items, applied here:

1. **DRY the alias-body instantiation.** `resolve_alias_body_to_mapped_type` (added in #17142) and the existing `is_generic_mapped_application_db` both open-coded the same substitute-then-classify boilerplate: `lookup → get_lazy_def_id → get_lazy_type_params → resolve_lazy → TypeSubstitution::from_args → instantiate_type_cached`. Extracted into one private `instantiate_application_body` helper both call; each keeps only its terminal classifier (`is_generic_mapped_type_db` vs `get_mapped_type`).

2. **Collapse triplicated prose.** The tsc "deferred mapped index" rationale was written near-verbatim in three places (the solver query doc, the checker query-boundary fn doc, and the call-site inline comment in `check_indexed_access`). Kept the full explanation on the solver query that owns the decision and reduced the two checker-side copies to one-liners that point at it — matching the existing `access_helpers.rs` forwarder's "See …" convention.

Net −65/+45 lines across three files; the regression test file is untouched.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test indexed_access_keyof_wrapper_ts2536_tests` — 16 passed (unchanged).
- tsc-vs-tsz matrix parity unchanged (remap-over-T/foreign/unrelated clean; constant-key, concrete-object-keyof, bare `keyof U` still `TS2536`).
- `clippy` + architecture guard + pre-commit local verification pass.
- Refactor touches the shared `is_generic_mapped_application_db` (also used by assignability / readonly); behavior preserved (same instantiate-then-classify, same results).

## Provenance
Machine: cloud
Assistant: claude-code
Model: opus
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRQqKmNraxiGf72e7iBzZV)_