### PR TITLE
refactor(checker): route property-access receiver reduction fully through the apparent_type gateway (#15396)

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/apparent_type.rs
+++ b/crates/tsz-checker/src/query_boundaries/apparent_type.rs
@@ -133,8 +133,11 @@ mod raw_entry {
     ];
 
     /// Residual direct raw-entry calls left in `resolve.rs` after routing the
-    /// receiver reduction through the gateway. Shrink-only: never raise it.
-    const BASELINE: usize = 3;
+    /// receiver reduction through the gateway. Now zero: every property-access
+    /// receiver reduction — the primary env/light branches and the three
+    /// `UNKNOWN`-recovery / no-flow-probe re-reductions — routes through
+    /// [`apparent_type`](super). Shrink-only: never raise it.
+    const BASELINE: usize = 0;
 
     fn raw_entry_call_count(src: &str) -> usize {
         RAW_ENTRIES
@@ -146,12 +149,19 @@ mod raw_entry {
     #[test]
     fn property_access_decision_site_stays_shrink_only() {
         let count = raw_entry_call_count(RESOLVE_SRC);
-        assert!(
-            count <= BASELINE,
-            "property-access decision site added a raw evaluation-entry call \
-             ({count} > baseline {BASELINE}); route it through \
-             query_boundaries::apparent_type instead of calling a raw evaluate_* \
-             entry directly. If you migrated a call *out*, lower BASELINE to {count}.",
+        // Exact match, not `<=`: `BASELINE` is `0` (the site is fully behind the
+        // gateway), so a `count <= BASELINE` would be an always-true comparison
+        // against `usize::MIN` (`clippy::absurd_extreme_comparisons`). Any raw
+        // evaluate_* call added to the decision site makes `count > BASELINE` and
+        // fails; migrating one out (only possible if `BASELINE` is later raised)
+        // makes `count < BASELINE` and must be paired with lowering `BASELINE`.
+        assert_eq!(
+            count, BASELINE,
+            "property-access decision site changed its raw evaluation-entry call \
+             count ({count} vs baseline {BASELINE}); route new receiver reductions \
+             through query_boundaries::apparent_type instead of calling a raw \
+             evaluate_* entry directly. If you migrated a call *out*, lower BASELINE \
+             to {count}.",
         );
     }
 

--- a/crates/tsz-checker/src/types/property_access_type/resolve.rs
+++ b/crates/tsz-checker/src/types/property_access_type/resolve.rs
@@ -360,7 +360,9 @@ impl<'a> CheckerState<'a> {
                 .get_identifier(name_node)
                 .map(|ident| ident.escaped_text.clone());
             let can_use_no_flow = if let Some(property_name) = property_name_for_probe.as_deref() {
-                let evaluated_no_flow = self.evaluate_application_type(object_type_no_flow);
+                let evaluated_no_flow = self
+                    .apparent_type_of_receiver_light(object_type_no_flow)
+                    .into_type();
                 let resolved_no_flow = self.resolve_type_for_property_access(evaluated_no_flow);
                 !matches!(
                     self.resolve_property_access_with_env(resolved_no_flow, property_name),
@@ -472,7 +474,7 @@ impl<'a> CheckerState<'a> {
                 if let Some(sym_id) = self.resolve_identifier_symbol(access.expression) {
                     let sym_type = self.get_type_of_symbol(sym_id);
                     if sym_type != TypeId::UNKNOWN && sym_type != TypeId::ERROR {
-                        object_type = self.evaluate_application_type(sym_type);
+                        object_type = self.apparent_type_of_receiver_light(sym_type).into_type();
                     }
                 }
             } else if self.ctx.arena.get_access_expr(expr_node).is_some() {
@@ -481,7 +483,7 @@ impl<'a> CheckerState<'a> {
                     &TypingRequest::NONE,
                 );
                 if inner_type != TypeId::UNKNOWN && inner_type != TypeId::ERROR {
-                    object_type = self.evaluate_application_type(inner_type);
+                    object_type = self.apparent_type_of_receiver_light(inner_type).into_type();
                 }
             }
         }


### PR DESCRIPTION
Completes the property-access decision-site consolidation the #15396 first PR
started. The `query_boundaries::apparent_type` materialize-or-defer gateway
already owned the two primary receiver-reduction branches
(`apparent_type_of_receiver_env` / `_light`), but three raw
`evaluate_application_type` calls remained in the same decision site
(`property_access_type/resolve.rs`): the two `UNKNOWN`-recovery re-reductions
(identifier and inner property-access) and the no-flow-probe reduction. Those
now route through `apparent_type_of_receiver_light` too, so **every**
property-access receiver reduction at that site goes through the single
chokepoint, and the `apparent_type::raw_entry` arch-scan `BASELINE` shrinks
**3 → 0** (issue acceptance item 4, "the arch scan only shrinks").

This is a behavior-preserving consolidation, not a semantic change:
`apparent_type_of_receiver_light(x).into_type()` wraps that exact evaluation
entry and `into_type()` returns the reduced `TypeId` unchanged, so the result
is byte-identical to the prior `evaluate_application_type(x)`. The value is
structural: a future fix that consumes the `Deferred` verdict (the issue's
remaining follow-up for the relation-member / TS2344 sites) can be applied at
one place rather than per-path.

The corpus fix for the valibot false-positive families this issue tracks is
**not** in scope here and remains the deeper #13212/#14345 campaign — see the
issue thread for a verify-first reproduction (245 diagnostics, family
breakdown) and a measured-negative relation-reflexivity sub-fix recorded so it
is not re-attempted.

## Goal
Goal: hold

<!-- Behavior-preserving consolidation that advances the #15396 green campaign
     while holding the conformance/parity floor exactly. -->

## Verification
- valibot guard row (release, cold clone `e7bcacb1`, guard `compilerOptions`
  per `tsz_write_valibot_config`): **245 diagnostics, byte-identical set**
  before and after this change.
- `cargo test -p tsz-checker --lib`: **11066/11066 pass, 0 failures**.
- `apparent_type::raw_entry` arch-scan tests pass at `BASELINE = 0`
  (`property_access_decision_site_stays_shrink_only`,
  `receiver_reduction_uses_the_gateway`).
- `cargo clippy -p tsz-checker`: clean.
- Conformance not run locally (TypeScript corpus not checked out); the change
  is byte-parity by construction (gateway wraps the identical raw entry).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01246tPJB7A9duZCgfZBDj3F)_