### PR TITLE
fix(checker): declared inline signature source renders canonical spacing with preserved literals (#17128)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
@@ -204,6 +204,19 @@ impl<'a> CheckerState<'a> {
             return display;
         }
 
+        // A source whose declared annotation is an inline call/construct
+        // signature (`declare const v: () => 1`, `new () => 1`) renders through
+        // the canonical structural formatter so the author's whitespace is
+        // normalized (`()=>1` -> `() => 1`, `(x:1)=>void` -> `(x: 1) => void`),
+        // while a literal written in the signature stays verbatim: tsc widens
+        // only fresh literals, and a declared signature is non-fresh. See
+        // `inline_signature_annotation_source_display`.
+        if let Some(display) =
+            self.inline_signature_annotation_source_display(anchor_idx, source, target)
+        {
+            return display;
+        }
+
         let has_optional_callable_param =
             crate::query_boundaries::common::function_shape_for_type(self.ctx.types, source)
                 .is_some_and(|shape| shape.params.iter().any(|param| param.optional))

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_source_preservation.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_source_preservation.rs
@@ -5,6 +5,54 @@ use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
+    /// Structural display for an assignment/return **source** whose declared
+    /// annotation is a non-generic inline call/construct signature (`() => 1`,
+    /// `(x: 1) => void`, `new () => 1`).
+    ///
+    /// Such a signature is rendered through tsc's `typeToString`, which
+    /// canonicalizes the author's whitespace (`()=>1` -> `() => 1`) — so the
+    /// raw-source-text fallback (which echoes the written spelling verbatim,
+    /// leaking `()=>1`) is wrong here. But `normalize_assignability_display_type`
+    /// widens a `TypeData::Function` return by default (the fresh
+    /// function-expression case, where an inferred `() => 1` widens to
+    /// `() => number`), while never touching a `TypeData::Callable`
+    /// construct-signature return — so routing a *declared* function source
+    /// through the canonical formatter alone would widen its written return
+    /// literal, diverging from the constructor path. Because a declared
+    /// signature is non-fresh, activate [`PreserveSignatureReturnLiteralsScope`]
+    /// so the written return literal is kept, giving both canonical spacing and
+    /// literal preservation across the call- and construct-signature forms.
+    ///
+    /// Generic callables (`<S>() => S[]`, `new <T>(x: T) => T`) are excluded by
+    /// [`Self::annotation_is_inline_signature_type`] and keep the established
+    /// `declared_identifier_source_display` handling, which owns tsc's
+    /// alias-name / `?:`-surface rules for those. Returns `None` for any other
+    /// source, leaving the established display path untouched.
+    ///
+    /// [`PreserveSignatureReturnLiteralsScope`]: crate::error_reporter::core::type_display::PreserveSignatureReturnLiteralsScope
+    pub(in crate::error_reporter) fn inline_signature_annotation_source_display(
+        &mut self,
+        anchor_idx: NodeIndex,
+        source: TypeId,
+        target: TypeId,
+    ) -> Option<String> {
+        let expr_idx = self
+            .direct_diagnostic_source_expression(anchor_idx)
+            .or_else(|| self.assignment_source_expression(anchor_idx))?;
+        let is_inline_signature = self
+            .declared_type_annotation_node_for_expression(expr_idx)
+            .is_some_and(|(arena, annotation_idx)| {
+                Self::annotation_is_inline_signature_type(arena, annotation_idx)
+            });
+        if !is_inline_signature {
+            return None;
+        }
+        let _preserve_signature_returns =
+            crate::error_reporter::core::type_display::PreserveSignatureReturnLiteralsScope::enter(
+            );
+        Some(self.format_assignability_type_for_message(source, target))
+    }
+
     pub(in crate::error_reporter) fn declared_identifier_candidate_preserves_source_surface(
         &self,
         existing: &str,

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/type_query_alias.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/type_query_alias.rs
@@ -1,6 +1,5 @@
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
-use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
 
@@ -230,61 +229,74 @@ impl<'a> CheckerState<'a> {
         arena: &tsz_parser::NodeArena,
         annotation_idx: NodeIndex,
     ) -> bool {
-        let mut idx = annotation_idx;
-        for _ in 0..16 {
-            let Some(node) = arena.get(idx) else {
-                return false;
-            };
-            match node.kind {
-                syntax_kind_ext::PARENTHESIZED_TYPE => {
-                    let Some(wrapped) = arena.get_wrapped_type(node) else {
-                        return false;
-                    };
-                    idx = wrapped.type_node;
-                }
-                syntax_kind_ext::TUPLE_TYPE
-                | syntax_kind_ext::FUNCTION_TYPE
-                | syntax_kind_ext::CONSTRUCTOR_TYPE => {
-                    // tsc's `getWidenedType` widens only *fresh* literals — a
-                    // literal type written anywhere inside a declared
-                    // signature (`() => 1`, `(x: 1) => void`) is part of the
-                    // signature's own spelling and must stay verbatim, not
-                    // pass through the canonical structural formatter (which
-                    // renders the type's current, possibly-widened `TypeId`
-                    // and has no notion of "this literal was written, don't
-                    // widen it"). The raw-source-text fallback this predicate
-                    // gates already preserves such literals correctly, so
-                    // decline canonicalization here and let it through.
-                    return !Self::type_subtree_contains_literal_type(arena, idx, 0);
-                }
-                _ => return false,
-            }
-        }
-        false
+        Self::unwrapped_annotation_node(arena, annotation_idx)
+            .and_then(|idx| arena.get(idx))
+            .is_some_and(|node| {
+                matches!(
+                    node.kind,
+                    syntax_kind_ext::TUPLE_TYPE
+                        | syntax_kind_ext::FUNCTION_TYPE
+                        | syntax_kind_ext::CONSTRUCTOR_TYPE
+                )
+            })
     }
 
-    /// Whether `idx`'s type subtree contains a `LiteralType` node (`1`,
-    /// `"x"`, `true`, `-1`, ...) anywhere beneath it. Depth- and
-    /// visit-bounded against pathological nesting, mirroring the bound used
-    /// by `anchor_is_within_object_literal_member`.
-    fn type_subtree_contains_literal_type(
+    /// Whether a declared type annotation, after unwrapping parenthesized
+    /// wrappers, is a *non-generic* inline `FUNCTION_TYPE` or `CONSTRUCTOR_TYPE`
+    /// — a bare call/construct signature written directly at a declaration site
+    /// (`() => 1`, `(x: 1) => void`, `new () => 1`).
+    ///
+    /// Such a source is *declared* (non-fresh): tsc's `getWidenedType` widens
+    /// only fresh literals, so a literal written inside a declared signature
+    /// (`() => 1`) renders verbatim while its whitespace is still canonicalized
+    /// by `typeToString` (`()=>1` -> `() => 1`). This predicate gates the
+    /// canonical-formatter-under-preserve-scope source path that reconciles
+    /// those two rules; a fresh function-expression source is not an inline
+    /// signature annotation on a declared binding and never matches here.
+    ///
+    /// A *generic* signature (`<S>() => S[]`, `new <T>(x: T) => T`) is excluded:
+    /// those keep the established `declared_identifier_source_display` handling,
+    /// which owns tsc's alias-name / `?:`-surface rules for type-parameterized
+    /// callables. The generic-ness is read from the signature's own
+    /// `type_parameters` (both node kinds share `FunctionTypeData`).
+    pub(in crate::error_reporter) fn annotation_is_inline_signature_type(
         arena: &tsz_parser::NodeArena,
-        idx: NodeIndex,
-        depth: u32,
+        annotation_idx: NodeIndex,
     ) -> bool {
-        if idx.is_none() || depth > 64 {
-            return false;
-        }
-        let Some(node) = arena.get(idx) else {
+        let Some(node) =
+            Self::unwrapped_annotation_node(arena, annotation_idx).and_then(|idx| arena.get(idx))
+        else {
             return false;
         };
-        if node.kind == syntax_kind_ext::LITERAL_TYPE {
-            return true;
+        if !matches!(
+            node.kind,
+            syntax_kind_ext::FUNCTION_TYPE | syntax_kind_ext::CONSTRUCTOR_TYPE
+        ) {
+            return false;
         }
         arena
-            .get_children(idx)
-            .into_iter()
-            .any(|child| Self::type_subtree_contains_literal_type(arena, child, depth + 1))
+            .get_function_type(node)
+            .is_some_and(|data| data.type_parameters.is_none())
+    }
+
+    /// The `NodeIndex` of `annotation_idx` after peeling parenthesized-type
+    /// wrappers (`([number, string])` is classified by its inner tuple).
+    /// Bounded against pathological wrapper nesting; returns `None` on a
+    /// missing node or when the wrapper depth bound is exceeded.
+    fn unwrapped_annotation_node(
+        arena: &tsz_parser::NodeArena,
+        annotation_idx: NodeIndex,
+    ) -> Option<NodeIndex> {
+        let mut idx = annotation_idx;
+        for _ in 0..16 {
+            let node = arena.get(idx)?;
+            if node.kind == syntax_kind_ext::PARENTHESIZED_TYPE {
+                idx = arena.get_wrapped_type(node)?.type_node;
+                continue;
+            }
+            return Some(idx);
+        }
+        None
     }
 
     /// Whether a declared type annotation is one whose written form `tsc` never

--- a/crates/tsz-checker/src/tests/declared_signature_return_literal_display_tests.rs
+++ b/crates/tsz-checker/src/tests/declared_signature_return_literal_display_tests.rs
@@ -188,6 +188,63 @@ const s: string = v;
 }
 
 #[test]
+fn declared_top_level_function_badly_spaced_return_literal_canonicalizes_spacing() {
+    // #17128: a written signature literal must stay verbatim (`1`, not
+    // `number`) *and* have its author whitespace canonicalized (`()=>1` ->
+    // `() => 1`). #17124 fixed the literal by echoing the raw source text,
+    // which re-leaked the spacing on badly-spaced input; the canonical
+    // formatter under `PreserveSignatureReturnLiteralsScope` reconciles both.
+    assert_source_displays(
+        r#"
+declare const v: ()=>1;
+const s: string = v;
+"#,
+        "() => 1",
+    );
+}
+
+#[test]
+fn declared_top_level_function_badly_spaced_param_literal_canonicalizes_spacing() {
+    // The `(x:1)=>void` row that regressed silently under #17124 (no test
+    // covered a no-space param-position literal).
+    assert_source_displays(
+        r#"
+declare const v: (x:1)=>void;
+const s: string = v;
+"#,
+        "(x: 1) => void",
+    );
+}
+
+#[test]
+fn declared_top_level_constructor_badly_spaced_return_literal_canonicalizes_spacing() {
+    // The construct-signature (`TypeData::Callable`) form of the same rule:
+    // `new()=>1` canonicalizes to `new () => 1` while keeping the return
+    // literal.
+    assert_source_displays(
+        r#"
+declare const v: new()=>1;
+const s: string = v;
+"#,
+        "new () => 1",
+    );
+}
+
+#[test]
+fn declared_top_level_function_badly_spaced_no_literal_canonicalizes_spacing() {
+    // Control: the no-literal signature still canonicalizes its spacing under
+    // the inline-signature source path (it never widens a literal, so the
+    // preserve scope is a no-op for it).
+    assert_source_displays(
+        r#"
+declare const v: (x:number)=>void;
+const s: string = v;
+"#,
+        "(x: number) => void",
+    );
+}
+
+#[test]
 fn declared_method_literal_preserved_when_source_is_in_target_role_position() {
     // The mismatching source here is `x` (`{ m(): 2 }`); it must keep `2`.
     assert_source_displays(


### PR DESCRIPTION
Fixes #17128.

A declared inline call/construct signature source (`declare const v: ()=>1`) is now rendered through tsc's `typeToString` — canonicalizing the author's whitespace (`()=>1` → `() => 1`, `(x:1)=>void` → `(x: 1) => void`, `new()=>1` → `new () => 1`) — **while** a literal written in the signature stays verbatim (`() => 1`, not `() => number`). This reaches 9/9 against `tsc` on the display family that #17112/#17124 kept trading one wrong row for another (and #17128's own table missed `new()=>1`, which was broken too).

**Structural rule:** when a source's declared annotation is a non-generic inline `FUNCTION_TYPE`/`CONSTRUCTOR_TYPE`, `tsc` renders it through `typeToString` with the written literal kept; tsz now formats the source type through the canonical assignability formatter under `PreserveSignatureReturnLiteralsScope` (owner: `error_reporter` source-display gateway → solver `TypeFormatter`).

**Root cause:** `normalize_assignability_display_type` widens a `TypeData::Function` return by default (the *fresh* function-expression case, where an inferred `(x) => 1` widens to `(x) => number`), preserving the literal only while `PreserveSignatureReturnLiteralsScope` is active. It has **no `TypeData::Callable` branch**, so a declared *constructor* already survived through the canonical formatter while a declared *call-only function* did not — the exact asymmetry #17128 observed. `declared_identifier_source_display` enters that scope only on its conditional override and returns `None` when the declared and checked displays are equal (the common `declare const` case), dropping the scope so the unscoped fall-through widened the return. #17112 routed these annotations through the canonical formatter for spacing; #17124 then declined canonicalization for literal-containing signatures and fell back to the raw-source-text echo, which preserved the literal but re-leaked the author's whitespace and silently regressed the no-space rows.

**The change:**
- `inline_signature_annotation_source_display` (new, `assignment_source_preservation.rs`): the early source-display branch, active under the preserve scope.
- `annotation_is_inline_signature_type` (new predicate): non-generic `FUNCTION_TYPE`/`CONSTRUCTOR_TYPE` after peeling parens; generic-ness read syntactically from the signature's own `type_parameters` (no rendered-string inspection, no type-shape barrel reference). Generic callables keep the established `declared_identifier_source_display` handling.
- `annotation_is_canonicalized_structural_type`: #17124's `type_subtree_contains_literal_type` decline removed; both predicates share one `unwrapped_annotation_node` paren-peeler.

**Anti-hardcoding:** no user-name/file-name literal, no formatted-string predicate (the generic check reads the AST `type_parameters`, not printed output), no single-test suppression. Fresh function-expression sources are not inline-signature annotations on a declared binding, so they never match and keep widening.

**Adjacent matrix** (in `declared_signature_return_literal_display_tests.rs`): no-space return literal (`()=>1`), no-space param literal (`(x:1)=>void`), no-space constructor return literal (`new()=>1`), and a no-space no-literal control (`(x:number)=>void`). Existing fresh-arrow / fresh-function-expression / fresh-object-literal widening negatives guard the fresh side.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --lib` — full unit suite green (11k+ tests, incl. the four new cases; `computed_alias_source_display_tests` / `alias_application_display_retention_tests` unaffected — a mid-work regression there was caught and fixed before this commit).
- `cargo test -p tsz-checker --test ts2322_tests` — 314 passed.
- Pre-commit gate: `cargo clippy -p tsz-checker` clean; arch-guard passed (`query_boundaries::common` reference count held at cap 3065; `assignment_formatting.rs` kept under the 2000-LOC ceiling by moving the helper to `assignment_source_preservation.rs`).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cwa8V1hJPR7e32iena7TE3)_