### PR TITLE
fix(checker): parenthesized zero-param ES class decorator TS1238 anchors at expression, not @

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/class_decorators.rs
+++ b/crates/tsz-checker/src/state/state_checking/class_decorators.rs
@@ -403,13 +403,19 @@ impl<'a> CheckerState<'a> {
                 .count();
             // ES decorators are invoked with `(value, context)`. When the
             // factory requires more than two parameters, the call cannot
-            // supply them; tsc anchors the error at the whole decorator
-            // (including `@`). Zero required params is normally the TS1329
-            // decorator-factory hint above, but a parenthesized expression
-            // opts out of that hint and still needs the arity failure here.
+            // supply them; tsc anchors that "too few arguments" failure at
+            // the whole decorator (including `@`) — same convention as the
+            // shared `decorator_failure_anchor` helper the legacy class- and
+            // member-decorator paths use. Zero required params is normally
+            // the TS1329 decorator-factory hint above, but a parenthesized
+            // expression opts out of that hint and still needs the arity
+            // failure here; since 0 declared params is never "too few" for
+            // a 2-argument call, that case anchors at the decorator
+            // expression instead (oracle-verified, typescript@7.0.2).
             if required_params > 2 || required_params == 0 {
+                let anchor = self.decorator_failure_anchor(decorator_node, resolved, 2);
                 self.error_at_node(
-                    decorator_node,
+                    anchor,
                     diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                     diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                 );

--- a/crates/tsz-checker/tests/ts1238_tests.rs
+++ b/crates/tsz-checker/tests/ts1238_tests.rs
@@ -250,6 +250,25 @@ fn ts1238_es_decorator_zero_arity_factory_emits_error() {
 }
 
 #[test]
+fn ts1238_es_decorator_zero_arity_parenthesized_factory_anchors_at_expression() {
+    // A parenthesized zero-param decorator (`@(() => {})`) declines the
+    // TS1329 "did you mean to call it" hint (that hint requires a
+    // referenceable decorator expression) and falls through to this
+    // generic TS1238 arity failure. 0 declared params is never "too few"
+    // for a 2-argument `(value, context)` ES call, so tsc anchors at the
+    // decorator EXPRESSION `(2,2)`-style position (one column after the
+    // `@`), not at the whole decorator including `@` — oracle-verified
+    // (typescript@7.0.2) against `esDecorators-arguments.ts`.
+    let source = "@(() => {})\nclass C {}\n";
+    let diagnostics = tsz_checker::test_utils::check_source_diagnostics(source);
+    tsz_checker::test_utils::assert_diagnostic_shape(
+        source,
+        &diagnostics,
+        &tsz_checker::test_utils::DiagnosticShape::code(1238).at(1, 2),
+    );
+}
+
+#[test]
 fn ts1238_es_decorator_one_or_two_required_params_no_error() {
     for source in [
         "@((a: any) => {})\nclass C {}\n",
@@ -275,4 +294,20 @@ fn ts1238_es_decorator_too_many_required_params_emits_error() {
             "Expected TS1238 for >2 required params, got: {codes:?} for {source}"
         );
     }
+}
+
+#[test]
+fn ts1238_es_decorator_too_many_required_params_anchors_at_whole_decorator() {
+    // Adjacent case to the zero-arity anchor fix above: a factory that
+    // requires MORE params than the 2-argument ES call can ever supply is
+    // genuinely "too few arguments", so tsc keeps anchoring at the whole
+    // decorator (including `@`) here — the shared `decorator_failure_anchor`
+    // helper must not flip this case too.
+    let source = "@((a: any, b: any, c: any) => {})\nclass C {}\n";
+    let diagnostics = tsz_checker::test_utils::check_source_diagnostics(source);
+    tsz_checker::test_utils::assert_diagnostic_shape(
+        source,
+        &diagnostics,
+        &tsz_checker::test_utils::DiagnosticShape::code(1238).at(1, 1),
+    );
 }


### PR DESCRIPTION
Fixes #17132.

## Structural rule

When an ES (TC39 stage-3) class decorator's arity check fails because the
factory declares 0 required parameters (`@(() => {})` — no slot for the
`value` argument the runtime supplies), `tsc` anchors `TS1238` at the
decorator **expression** (one column after `@`), not the whole decorator
span. #17120 moved both the code and the anchor to the TS1329 convention
(anchor at `@`); #17125 restored the correct `TS1238` code but left the
anchor behind at `@`.

`0` declared params is never "too few" for the 2-argument `(value, context)`
ES calling convention — it only becomes a genuine "too few arguments"
failure once a factory requires **more** than 2 params, and *that* shape
correctly anchors at the whole decorator (`@`) per `tsc`. Owner:
`check_es_class_decorator_arity`
(`crates/tsz-checker/src/state/state_checking/class_decorators.rs`), which
hardcoded `decorator_node` (the `@`-inclusive span) for both the `>2` and
`==0` branches instead of routing through the shared `decorator_failure_anchor`
helper (`decorator_signature_checks.rs`) that the legacy
(`experimentalDecorators`) class-decorator path and the member/parameter
decorator paths already use — that helper derives the anchor from the actual
too-few-args condition (every declared signature requires strictly more
params than the call supplies).

## Fix

Route `check_es_class_decorator_arity`'s arity-failure branch through
`self.decorator_failure_anchor(decorator_node, resolved, 2)` (2 = the ES
`(value, context)` call arity) instead of hardcoding `decorator_node`. For
`required_params > 2`, the helper still resolves to `decorator_node` (`@`) —
unchanged behavior. For `required_params == 0`, it now resolves to
`decorator_expression_anchor(decorator_node)` (the expression), matching
`tsc`.

## Adjacent cases (new tests)

- `@(() => {})\nclass C {}` — TS1238 now anchors at `(1, 2)`, the
  parenthesized expression (was `(1, 1)`, the `@`). Regression test:
  `ts1238_es_decorator_zero_arity_parenthesized_factory_anchors_at_expression`.
- `@((a: any, b: any, c: any) => {})\nclass C {}` — TS1238 still anchors at
  `(1, 1)`, the whole decorator (`>2` required params is genuinely "too few
  arguments"). Guard test:
  `ts1238_es_decorator_too_many_required_params_anchors_at_whole_decorator`,
  confirming the shared-helper routing doesn't flip this case too.
- Existing code-only tests (`ts1238_es_decorator_zero_arity_factory_emits_error`,
  `ts1238_es_decorator_one_or_two_required_params_no_error`,
  `ts1238_es_decorator_too_many_required_params_emits_error`) still pass
  unchanged.

This is a diagnostic-anchor-only change — no type semantics, resolution, or
`TypeId` identity touched.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts1238_tests`: 16/16 passed (2 new
  position-pinned regression tests + 14 existing, 0 regressions).
- `cargo clippy -p tsz-checker --lib --no-deps -- -D warnings`: clean.
- `cargo fmt -p tsz-checker -- --check`: clean.
- `python3 scripts/arch/arch_guard.py` (the CI `arch-size` gate): `Architecture guardrails passed.`
- Fixes the fingerprint-only regression on
  `conformance/esDecorators/esDecorators-arguments.ts` (TS1238 on both sides,
  only the anchor position differed) per #17132's bisect.
- No `crates/**/src` semantic/type-identity change — this is a diagnostic
  anchor-selection fix reusing an already-shared helper, so no conformance/emit
  corpus sweep was performed; the position-pinned unit tests are the primary
  evidence, matching the precedent set by other diagnostic-anchor fixes in
  this decorator family (#17126/#17127's TS6210/TS6236 pointer work).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_012og92JBGHNz1MFkLAYkyrf)_