### PR TITLE
fix(checker): call-argument missing-property promotion survives a bound method type parameter in a concrete target (#17145)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1891,6 +1891,9 @@ path = "tests/jsx_multi_construct_overload_tests.rs"
 name = "jsx_overload_anchor_literal_attr_tests"
 path = "tests/jsx_overload_anchor_literal_attr_tests.rs"
 [[test]]
+name = "ts2741_generic_method_index_signature_call_argument_tests"
+path = "tests/ts2741_generic_method_index_signature_call_argument_tests.rs"
+[[test]]
 name = "jsx_spread_assignability_suppresses_ts2741"
 path = "tests/jsx_spread_assignability_suppresses_ts2741.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -1160,8 +1160,20 @@ impl<'a> CheckerState<'a> {
                     arg_types,
                     index,
                 );
+                // Only a FREE type parameter in `expected` — one from an
+                // enclosing generic scope or the call's own unresolved type
+                // arguments — warrants the verbatim `T`/`Array<T>` display path
+                // (`error_argument_not_assignable_preserving_param_display`),
+                // which renders the parameter as written and skips the
+                // missing-property elaboration. A concrete target whose only
+                // type parameters are BOUND by its own method signatures
+                // (`interface Big { m<S>(x: S): S }`, or `Array<T>`/
+                // `ReadonlyArray<T>`'s `every<S extends T>`) is fully resolved
+                // for this argument, so it must take the ordinary
+                // `check_argument_assignable_or_report` path and promote a sole
+                // missing property to TS2739/TS2740/TS2741 (#17145).
                 let preserve_type_parameter_expected_display =
-                    common::contains_type_parameters(self.ctx.types, expected);
+                    common::contains_free_type_parameters(self.ctx.types, expected);
                 let reported_expected = if let Some(expected) = polymorphic_this_expected {
                     expected
                 } else if common::contains_this_type(self.ctx.types, expected) {

--- a/crates/tsz-checker/tests/ts2741_generic_method_index_signature_call_argument_tests.rs
+++ b/crates/tsz-checker/tests/ts2741_generic_method_index_signature_call_argument_tests.rs
@@ -1,0 +1,186 @@
+//! Locks tsc-parity for the missing-property head promotion (TS2739 / TS2740 /
+//! TS2741) when a value is passed as a CALL ARGUMENT to a parameter whose type
+//! is a concrete object/interface that declares BOTH an index signature AND a
+//! method with its own (bound) generic type parameter — e.g.
+//!
+//! ```ts
+//! interface Big { m<S>(x: S): S; readonly [n: number]: string }
+//! function f(x: Big) {}
+//! f({}); // tsc: TS2741 "Property 'm' is missing ... but required in type 'Big'"
+//! ```
+//!
+//! Regression for issue #17145. The call-argument mismatch renderer decides
+//! whether to take the "preserve the parameter type's verbatim display" path
+//! (which skips missing-property elaboration and emits a bare TS2345) by asking
+//! whether the parameter type contains a type parameter. It must ask for a
+//! *free* type parameter: a method's own `<S>` is BOUND by that method's
+//! signature, so a concrete target like `Big` (or the real shape of
+//! `Array<T>` / `ReadonlyArray<T>`, whose `every<S extends T>` etc. carry bound
+//! method type parameters) is fully resolved for the argument and must promote
+//! a sole missing property to TS2741 — exactly as the direct-assignment path
+//! already does.
+//!
+//! The binder names are varied deliberately (`Big`, `Enormous`, `StrIdx`) so no
+//! fix can key on a specific identifier.
+
+use tsz_checker::test_utils::check_source_code_messages as check;
+use tsz_common::diagnostics::diagnostic_codes;
+
+const TS2345: u32 = diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE;
+const TS2739: u32 = diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE;
+const TS2740: u32 = diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE_AND_MORE;
+const TS2741: u32 = diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE;
+
+fn assert_has(code: u32, source: &str) {
+    let diags = check(source);
+    assert!(
+        diags.iter().any(|(c, _)| *c == code),
+        "Expected TS{code}. Got: {diags:?}"
+    );
+}
+
+fn assert_none(code: u32, source: &str) {
+    let diags = check(source);
+    assert!(
+        diags.iter().all(|(c, _)| *c != code),
+        "Expected no TS{code}. Got: {diags:?}"
+    );
+}
+
+// The core repro: number index signature + generic method, passed as a call
+// argument. Before the fix this fell back to a bare TS2345 with no elaboration;
+// now it promotes to exactly one TS2741 and emits no bare TS2345 head.
+#[test]
+fn number_index_plus_generic_method_call_arg_promotes_to_ts2741() {
+    let diags = check(
+        r#"
+interface Big {
+    m<S>(x: S): S;
+    readonly [n: number]: string;
+}
+function f(x: Big) {}
+f({});
+"#,
+    );
+    assert!(
+        diags.iter().all(|(c, _)| *c != TS2345),
+        "call argument should promote to TS2741, not fall back to bare TS2345. Got: {diags:?}"
+    );
+    assert_eq!(
+        diags.iter().filter(|(c, _)| *c == TS2741).count(),
+        1,
+        "exactly one TS2741 expected. Got: {diags:?}"
+    );
+}
+
+// Renamed binders: the fix must not depend on any identifier.
+#[test]
+fn renamed_binders_still_promote() {
+    assert_has(
+        TS2741,
+        r#"
+interface Enormous {
+    handle<Q>(v: Q): Q;
+    readonly [k: number]: string;
+}
+function g(y: Enormous) {}
+g({});
+"#,
+    );
+}
+
+// String index signature variant (either index-signature kind triggers it).
+#[test]
+fn string_index_plus_generic_method_call_arg_promotes() {
+    let src = r#"
+interface StrIdx {
+    pick<T>(k: T): T;
+    [s: string]: unknown;
+}
+function h(z: StrIdx) {}
+h({});
+"#;
+    assert_has(TS2741, src);
+    assert_none(TS2345, src);
+}
+
+// The real-world shape that surfaced this: an interface extending a generic
+// base that itself carries bound method type parameters. Passing an
+// incompatible value must promote to the missing-property family (TS2739 /
+// TS2740 / TS2741), never fall back to a bare TS2345. (The unit harness does
+// not load `lib.es5`, so `Array<T>` resolves to only the interface's own
+// `clear` here; the full lib shape's many-missing TS2740 head is exercised by
+// the conformance corpus — `templateStringsArrayType*`, `noParameterReassignmentJSIIFE`.)
+#[test]
+fn interface_extends_generic_base_promotes_missing_property() {
+    let src = r#"
+interface Base<T> {
+    every<S extends T>(pred: (v: T) => v is S): boolean;
+    readonly [n: number]: T;
+}
+interface ObsArr<T> extends Base<T> {
+    clear(): T[];
+}
+function k(a: ObsArr<number>) {}
+k({});
+"#;
+    let diags = check(src);
+    assert!(
+        diags.iter().all(|(c, _)| *c != TS2345),
+        "extends-generic-base argument must promote, not fall back to bare TS2345. Got: {diags:?}"
+    );
+    assert!(
+        diags
+            .iter()
+            .any(|(c, _)| *c == TS2739 || *c == TS2740 || *c == TS2741),
+        "expected a missing-property head (TS2739/2740/2741). Got: {diags:?}"
+    );
+}
+
+// The direct-assignment path already promoted correctly; guard it so a future
+// change cannot regress the reference behavior the call path now matches.
+#[test]
+fn direct_assignment_still_promotes_to_ts2741() {
+    assert_has(
+        TS2741,
+        r#"
+interface Big {
+    m<S>(x: S): S;
+    readonly [n: number]: string;
+}
+const b: Big = {};
+"#,
+    );
+}
+
+// Negative: a value that genuinely satisfies the parameter type must NOT error.
+#[test]
+fn satisfying_argument_is_accepted() {
+    assert_none(
+        TS2741,
+        r#"
+interface Big {
+    m<S>(x: S): S;
+    readonly [n: number]: string;
+}
+function f(x: Big) {}
+declare const good: Big;
+f(good);
+"#,
+    );
+}
+
+// Negative: a genuinely missing property on a plain (non-generic) target still
+// promotes — the fix narrows the preserve-display gate, it does not disable
+// promotion.
+#[test]
+fn plain_target_missing_property_still_promotes() {
+    assert_has(
+        TS2741,
+        r#"
+interface Plain { a: number; }
+function p(q: Plain) {}
+p({});
+"#,
+    );
+}


### PR DESCRIPTION
## Structural rule

When a value is passed as a **call argument** to a parameter whose type is a
concrete object/interface that declares BOTH an index signature AND a method
with its own (bound) generic type parameter — e.g.
`` `interface Big { m<S>(x: S): S; readonly [n: number]: string }` `` — and the
argument is missing a required property, `tsc` promotes the sole
missing-property head (`TS2739` / `TS2740` / `TS2741`). tsz was falling back to
a bare `TS2345` with **no** elaboration. The equivalent direct assignment
(`` `const b: Big = {}` ``) already promoted correctly.

> When the call-argument parameter type is a fully concrete target whose only
> type parameters are BOUND by its own method signatures, `tsc` promotes the
> missing-property head; tsz now does too, through the checker's call-result
> display-routing gate.

## Root cause

The call-argument mismatch renderer (`handle_call_result` in
`crates/tsz-checker/src/types/computation/call_result.rs`) routes to
`error_argument_not_assignable_preserving_param_display` — which renders the
parameter type verbatim and **deliberately skips missing-property
elaboration** — whenever `preserve_type_parameter_expected_display` is true.
That gate was `contains_type_parameters(expected)`.

`contains_type_parameters(Big)` returns `true` only because `Big`'s method
`` `m<S>(x: S): S` `` carries a type parameter `S`. But `S` is **bound** by that
method's own signature — it is not a free/outer type parameter of the call.
So a fully concrete target (`Big`, and the real shape of `` `Array<T>` `` /
`` `ReadonlyArray<T>` `` whose `` `every<S extends T>` `` etc. carry bound method
type params) was misclassified as "generic" and routed to the verbatim-display
path, dropping the promotion. This is why the report's earlier trace found
`explain_failure` was never reached in the call case — the elaboration
machinery was correct; it simply was not on this path. The direct-assignment
path does not consult this gate, so it was unaffected.

Confirmed with a release binary + temporary `Backtrace::force_capture()` probes
on every diagnostic-insertion site (all reverted): the bare `TS2345` was emitted
by `error_argument_not_assignable_preserving_param_display` via `error_at_node`,
never through `analyze_assignability_failure`.

## Fix (owner layer: checker call-result display routing)

Gate on `contains_free_type_parameters(expected)` instead.
`contains_free_type_parameters_db`
(`crates/tsz-solver/src/type_queries/data/content_predicates.rs`) already exists
and its doc comment describes this exact hazard ("an object type with a method
`` `bar<W>()` `` … `W` is bound by `bar`'s signature … skips function/callable
bodies that have their own type parameters"). It is a strict narrowing
(`free ⟹ contains`) sharing the same project-wide predicate memo, so no
genuinely-generic target loses the verbatim-display path — only bound-only
concrete targets move back onto the ordinary
`check_argument_assignable_or_report` elaboration path. Correct general
predicate, reused from the solver boundary, applied at the single site that owns
the display-routing decision — not a shape-match special case.

## Adjacent-case matrix (release binary vs `tsc` 7.0.2 oracle — all byte-match)

| case | tsc | tsz (fixed) |
| --- | --- | --- |
| `f({})`, `Big` = `{ m<S>; [n:number] }` (call) | `TS2741 m` | `TS2741 m` |
| `const b: Big = {}` (assign, control) | `TS2741 m` | `TS2741 m` |
| renamed binders `Enormous` = `{ handle<Q>; [k:number] }` | `TS2741 handle` | `TS2741 handle` |
| string index `StrIdx` = `{ pick<T>; [s:string] }` | `TS2741 pick` | `TS2741 pick` |
| `interface ObsArr<T> extends Array<T>` | `TS2740 …and 17 more` | `TS2740 …and 17 more` |
| plain non-generic `Plain` = `{ a }` (negative) | `TS2741 a` | `TS2741 a` |
| `f(good)` where `good: Big` (negative) | clean | clean |

New test:
`crates/tsz-checker/tests/ts2741_generic_method_index_signature_call_argument_tests.rs`
(7 cases: core call promotion with exact-count assertion, renamed binders,
string/number index, extends-generic-base, direct-assignment control, two
negatives). Binder names are varied so no fix can key on an identifier.

## Scope: the 3 conformance cases in #17145 are NOT flipped by this PR

`templateStringsArrayTypeDefinedInES5Mode`,
`templateStringsArrayTypeRedefinedInES6Mode`, and `noParameterReassignmentJSIIFE`
remain red. Investigation (release binary, probes reverted) shows they hit a
**distinct, deeper defect**, not the free-vs-bound gate this PR fixes:

- A user `interface X extends ReadonlyArray<string>` (same arena) — even with a
  co-declared user `class X {}` merged in — resolves to a concrete target with
  `free = false` and now correctly promotes to `TS2740`.
- Only the real case, where a user `class TemplateStringsArray {}` merges with
  the **lib ambient** `interface TemplateStringsArray extends ReadonlyArray<string>`
  **across arenas**, leaves a **free `T` leaked** into the resolved member
  bodies (`free = true`, and it survives evaluation). That is a cross-arena
  heritage-materialization defect in the #14345 / #16308 family — the
  instantiation of the lib base fails to substitute `T := string` when merging
  across the lib arena. Fixing it is out of scope here and left as a tracked
  follow-up; forcing this row green through the diagnostic site would be a hack
  on top of a real materialization leak.

## Follow-up (not in this PR)

- The cross-arena lib-interface-merge free-`T` leak above (blocks the 3 rows).
- `call_target_generic_rest_requires_fixed_arity_error` (call_result.rs ~1886)
  shares the same latent free-vs-bound misclassification on a callback rest
  parameter's element type, but is highly contrived and has no concrete repro —
  tracked, not folded in speculatively. (`preferred_literal_expected_for_mismatch`
  at ~680 uses the broad predicate correctly and is left as-is.)

## Goal
Goal: green

## Verification
- `cargo test -p tsz-checker --test ts2741_generic_method_index_signature_call_argument_tests` — 7/7 pass.
- Adjacent matrix above vs `scripts/conformance/oracle.sh` (typescript@7.0.2) — byte-match.
- `cargo clippy -p tsz-checker` clean; architecture guard (0 LOC violations, 0 cross-layer imports) clean — both enforced by the pre-commit hook.
- Conformance snapshot (`conformance.sh snapshot --workers 12 --force`, full corpus): **no regression attributable to this change.** The change touches only the call-argument missing-property routing; the run-vs-baseline diff is symmetric nondeterminism (#16309) in unrelated domains (jsdoc `TS2694` namespace resolution, salsa JS, module-syntax elision, decorators). The one type-level "regression", `templateLiteralTypes7.ts`, contains no call expressions at all and so cannot be affected by this fix; `nonPrimitiveAssignError.ts` moved FAIL→PASS (a spurious extra `TS2741` removed). No case in the `TS2345`/`TS2739`/`TS2740`/`TS2741` family regressed.
- Emit parity (`scripts/emit/run.sh`) — running; a diagnostic-routing change emits no JS/DTS bytes, expected to hold 11562 JS / 1375 DTS.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high