### PR TITLE
fix(checker): promote missing-property call-argument failures in the preserve-display path (#17145)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2553,6 +2553,9 @@ path = "tests/union_property_optional_modifier_tests.rs"
 [[test]]
 name = "call_argument_boolean_literal_array_display_tests"
 path = "tests/call_argument_boolean_literal_array_display_tests.rs"
+[[test]]
+name = "call_argument_index_signature_generic_method_missing_property_tests"
+path = "tests/call_argument_index_signature_generic_method_missing_property_tests.rs"
 
 [[test]]
 name = "call_argument_bound_type_parameter_missing_property_promotion_tests"

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -92,6 +92,72 @@ impl<'a> CheckerState<'a> {
         self.error_argument_not_assignable_at_impl(arg_type, param_type, idx, true);
     }
 
+    /// Promote a sole/grouped missing-required-property argument failure to the
+    /// PRIMARY diagnostic at the argument node — TS2741 (one property), TS2739
+    /// (a few), TS2740 (many) — replacing the generic TS2345 head, exactly as
+    /// tsc's `reportUnmatchedProperty` runs before the relation head message.
+    ///
+    /// The renderer owns the guard set (intersection targets, index-signature
+    /// member compat, primitive/`object` sources keep the generic wording), so
+    /// this promotes exactly when it selected the property-missing family.
+    ///
+    /// This is shared by every call-argument emitter so the promotion cannot be
+    /// bypassed by a display-only branch: in particular
+    /// `error_argument_not_assignable_preserving_param_display` (the "preserve
+    /// the generic parameter display" fallback) must still honor it, otherwise a
+    /// target that merely *contains* a free type parameter — e.g. a class merged
+    /// with a generic-base interface — would drop the missing-property
+    /// elaboration and emit a bare TS2345 (#17145). Returns `true` when it
+    /// emitted a promoted diagnostic; the caller must then stop.
+    pub(crate) fn try_promote_missing_property_argument(
+        &mut self,
+        analysis: &crate::query_boundaries::assignability::AssignabilityFailureAnalysis,
+        arg_type: TypeId,
+        param_type: TypeId,
+        idx: NodeIndex,
+    ) -> bool {
+        let Some(reason) = analysis.failure_reason.as_ref() else {
+            return false;
+        };
+        if !matches!(
+            reason,
+            tsz_solver::SubtypeFailureReason::MissingProperty { .. }
+                | tsz_solver::SubtypeFailureReason::MissingProperties { .. }
+        ) || !self.missing_property_head_promotion_applies(arg_type, param_type)
+        {
+            return false;
+        }
+        // Render the source through the argument-context display pipeline
+        // (fresh object-literal widening included) — the same policy the
+        // TS2345 head applied to its argument string; the renderer's
+        // assignment-oriented role cannot reproduce it.
+        let source_display = Some(self.format_type_for_diagnostic_role(
+            arg_type,
+            DiagnosticTypeDisplayRole::CallArgument {
+                parameter: param_type,
+                argument_idx: idx,
+            },
+        ));
+        let diag = self.render_failure_reason_with_source_display(
+            reason,
+            arg_type,
+            param_type,
+            idx,
+            0,
+            source_display,
+        );
+        if matches!(
+            diag.code,
+            diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE
+                | diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE
+                | diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE_AND_MORE
+        ) {
+            self.ctx.push_diagnostic(diag);
+            return true;
+        }
+        false
+    }
+
     fn error_argument_not_assignable_at_impl(
         &mut self,
         arg_type: TypeId,
@@ -251,50 +317,10 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        // tsc promotes a sole missing-required-property failure to the PRIMARY
-        // diagnostic at the argument node — TS2741 (one property), TS2739
-        // (2-5), TS2740 (more) replace the generic TS2345 head
-        // (`reportUnmatchedProperty` runs before the relation head message).
-        // The renderer owns the guard set (intersection targets,
-        // index-signature member compat, primitive/`object` sources keep the
-        // generic wording), so promote exactly when it selected the
-        // property-missing family.
-        if let Some(reason) = analysis.failure_reason.as_ref()
-            && matches!(
-                reason,
-                tsz_solver::SubtypeFailureReason::MissingProperty { .. }
-                    | tsz_solver::SubtypeFailureReason::MissingProperties { .. }
-            )
-            && self.missing_property_head_promotion_applies(arg_type, param_type)
-        {
-            // Render the source through the argument-context display pipeline
-            // (fresh object-literal widening included) — the same policy the
-            // TS2345 head applied to its argument string; the renderer's
-            // assignment-oriented role cannot reproduce it.
-            let source_display = Some(self.format_type_for_diagnostic_role(
-                arg_type,
-                DiagnosticTypeDisplayRole::CallArgument {
-                    parameter: param_type,
-                    argument_idx: idx,
-                },
-            ));
-            let diag = self.render_failure_reason_with_source_display(
-                reason,
-                arg_type,
-                param_type,
-                idx,
-                0,
-                source_display,
-            );
-            if matches!(
-                diag.code,
-                diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE
-                    | diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE
-                    | diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE_AND_MORE
-            ) {
-                self.ctx.push_diagnostic(diag);
-                return;
-            }
+        // tsc promotes a sole/grouped missing-required-property failure to the
+        // PRIMARY diagnostic at the argument node (TS2741/TS2739/TS2740).
+        if self.try_promote_missing_property_argument(&analysis, arg_type, param_type, idx) {
+            return;
         }
 
         // When the failure reason is NoCommonProperties (weak types with no

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -292,6 +292,15 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
+        // Preserving the parameter display governs only the fallback TS2345
+        // rendering — a missing-property failure still promotes to TS2741/2739/
+        // 2740, even when the target merely contains a free type parameter (a
+        // class merged with a generic-base interface leaks the base's `T`; #17145).
+        let analysis = self.analyze_assignability_failure(arg_type, param_type);
+        if self.try_promote_missing_property_argument(&analysis, arg_type, param_type, arg_idx) {
+            return;
+        }
+
         let display_arg_type =
             diagnostics::widen_argument_type_for_display(self.ctx.types, arg_type);
         // Widen a fresh boolean-literal array element to `boolean` structurally

--- a/crates/tsz-checker/tests/call_argument_index_signature_generic_method_missing_property_tests.rs
+++ b/crates/tsz-checker/tests/call_argument_index_signature_generic_method_missing_property_tests.rs
@@ -1,0 +1,198 @@
+//! Call-argument missing-property promotion for a target that carries BOTH an
+//! index signature AND a method with its own (bound) type parameter (#17145).
+//!
+//! Structural rule: when an incompatible value is passed as a call argument to a
+//! parameter whose object/interface type declares both (a) a number/string index
+//! signature and (b) a method member whose signature has its own type
+//! parameter(s) (`m<S>(x: S): S`), tsc promotes the sole/grouped
+//! missing-property failure to the primary diagnostic (TS2741/TS2739/TS2740),
+//! exactly as it already does for a direct assignment. tsz previously dropped
+//! the elaboration and emitted a bare TS2345 for this shape only.
+//!
+//! Root cause: the call-argument display gate
+//! (`preserve_type_parameter_expected_display`) tested
+//! `contains_type_parameters`, which counts a member method's *bound* signature
+//! parameter as a type parameter (and, when the object also carries an index
+//! signature, surfaces it as a raw `TypeParameter`). That routed the argument to
+//! the bare "preserve the generic parameter display" head, which never runs the
+//! missing-property elaboration. The gate now uses `contains_free_type_parameters`
+//! so only a genuinely FREE type parameter (from an enclosing generic signature)
+//! preserves its display; a member-bound parameter does not.
+//!
+//! These tests vary the interface name, the type-parameter name, the property
+//! names, and the index-signature key/value types so a fix keyed to a particular
+//! spelling would not satisfy them. They assert on the diagnostic code and the
+//! named missing member(s), not on the exact rendered type text.
+
+use tsz_checker::test_utils::check_source_diagnostics;
+use tsz_common::diagnostics::Diagnostic;
+
+fn diagnostics(source: &str) -> Vec<Diagnostic> {
+    check_source_diagnostics(source)
+}
+
+/// True when a sole-missing-property TS2741 names `prop` as missing and required.
+fn has_single_missing_property(diags: &[Diagnostic], prop: &str) -> bool {
+    let needle = format!("Property '{prop}' is missing");
+    diags.iter().any(|d| {
+        d.code == 2741 && d.message_text.contains(&needle) && d.message_text.contains("required in")
+    })
+}
+
+/// True when a grouped missing-property diagnostic (TS2739/TS2740) lists every
+/// name in `props`.
+fn has_grouped_missing_properties(diags: &[Diagnostic], props: &[&str]) -> bool {
+    diags.iter().any(|d| {
+        (d.code == 2739 || d.code == 2740)
+            && d.message_text
+                .contains("is missing the following properties from type")
+            && props.iter().all(|p| d.message_text.contains(p))
+    })
+}
+
+/// True when a bare TS2345 argument error was emitted with no missing-property
+/// promotion — the pre-fix behavior this issue is about.
+fn has_bare_argument_ts2345(diags: &[Diagnostic]) -> bool {
+    diags
+        .iter()
+        .any(|d| d.code == 2345 && d.message_text.contains("is not assignable to parameter"))
+}
+
+/// The reported repro: index signature + generic method, passed as a call
+/// argument. tsc promotes to TS2741; tsz used to emit a bare TS2345.
+#[test]
+fn call_argument_index_and_generic_method_promotes_single_missing_property() {
+    let diags = diagnostics(
+        "interface Big {\n\
+         \x20   m<S>(x: S): S;\n\
+         \x20   readonly [n: number]: string;\n\
+         }\n\
+         declare function f(x: Big): void;\n\
+         f({});",
+    );
+    assert!(
+        has_single_missing_property(&diags, "m"),
+        "call argument must promote to TS2741 naming the missing method `m`: {diags:?}"
+    );
+    assert!(
+        !has_bare_argument_ts2345(&diags),
+        "the bare TS2345 head must no longer be emitted for this shape: {diags:?}"
+    );
+}
+
+/// Anti-hardcoding: rename the interface, the bound type parameter, the missing
+/// method, and the index-signature key/value types. The promotion must still
+/// fire — the fix is structural, not keyed to any spelling.
+#[test]
+fn call_argument_promotion_survives_renamed_binders() {
+    let diags = diagnostics(
+        "interface Container {\n\
+         \x20   transform<Elem>(value: Elem): Elem;\n\
+         \x20   readonly [key: number]: boolean;\n\
+         }\n\
+         declare function accept(c: Container): void;\n\
+         accept({});",
+    );
+    assert!(
+        has_single_missing_property(&diags, "transform"),
+        "renamed shape must still promote to TS2741 naming `transform`: {diags:?}"
+    );
+    assert!(
+        !has_bare_argument_ts2345(&diags),
+        "no bare TS2345 for the renamed shape: {diags:?}"
+    );
+}
+
+/// A string index signature (not just numeric) alongside the generic method is
+/// the same shape and must promote identically.
+#[test]
+fn call_argument_promotion_with_string_index_signature() {
+    let diags = diagnostics(
+        "interface Bag {\n\
+         \x20   pick<K>(k: K): K;\n\
+         \x20   readonly [name: string]: unknown;\n\
+         }\n\
+         declare function use(b: Bag): void;\n\
+         use({});",
+    );
+    assert!(
+        has_single_missing_property(&diags, "pick"),
+        "string-index shape must promote to TS2741 naming `pick`: {diags:?}"
+    );
+}
+
+/// Several required members missing at once (a generic method plus two plain
+/// properties) alongside the index signature: tsc groups them into TS2739/TS2740.
+#[test]
+fn call_argument_groups_multiple_missing_properties() {
+    let diags = diagnostics(
+        "interface Multi {\n\
+         \x20   alpha<A>(x: A): A;\n\
+         \x20   beta: number;\n\
+         \x20   gamma: string;\n\
+         \x20   readonly [i: number]: symbol;\n\
+         }\n\
+         declare function want(m: Multi): void;\n\
+         want({});",
+    );
+    assert!(
+        has_grouped_missing_properties(&diags, &["alpha", "beta", "gamma"]),
+        "multiple missing members must group into TS2739/TS2740 listing all names: {diags:?}"
+    );
+    assert!(
+        !has_bare_argument_ts2345(&diags),
+        "no bare TS2345 when several properties are missing: {diags:?}"
+    );
+}
+
+/// Parity guard: the identical target as a DIRECT ASSIGNMENT was already correct
+/// (TS2741). Keep it pinned so the two paths cannot drift apart again.
+#[test]
+fn direct_assignment_same_shape_still_promotes() {
+    let diags = diagnostics(
+        "interface Big {\n\
+         \x20   m<S>(x: S): S;\n\
+         \x20   readonly [n: number]: string;\n\
+         }\n\
+         const b: Big = {};",
+    );
+    assert!(
+        has_single_missing_property(&diags, "m"),
+        "direct assignment must keep promoting to TS2741: {diags:?}"
+    );
+}
+
+/// Control: the generic method WITHOUT an index signature already promoted; keep
+/// it green so the fix does not regress the single-condition case.
+#[test]
+fn control_generic_method_only_still_promotes() {
+    let diags = diagnostics(
+        "interface OnlyGeneric {\n\
+         \x20   m<S>(x: S): S;\n\
+         }\n\
+         declare function f(x: OnlyGeneric): void;\n\
+         f({});",
+    );
+    assert!(
+        has_single_missing_property(&diags, "m"),
+        "generic-method-only target must still promote to TS2741: {diags:?}"
+    );
+}
+
+/// Control: the index signature WITHOUT a generic method already promoted; keep
+/// it green so the fix does not regress the single-condition case.
+#[test]
+fn control_index_signature_only_still_promotes() {
+    let diags = diagnostics(
+        "interface OnlyIndex {\n\
+         \x20   m(x: number): number;\n\
+         \x20   readonly [n: number]: string;\n\
+         }\n\
+         declare function f(x: OnlyIndex): void;\n\
+         f({});",
+    );
+    assert!(
+        has_single_missing_property(&diags, "m"),
+        "index-signature-only target must still promote to TS2741: {diags:?}"
+    );
+}


### PR DESCRIPTION
Fixes #17145.

**Structural rule:** when a value missing required properties is passed as a **call argument** to a parameter whose object/interface type carries a member method with its own bound type parameter (`m<S>(x: S): S`) — or, once the object also has an index signature, a class merged with a generic-base library interface (`TemplateStringsArray extends ReadonlyArray<T>`) — tsc promotes the missing-property failure to `TS2741`/`TS2739`/`TS2740` (`reportUnmatchedProperty`, which runs before the relation head). tsz instead dropped the elaboration and emitted a bare `TS2345`, even though the identical **direct assignment** reported the missing-property diagnostic. Owner layer: the checker call-argument diagnostic emitters.

**Root cause & fix.** The `preserve_type_parameter_expected_display` gate already uses `contains_free_type_parameters` (which fixed the bound-signature-parameter case such as the `Big` interface). But a target that still carries a genuinely *free* type parameter — a class merged with a generic-base interface leaks the base's `T` — is routed to `error_argument_not_assignable_preserving_param_display`, the "preserve the generic parameter display" fallback, which **never ran the missing-property promotion**.

- Extract the promotion block from `error_argument_not_assignable_at_impl` into a shared `try_promote_missing_property_argument` helper.
- Call it from `error_argument_not_assignable_preserving_param_display` too. Preserving the parameter display now governs only the fallback `TS2345` rendering — never whether the missing-property diagnostic fires. The promotion stays behind its existing guard set (`missing_property_head_promotion_applies`: intersection targets, index-signature member compat, primitive/`object` sources keep the generic wording), so it fires exactly when the renderer selected the property-missing family.

Adjacent cases in the new unit suite: renamed binders/type-parameter names, string *and* number index signatures, grouped-missing (`TS2739`/`TS2740`), direct-assignment parity, and single-condition (index-only, generic-method-only) controls.

## Goal
Goal: hold

## Verification
- `templateStringsArrayTypeDefinedInES5Mode` and `templateStringsArrayTypeRedefinedInES6Mode` flip **FAIL → PASS** (verified individually via `scripts/conformance/conformance.sh run --filter <case>`, and by stash/unstash before-after).
- Full conformance run (`scripts/conformance/conformance.sh run --workers 12`): **no regression attributable to this change** — the apparent regressions vs the stored (stale, older-commit) baseline fail identically with the change stashed, and both target cases fail with it stashed and pass with it applied.
- New unit suite `call_argument_index_signature_generic_method_missing_property_tests`: **7/7 pass**.
- `cargo clippy -p tsz-checker --all-targets`: clean. Architecture guard: pass (LOC + boundary).
- Out of scope: `noParameterReassignmentJSIIFE` (the third case in the issue) stays failing — it reaches the diagnostic through the generic `CallableFunction.apply<T, A, R>` inference path, a distinct emitter that resolves `IArguments`→`string[]` differently; noted for follow-up.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pf3mCZhfd1K1Te5NbqHvSD)_