### PR TITLE
fix(binder): aliased named export resolves by local name, not exported alias

### DIFF
--- a/crates/tsz-binder/src/modules/binding.rs
+++ b/crates/tsz-binder/src/modules/binding.rs
@@ -853,18 +853,53 @@ impl BinderState {
                                                         && let Some(spec) =
                                                             arena.get_specifier(spec_node)
                                                     {
-                                                        let name_idx = if spec.name.is_none() {
-                                                            spec.property_name
-                                                        } else {
-                                                            spec.name
-                                                        };
-                                                        if let Some(name_node) = arena.get(name_idx)
-                                                            && let Some(ident) =
-                                                                arena.get_identifier(name_node)
+                                                        // `export { foo }`: property_name is
+                                                        // NONE, name is "foo" (local == exported).
+                                                        // `export { foo as bar }`: property_name
+                                                        // is "foo" (local), name is "bar"
+                                                        // (exported) — these must resolve the
+                                                        // symbol by the LOCAL name, not the
+                                                        // exported alias.
+                                                        let local_name_idx =
+                                                            if spec.property_name.is_none() {
+                                                                spec.name
+                                                            } else {
+                                                                spec.property_name
+                                                            };
+                                                        let exported_name_idx =
+                                                            if spec.name.is_none() {
+                                                                spec.property_name
+                                                            } else {
+                                                                spec.name
+                                                            };
+                                                        if let Some(local_name_node) =
+                                                            arena.get(local_name_idx)
+                                                            && let Some(local_ident) = arena
+                                                                .get_identifier(local_name_node)
+                                                            && let Some(exported_name_node) =
+                                                                arena.get(exported_name_idx)
+                                                            && let Some(exported_ident) = arena
+                                                                .get_identifier(exported_name_node)
                                                         {
-                                                            exported_names.push(
-                                                                ident.escaped_text.to_string(),
-                                                            );
+                                                            let local_name = local_ident
+                                                                .escaped_text
+                                                                .to_string();
+                                                            let exported_name = exported_ident
+                                                                .escaped_text
+                                                                .to_string();
+                                                            exported_names
+                                                                .push(exported_name.clone());
+                                                            if let Some(sym_id) = self
+                                                                .current_scope()
+                                                                .get(local_name.as_str())
+                                                                .or_else(|| {
+                                                                    self.file_locals
+                                                                        .get(local_name.as_str())
+                                                                })
+                                                            {
+                                                                exported_symbols
+                                                                    .push((exported_name, sym_id));
+                                                            }
                                                         }
                                                     }
                                                 }

--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -873,6 +873,9 @@ path = "tests/ambient_module_renamed_export_ts2460_tests.rs"
 name = "ambient_module_renamed_export_local_shadow_tests"
 path = "tests/ambient_module_renamed_export_local_shadow_tests.rs"
 [[test]]
+name = "ambient_module_block_local_named_export_cross_block_leak_tests"
+path = "tests/ambient_module_block_local_named_export_cross_block_leak_tests.rs"
+[[test]]
 name = "ambient_module_import_alias_defid_collision_tests"
 path = "tests/ambient_module_import_alias_defid_collision_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/ambient_module_block_local_named_export_cross_block_leak_tests.rs
+++ b/crates/tsz-checker/tests/ambient_module_block_local_named_export_cross_block_leak_tests.rs
@@ -1,0 +1,259 @@
+//! A block-local (non-exported) namespace declaration must not become
+//! visible in a sibling `declare module "M" { ... }` block just because an
+//! unrelated `export { Orig as Exp }` specifier in the same block happens to
+//! reuse its name as the export alias.
+//!
+//! Structural rule (one sentence):
+//!
+//! > When several `declare module "M" { ... }` blocks merge, tsc propagates
+//! > only a block's genuine *exports* into the merged module's export table
+//! > that sibling blocks see; tsz does the same through
+//! > `BinderState::populate_module_exports`
+//! > (`crates/tsz-binder/src/modules/binding.rs`), which must resolve an
+//! > aliased export specifier's exported symbol by its LOCAL declaration name
+//! > (`export { Orig as Exp }` exports the symbol named `Orig`), not by the
+//! > exported alias name `Exp`.
+//!
+//! Before this fix, `populate_module_exports`'s `NAMED_EXPORTS` handling
+//! looked the exported symbol up in scope **by the exported alias name**
+//! instead of the local declaration name. When a block-local declaration
+//! happened to share the alias name (e.g. a plain, non-exported
+//! `namespace X` alongside `export { Y as X }` in the same block), the
+//! lookup found that unrelated block-local symbol instead of `Y`, exported
+//! *it* under the name `X`, and that wrong symbol then leaked into every
+//! sibling block through the normal (and otherwise correct) cross-block
+//! export-merge path — making the block-local namespace wrongly resolvable
+//! from a block that never declared it.
+//!
+//! Reported witness (oracled against tsc 7.0.2, which reports TS2503 on the
+//! second block's `X.I` and nothing else relevant):
+//! ```ts
+//! declare module "m2" {
+//!     namespace X { interface I {} }
+//!     function Y();
+//!     export { Y as X };
+//!     function Z(): X.I;
+//! }
+//! declare module "m2" {
+//!     function Z2(): X.I;
+//! }
+//! ```
+//!
+//! Every test varies at least one user-chosen name (module specifier,
+//! namespace name, alias name, member name) so the fix is structural rather
+//! than shape-fingerprinted.
+
+use tsz_checker::test_utils::check_source_codes;
+
+const TS2503: u32 = 2503;
+
+// ─────────────────── 1. reported repro and its renamings ───────────────────
+
+/// The conformance witness itself: the block-local namespace must stay
+/// invisible from the sibling block, even though an aliased export in the
+/// declaring block reuses its name.
+#[test]
+fn block_local_namespace_does_not_leak_across_merged_blocks_via_export_alias() {
+    let codes = check_source_codes(
+        r#"
+declare module "m2" {
+    namespace X {
+        interface I { }
+    }
+    function Y(): void;
+    export { Y as X };
+    function Z(): X.I;
+}
+
+declare module "m2" {
+    function Z2(): X.I;
+}
+"#,
+    );
+    assert!(
+        codes.contains(&TS2503),
+        "block-local namespace must not leak into a sibling block: {codes:?}"
+    );
+}
+
+/// Same shape with every binder renamed — the rule is structural, not keyed
+/// to the witness's identifiers.
+#[test]
+fn renamed_binders_block_local_namespace_does_not_leak() {
+    let codes = check_source_codes(
+        r#"
+declare module "mod-alpha" {
+    namespace Qq {
+        interface Inner { }
+    }
+    function Helper(): void;
+    export { Helper as Qq };
+    function Use(): Qq.Inner;
+}
+
+declare module "mod-alpha" {
+    function UseElsewhere(): Qq.Inner;
+}
+"#,
+    );
+    assert!(
+        codes.contains(&TS2503),
+        "renamed binders must behave identically: {codes:?}"
+    );
+}
+
+/// A deeper container: the block-local namespace shadowed by the alias is
+/// reached through a qualified name.
+#[test]
+fn nested_qualified_block_local_namespace_does_not_leak() {
+    let codes = check_source_codes(
+        r#"
+declare module "deep-mod" {
+    namespace Outer {
+        namespace Middle {
+            interface Leaf { }
+        }
+    }
+    function fallback(): void;
+    export { fallback as Outer };
+    function consume(): Outer.Middle.Leaf;
+}
+
+declare module "deep-mod" {
+    function consumeElsewhere(): Outer.Middle.Leaf;
+}
+"#,
+    );
+    assert!(
+        codes.contains(&TS2503),
+        "nested qualified block-local namespace must not leak: {codes:?}"
+    );
+}
+
+/// Three merged blocks: the leak must not reach any sibling, not just the
+/// immediately following one.
+#[test]
+fn block_local_namespace_does_not_leak_into_third_merged_block() {
+    let codes = check_source_codes(
+        r#"
+declare module "m9" {
+    namespace X {
+        interface I { }
+    }
+    function Y(): void;
+    export { Y as X };
+}
+
+declare module "m9" {
+    function unrelated(): void;
+}
+
+declare module "m9" {
+    function Z2(): X.I;
+}
+"#,
+    );
+    assert!(
+        codes.contains(&TS2503),
+        "block-local namespace must not leak past an intervening block: {codes:?}"
+    );
+}
+
+// ───────────────────────── 2. positive/negative controls ──────────────────
+
+/// The declaring block itself must still resolve `X.I` cleanly — the fix
+/// must not overcorrect into hiding the local namespace from its own block.
+#[test]
+fn declaring_block_still_resolves_its_own_local_namespace() {
+    let codes = check_source_codes(
+        r#"
+declare module "m2" {
+    namespace X {
+        interface I { }
+    }
+    function Y(): void;
+    export { Y as X };
+    function Z(): X.I;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&TS2503),
+        "the declaring block must keep resolving its own local namespace: {codes:?}"
+    );
+}
+
+/// A genuinely (non-aliased) exported namespace must still merge correctly
+/// across blocks — the fix must not disturb the already-correct path for
+/// direct declarations reached via `node_symbols`.
+#[test]
+fn genuinely_exported_namespace_still_merges_across_blocks() {
+    let codes = check_source_codes(
+        r#"
+declare module "m11" {
+    export namespace X {
+        interface I { }
+    }
+}
+
+declare module "m11" {
+    function Z2(): X.I;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&TS2503),
+        "a genuinely exported namespace must still merge across blocks: {codes:?}"
+    );
+}
+
+/// When the alias does not collide with any block-local declaration, the
+/// aliased export must still correctly export the target VALUE across
+/// blocks (the fix must not break the working, non-colliding case).
+#[test]
+fn non_colliding_aliased_value_export_still_crosses_blocks() {
+    let codes = check_source_codes(
+        r#"
+declare module "m12" {
+    function Y(): void;
+    export { Y as W };
+}
+
+declare module "m12" {
+    const w: typeof W;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&TS2503),
+        "a non-colliding aliased value export must still cross blocks: {codes:?}"
+    );
+}
+
+/// A block with no `export` statement at all is in tsc's *implicit-export*
+/// mode (see the `hasExportDeclarations` doc comment in `binding.rs`): every
+/// top-level declaration, including a plain `namespace X`, is treated as
+/// exported and does cross into sibling blocks. This is the control that
+/// isolates the bug: adding an unrelated `export { ... }` specifier to the
+/// same block (as in the other tests above) is what disables implicit
+/// export and makes the plain `namespace X` block-local again.
+#[test]
+fn block_with_no_export_at_all_implicitly_exports_and_crosses_blocks() {
+    let codes = check_source_codes(
+        r#"
+declare module "m13" {
+    namespace X {
+        interface I { }
+    }
+}
+
+declare module "m13" {
+    function Z2(): X.I;
+}
+"#,
+    );
+    assert!(
+        !codes.contains(&TS2503),
+        "an implicit-export block's namespace must cross into a sibling block: {codes:?}"
+    );
+}


### PR DESCRIPTION
When a `declare module "M" { ... }` block's `export { Orig as Exp }` specifier is materialized, tsc looks the exported symbol up by `Orig` (the local declaration name) and records it under `Exp` in the module's export table. `BinderState::populate_module_exports`'s `NAMED_EXPORTS` arm (`crates/tsz-binder/src/modules/binding.rs`) did the opposite: it looked up the symbol to export **by the exported alias name** instead of the local declaration name.

When a block-local, unexported declaration happens to share the alias name — e.g. a plain `namespace X { ... }` alongside `export { Y as X }` in the same block — the lookup found that unrelated block-local symbol instead of `Y`, exported *it* under `"X"`, and that wrong symbol then leaked into every sibling `declare module "same-name"` block through the otherwise-correct cross-block export-merge mechanism (`prior_exports` seeding). The result: a block-local namespace became resolvable from a sibling block that never declared it, silently swallowing the TS2503 tsc reports there.

The fix mirrors the already-correct pattern used by the sibling resolution path in `crates/tsz-binder/src/modules/import_export.rs` (`original_name`/`exported_name` derived from `spec.property_name`/`spec.name` respectively), which a prior PR had already fixed for the same-block, in-scope-clobbering variant of this bug family (`ambient_module_renamed_export_local_shadow_tests.rs`) — this PR fixes the analogous cross-block leak that survived through the export-table channel instead.

## Goal
Goal: hold

## Verification
- New test file `crates/tsz-checker/tests/ambient_module_block_local_named_export_cross_block_leak_tests.rs` (8 tests, registered in `crates/tsz-checker/Cargo.toml`): the reported repro, renamed-binder variant, nested-qualified-name variant, a third-merged-block variant, a declaring-block-stays-clean control, a genuinely-exported-namespace-still-merges control, a non-colliding-aliased-value-still-crosses-blocks control, and an implicit-export (no `export` in the block at all) control that isolates why the explicit `export {...}` specifier is what disables implicit export and exposes the bug. Confirmed all 4 repro-shaped tests fail on the pre-fix code (`git stash` of the binder change) and all 8 pass with the fix.
- `cargo test -p tsz-checker --test ambient_module_block_local_named_export_cross_block_leak_tests` — 8/8 passed.
- `cargo test -p tsz-checker --test ambient_module_renamed_export_local_shadow_tests` (sibling fix's own regression suite) — 9/9 passed, no regression.
- `cargo test -p tsz-binder --lib` — 450/450 passed.
- `cargo test -p tsz-checker --lib` — running (long tail per repo notes); will report before landing if any failure surfaces.
- `cargo clippy -p tsz-binder -p tsz-checker --all-targets` — clean.
- `python3 scripts/arch/arch_guard.py` — passed.
- `python3 scripts/ci/check-test-file-reachability.py` — 0 new orphans.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_011sJ1ey5Fa3ELC6zncMZCg8)_