### PR TITLE
fix(tests): migrate import-type cross-file suites off the SymbolId-colliding multi-file helper

### DIFF
--- a/crates/tsz-checker/tests/import_type_ambient_module_member_tests.rs
+++ b/crates/tsz-checker/tests/import_type_ambient_module_member_tests.rs
@@ -10,8 +10,8 @@
 
 use tsz_checker::context::CheckerOptions;
 use tsz_checker::test_utils::{
-    check_multi_file_with_libs, check_source_strict_messages, diagnostic_code_messages,
-    load_lib_files,
+    check_multi_file_with_libs_unique_module_locals, check_source_strict_messages,
+    diagnostic_code_messages, load_lib_files,
 };
 
 fn diagnostics(source: &str) -> Vec<(u32, String)> {
@@ -180,9 +180,17 @@ const s: S = true;
 #[test]
 fn cross_file_import_type_member_still_works() {
     // Control: the cross-file (file-backed module) path must keep working
-    // exactly as before.
+    // exactly as before. Uses the unique-module-locals helper because the
+    // plain per-file-binder helper restarts every file's `SymbolId`s at 0
+    // (#15983 family): `Thing` in module.ts and `Member` in main.ts land on
+    // the same raw id by coincidence, and `CheckerState::get_or_create_def_id`
+    // — keyed by that raw id alone — collapses them onto one `DefId`, so
+    // resolving `Member`'s body re-enters its own alias-resolution stack
+    // entry and `mark_cross_arena_alias_cycle` misreports a genuine TS2456
+    // self-cycle. Production never hits this: the driver's bind-result
+    // reducer remaps every file into one globally-unique id space.
     let libs = load_lib_files(&["es5.d.ts"]);
-    let diags = diagnostic_code_messages(check_multi_file_with_libs(
+    let diags = diagnostic_code_messages(check_multi_file_with_libs_unique_module_locals(
         &[
             (
                 "module.ts",

--- a/crates/tsz-checker/tests/import_type_utility_identity_tests.rs
+++ b/crates/tsz-checker/tests/import_type_utility_identity_tests.rs
@@ -1,11 +1,21 @@
 use tsz_checker::context::CheckerOptions;
 use tsz_checker::test_utils::{
-    check_multi_file_with_libs, diagnostic_code_messages, load_lib_files,
+    check_multi_file_with_libs_unique_module_locals, diagnostic_code_messages, load_lib_files,
 };
 
+// Uses the unique-module-locals helper, not the plain per-file-binder one:
+// the plain helper restarts every file's `SymbolId`s at 0 (#15983 family), so
+// a `module.ts` declaration (`Wrap`, `Box`, `withArgs`, ...) can land on the
+// same raw id as an unrelated `consumer.ts` local (`ExtractWrapped`, `IsBox`,
+// `Test1`, ...). `CheckerState::get_or_create_def_id` is keyed by that raw id
+// alone, so the collision corrupts cross-file identity for the colliding
+// pair — an `infer` binding resolves to the wrong declaration, or a
+// conditional's checked type is confused with an unrelated import member.
+// Production never hits this: the driver's bind-result reducer remaps every
+// file into one globally-unique id space before checking starts.
 fn diagnostics_for_import_utility(entry: &str) -> Vec<(u32, String)> {
     let libs = load_lib_files(&["es5.d.ts"]);
-    diagnostic_code_messages(check_multi_file_with_libs(
+    diagnostic_code_messages(check_multi_file_with_libs_unique_module_locals(
         &[
             (
                 "module.ts",

--- a/scripts/ci/known-failures.txt
+++ b/scripts/ci/known-failures.txt
@@ -107,6 +107,25 @@
 # and the tsz-emitter overloaded-initializer row likewise pass. Full per-target
 # sweep of every target holding a gate entry: 30 failing, all remaining entries
 # still reproduce.
+# 2026-08-11 shrink (no generation bump — removals are always allowed): three
+# more #15983-family rows now pass, verified with per-target runs
+# (`cargo test -p tsz-checker --test <target>`). All three shared one root
+# cause: `import_type_ambient_module_member_tests::cross_file_import_type_member_still_works`
+# and two `import_type_utility_identity_tests` rows built their two-file
+# fixture with the plain `check_multi_file_with_libs` helper, whose per-file
+# binders both restart `SymbolId` at 0. An unrelated declaration in one file
+# (e.g. `Member`) landed on the same raw id as a declaration in the other file
+# (e.g. `Thing`), and `CheckerState::get_or_create_def_id`/`get_or_create_def_id_for_symbol_name`
+# — keyed by that raw id alone — collapsed them onto one `DefId`, corrupting
+# cross-file identity (a spurious TS2456 self-cycle in one case, an `infer`
+# binding or conditional check resolving to the wrong declaration in the
+# other two). Fixed by migrating both test files to
+# `check_multi_file_with_libs_unique_module_locals`, same as the 2026-08-06
+# kysely fix above. `import_type_extends_structural_match_no_false_positive`
+# stays listed: it reproduces the identical `boolean`-vs-`true` mismatch even
+# after the helper swap, and reproduces through the real `tsz` CLI binary too
+# (no test-harness collision involved) — a genuine cross-file import-type
+# identity gap in conditional-type evaluation. Filed as #17158.
 tsz-checker::commonjs_module_export_alias_tests::test_module_exports_forward_read_reports_ts2565
 tsz-checker::conditional_application_display_tests::deferred_generic_conditional_keeps_branch_union
 tsz-checker::conformance_issues_features::features::namespace_construct_signature::part_00::test_js_void_zero_expando_reports_named_receiver_type
@@ -122,10 +141,7 @@ tsz-checker::cross_module_nested_interface_tests::test_workspace_property_type_r
 tsz-checker::generic_call_assignment_flow_tests::colliding_generic_terminals_keep_flow_diagnostics_clean_across_file_orders
 tsz-checker::generic_call_assignment_flow_tests::imported_generic_result_narrows_inside_reduce_arrow
 tsz-checker::generic_generator_member_substitution_tests::generic_generator_genuine_mismatch_still_errors_with_substituted_source
-tsz-checker::import_type_ambient_module_member_tests::cross_file_import_type_member_still_works
 tsz-checker::import_type_utility_identity_tests::import_type_extends_structural_match_no_false_positive
-tsz-checker::import_type_utility_identity_tests::import_type_member_feeds_conditional_type
-tsz-checker::import_type_utility_identity_tests::nested_import_type_argument_feeds_conditional_type
 tsz-checker::issue_14123_repro_tests::issue_14123_alias_array_infer_reports_mismatch
 tsz-checker::js_export_surface_tests::part_01::test_current_file_exports_reads_use_prior_assignment_types
 tsz-checker::js_export_surface_tests::part_01::test_current_file_module_exports_reads_use_prior_assignment_types


### PR DESCRIPTION
## Goal
Goal: hold

## What

Three `known-failures.txt` rows in `crates/tsz-checker/tests/import_type_ambient_module_member_tests.rs` and `crates/tsz-checker/tests/import_type_utility_identity_tests.rs` were failing on main. All three share one root cause, and it is **not** a `tsc`-parity bug.

Structural rule: when a multi-file test fixture is built with `check_multi_file_with_libs`, each file's binder restarts `SymbolId` at 0 (per-file base-0 arenas). `CheckerState::get_or_create_def_id`/`get_or_create_def_id_for_symbol_name` are keyed by that raw `SymbolId` alone, with no file-index component in the cache key. When two *unrelated* declarations in the two fixture files happen to land on the same raw id (a near-certainty for small two-file fixtures — both binders start counting from 0), the `DefId` cache collapses them onto one canonical `DefId`. This is the pre-existing `#15983` collision family, already fixed once for the `kysely_callback_context_tests` rows (2026-08-06) by switching to `check_multi_file_with_libs_unique_module_locals`, which gives each file's module-local suffix a disjoint id range while keeping the shared lib-prefix ids intact.

Verified via the real `tsz` CLI binary (not just the unit harness) that production never hits this: the driver's bind-result reducer remaps every file into one globally-unique id space before checking starts, so the collision is purely a test-fixture-construction artifact, owned by the test infrastructure layer, not the checker/solver.

Fixed by switching both test files' fixture-building helper from `check_multi_file_with_libs` to `check_multi_file_with_libs_unique_module_locals`:
- `import_type_ambient_module_member_tests::cross_file_import_type_member_still_works` — `Thing`(module.ts) collided with `Member`(main.ts), so resolving `Member`'s alias body re-entered its own cross-arena alias-stack entry and `mark_cross_arena_alias_cycle` misreported a genuine TS2456 self-cycle instead of the expected TS2322.
- `import_type_utility_identity_tests::import_type_member_feeds_conditional_type`
- `import_type_utility_identity_tests::nested_import_type_argument_feeds_conditional_type`

`known-failures.txt` shrinks by three rows (removals need no generation bump per the file's own header).

## Left open

`import_type_utility_identity_tests::import_type_extends_structural_match_no_false_positive` stays in `known-failures.txt`. It reproduces the identical `boolean`-vs-`true` mismatch even after the helper swap, **and reproduces through the real `tsz` CLI binary** on a minimal fixture with a plain `import { Box } from "./module"` (no test-harness collision involved at all):

```ts
import { Box } from "./module";
type IsBox[T] = T extends Box ? true : false;
type Test1 = IsBox[import("./module").Box];
declare const t1: Test1;
const t1Check: true = t1; // tsz: TS2322 boolean vs true; tsc: clean
```
(square brackets stand in for angle brackets, which the GitHub API strips from PR bodies)

This is a genuine cross-file `import("mod").Member`-as-type-argument identity gap in conditional-type evaluation — filed as #17158 with the isolation matrix and owning-layer analysis, left for separate solver-level work.

## Verification
- `cargo test -p tsz-checker --test import_type_ambient_module_member_tests` — 11/11 pass (was 10/11).
- `cargo test -p tsz-checker --test import_type_utility_identity_tests` — 6/7 pass (was 4/7); the remaining failure is the real, now-isolated+filed bug (#17158), still correctly listed in `known-failures.txt`.
- `cargo clippy -p tsz-checker --test import_type_ambient_module_member_tests --test import_type_utility_identity_tests -- -D warnings` — clean.
- `cargo fmt -p tsz-checker -- --check` — clean.
- Test-only diff (`git diff --name-only` touches no `crates/**/src` path) plus one `scripts/ci/known-failures.txt` line-removal — no conformance/emit corpus gate is affected or owed.
- Pre-commit hook (clippy + arch-size + affected-crate tests) passed locally.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeDE
