### PR TITLE
fix(checker): publish inference-inert lib-generic interface heritage symmetrically with the consume gate

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/heritage_publication.rs
+++ b/crates/tsz-checker/src/state/type_resolution/heritage_publication.rs
@@ -24,14 +24,29 @@ impl<'a> CheckerState<'a> {
     /// evaluation caches when the body changes, so results computed before
     /// this registration cannot shadow it.
     ///
-    /// Scope: program-module files only (not ambient declaration files), and
-    /// only interfaces whose direct heritage bases all resolve to
-    /// program-file symbols. A lib base (`extends Response`,
-    /// `extends Omit<RequestInit, ..>`) already merges through the lib-aware
-    /// path on both sides; publishing those bodies additionally exposes a
-    /// pre-existing union-normalization defect (a resolver-less evaluator
-    /// mis-distributing still-generic conditionals, #13232) at relation
-    /// sites.
+    /// Scope: program-module files only (not ambient declaration files). The
+    /// heritage-merged body is published when *either* every direct heritage
+    /// base resolves to a program-file symbol, *or* the merged body is
+    /// inference-inert — it carries no conditional structure through alias
+    /// applications. The conditional-free relaxation lets an interface that
+    /// extends an inference-inert lib generic (`interface Registry<V> extends
+    /// Map<string, V>`) publish its inherited members, so an importing file
+    /// whose own arena-local lib-aware merge cannot resolve the lib base reads
+    /// the complete member set instead of a heritage-dropped body — the
+    /// conditional-free arm of #16308.
+    ///
+    /// The conditional-free guard is the same #13232-safety criterion the
+    /// consume side (`try_consume_published_heritage_body`) already applies, so
+    /// the two gates stay symmetric: a body an importer is allowed to consume
+    /// is one a declarer is allowed to publish. Publishing a body that carries
+    /// a conditional would instead expose a pre-existing union-normalization
+    /// defect (a resolver-less evaluator mis-distributing still-generic
+    /// conditionals, #13232) at relation sites, so those bodies stay
+    /// unpublished unless all bases are program symbols (already merged the
+    /// same way on both sides). A lib base whose own member set carries a
+    /// conditional — e.g. `Array<T>` via `flat`/`flatMap`'s `FlatArray<..>`
+    /// return — is therefore still excluded; that shape stays tracked by
+    /// #16308 (it also needs cross-arena def unification, #14345).
     pub(crate) fn publish_heritage_merged_interface_body(
         &mut self,
         def_id: tsz_solver::DefId,
@@ -46,7 +61,8 @@ impl<'a> CheckerState<'a> {
             && merged != interface_type
             && merged != TypeId::ERROR
             && merged != TypeId::UNKNOWN
-            && self.local_interface_heritage_bases_are_program_symbols(declarations)
+            && (self.local_interface_heritage_bases_are_program_symbols(declarations)
+                || !self.body_feeds_conditional_inference(merged))
             && self.ctx.definition_store.get_body(def_id) != Some(merged)
         {
             self.ctx
@@ -124,16 +140,8 @@ impl<'a> CheckerState<'a> {
         // (`interface D<T> extends Base<T>` with a method on `Base`). Detect the
         // conditional *through* alias applications, since the standard content
         // walk treats an applied alias base as an opaque leaf.
-        let published_feeds_conditional_inference = {
-            let db = self.ctx.types.as_type_database();
-            let def_store = &self.ctx.definition_store;
-            let mut resolve_lazy = |d: tsz_solver::DefId| def_store.get_body(d);
-            type_resolution_query::contains_conditional_through_aliases(
-                db,
-                published,
-                &mut resolve_lazy,
-            )
-        };
+        let published_feeds_conditional_inference =
+            self.body_feeds_conditional_inference(published);
         if published == TypeId::ERROR
             || published == TypeId::UNKNOWN
             || published == merged
@@ -165,6 +173,21 @@ impl<'a> CheckerState<'a> {
             "consumed published heritage body"
         );
         Some((published, owner_params))
+    }
+
+    /// Whether `body` carries a conditional type reachable through alias
+    /// applications. Such bodies feed the pre-existing resolver-less
+    /// union-normalization defect (#13232) when they participate in
+    /// contextual-inference/relation sites, so both the heritage publish gate
+    /// and the heritage consume gate refuse them: publishing keeps them out of
+    /// the shared `DefinitionStore`, consuming keeps an importing file from
+    /// reading one. Inference-inert bodies (a method-bearing generic interface
+    /// with no conditional in its signatures) are safe on both sides.
+    pub(crate) fn body_feeds_conditional_inference(&self, body: TypeId) -> bool {
+        let db = self.ctx.types.as_type_database();
+        let def_store = &self.ctx.definition_store;
+        let mut resolve_lazy = |d: tsz_solver::DefId| def_store.get_body(d);
+        type_resolution_query::contains_conditional_through_aliases(db, body, &mut resolve_lazy)
     }
 
     /// Whether `published` (a candidate definition body from the shared

--- a/crates/tsz-checker/tests/cross_file_lib_generic_heritage_tests.rs
+++ b/crates/tsz-checker/tests/cross_file_lib_generic_heritage_tests.rs
@@ -355,3 +355,101 @@ const n: number = b.unwrap();
          external-module lib generic `Boxed<T>`; got {offending:#?}"
     );
 }
+
+/// An interface that extends a *lib* generic (`Map<K, V>`), declared in one
+/// file and consumed from another, must expose every inherited lib member at
+/// the cross-file use site. `Map`'s member set is inference-inert (no
+/// conditional in any signature), so the declaring file's heritage-merged body
+/// is eligible for the shared `DefinitionStore` under the publish gate's
+/// inference-inert branch — the same #13232-safety criterion the consume gate
+/// applies. This keeps the publish and consume gates symmetric: a body a
+/// consumer would accept is one a declarer is allowed to publish.
+///
+/// Regression guard for the conditional-free arm of the #16308 family. (The
+/// `extends Array<T>` shape from the mobx row stays open under #16308 itself:
+/// `Array`'s body carries the `FlatArray` conditional through `flat`/`flatMap`,
+/// so both gates correctly refuse it and the inherited members are dropped
+/// through the deep cross-arena delegation path — a distinct blocker.)
+#[test]
+fn cross_file_interface_extends_lib_map_keeps_inherited_members() {
+    let diags = check(
+        &[
+            (
+                "decl.ts",
+                r#"
+export interface Registry<V> extends Map<string, V> {
+    describe(): string;
+}
+"#,
+            ),
+            (
+                "use.ts",
+                r#"
+import { Registry } from "./decl";
+declare const r: Registry<number>;
+const n: number | undefined = r.get("k");
+r.set("k", 1);
+const size: number = r.size;
+const own: string = r.describe();
+"#,
+            ),
+        ],
+        "use.ts",
+        ts_options(),
+    );
+    let offending: Vec<(u32, String)> = diags
+        .iter()
+        .filter(|d| d.code == 2339)
+        .map(|d| (d.code, d.message_text.clone()))
+        .collect();
+    assert!(
+        offending.is_empty(),
+        "inherited `Map` members (`get`/`set`/`size`) and the interface's own \
+         `describe` must all resolve on `Registry<V> extends Map<string, V>` \
+         across files; got {offending:#?}"
+    );
+}
+
+/// Renamed-binder twin of the `Map` case (different interface/param/member
+/// names, a `Set` base) so the rule cannot be keyed to any identifier or to
+/// `Map` specifically — it is about inference-inert lib-generic heritage
+/// surviving cross-file, whatever the names are.
+#[test]
+fn cross_file_interface_extends_lib_set_keeps_inherited_members_renamed() {
+    let diags = check(
+        &[
+            (
+                "shapes.ts",
+                r#"
+export interface Bucket<E> extends Set<E> {
+    tag(): number;
+}
+"#,
+            ),
+            (
+                "consume.ts",
+                r#"
+import { Bucket } from "./shapes";
+declare const b: Bucket<string>;
+const present: boolean = b.has("x");
+b.add("y");
+const count: number = b.size;
+const t: number = b.tag();
+"#,
+            ),
+        ],
+        "consume.ts",
+        ts_options(),
+    );
+    let offending: Vec<(u32, String)> = diags
+        .iter()
+        .filter(|d| d.code == 2339)
+        .map(|d| (d.code, d.message_text.clone()))
+        .collect();
+    assert!(
+        offending.is_empty(),
+        "inherited `Set` members (`has`/`add`/`size`) and the interface's own \
+         `tag` must all resolve on `Bucket<E> extends Set<E>` across files; \
+         got {offending:#?}"
+    );
+}


### PR DESCRIPTION
## Summary

Structural rule: when an interface's `extends` base is declared outside a consuming file's arena, that file's arena-local lib-aware heritage merge cannot supply the base, so the declaring file must publish the heritage-merged body to the shared `DefinitionStore` for the consumer to read inherited members through. `tsc` keeps every inherited member visible; tsz drops them when publication is refused — owned by the checker heritage publish/consume gates (`state/type_resolution/heritage_publication.rs`).

The **publish** gate registered a heritage-merged body only when *every* direct `extends` base resolved to a program-file symbol — a blunt proxy that dropped **all** lib-base bodies to avoid the pre-existing #13232 defect (a resolver-less evaluator mis-distributing still-generic conditionals at relation sites). The **consume** gate already used a *precise* criterion for the same defect: it refuses a body only when the body carries a conditional reachable through alias applications (`contains_conditional_through_aliases`).

This PR makes the two gates symmetric:

- Extracts the shared `body_feeds_conditional_inference` helper (deduping the inline computation the consume gate already had).
- Widens the publish gate to `all bases are program symbols **OR** the merged body is inference-inert`.

Net effect: an interface that extends an **inference-inert** lib generic (`interface Registry<V> extends Map<string, V>`) now publishes its inherited members for cross-arena consumers, while conditional-bearing lib bases stay excluded — exactly the bodies the consume side would refuse. A body an importer may consume is now one a declarer may publish.

## Scope / what this does not do

This advances the **conditional-free arm** of #16308. It does **not** close the mobx `IObservableArray<T> extends Array<T>` row. Measured on the pinned mobx fixture (`2a069e41`), the declaring file computes the complete `Array`-merged body but that body is **conditional-bearing**: `Array`'s member set carries the `FlatArray<..>` conditional through `flat`/`flatMap`, so both gates correctly exclude it (`cond=true`). That shape stays tracked by #16308 and additionally needs cross-arena def unification (#14345). Full measurements are posted as a findings comment on #16308.

## Goal
Goal: green

## Verification
- `cargo test -p tsz-checker --test cross_file_lib_generic_heritage_tests` — 9/9 pass, including two new renamed-binder regression cases (`... extends Map<string, V>`, `... extends Set<E>`) asserting inherited lib members + own members resolve cross-file, plus the existing negative case.
- `cargo test -p tsz-checker --lib` — 11000+ tests, 0 failures (run stopped before an unrelated recursion-heavy `ts2589` type-alias test that the change cannot touch — the publish gate fires only on the interface branch).
- `cargo clippy -p tsz-checker --lib` — clean.
- mobx fixture measured: `IObservableArray` family unchanged at 10 `TS2339` (documented above; #13232-safe by construction).
- Conformance / emit / fourslash: deferred to CI's nightly lane — the TypeScript corpus and emit baselines are not checked out locally. Kept as **draft** until CI validates the heritage behavior change.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bu6a7gEyGctc5612QE77AC)_