### PR TITLE
fix(checker): unify class-decorator TS1238 signature resolution + TS6210/TS6236 missing-argument pointer

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -597,6 +597,9 @@ path = "tests/parameter_initializer_identifier_context_tests.rs"
 name = "decorator_method_tdz_tests"
 path = "tests/decorator_method_tdz_tests.rs"
 [[test]]
+name = "ts1238_class_decorator_signature_tests"
+path = "tests/ts1238_class_decorator_signature_tests.rs"
+[[test]]
 name = "ts1238_generic_decorator_tests"
 path = "tests/ts1238_generic_decorator_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking/class.rs
+++ b/crates/tsz-checker/src/state/state_checking/class.rs
@@ -257,11 +257,17 @@ impl<'a> CheckerState<'a> {
         // TS1042: async modifier cannot be used on class declarations
         self.check_async_modifier_on_declaration(&class.modifiers);
 
-        let mut experimental_class_decorators = Vec::new();
+        let mut class_decorators = Vec::new();
 
         // Evaluate class-level decorator expressions to trigger definite-assignment
         // checks (TS2454) and other diagnostics. tsc evaluates decorator expressions
         // even if the class has other errors.
+        //
+        // The TS1238 call-signature validation itself is deferred until after the
+        // class value side has been refreshed below: it needs the class
+        // constructor type (both the legacy `decorator(classConstructor)` call and
+        // the ES `ClassDecoratorContext<typeof C>` context argument), and doing it
+        // here can see a provisional/re-entrant constructor shape and miss TS1238.
         if let Some(ref modifiers) = class.modifiers {
             for &mod_idx in &modifiers.nodes {
                 if let Some(mod_node) = self.ctx.arena.get(mod_idx)
@@ -272,24 +278,7 @@ impl<'a> CheckerState<'a> {
                     self.check_grammar_decorator(decorator.expression);
 
                     let decorator_type = self.compute_type_of_node(decorator.expression);
-
-                    // TS1238: Validate class decorator call signature.
-                    if self.ctx.compiler_options.experimental_decorators {
-                        // Experimental class decorators receive the class constructor
-                        // value. Save the expression type and validate it after the
-                        // class value side has been refreshed; doing it here can see a
-                        // provisional/re-entrant constructor shape and miss TS1238.
-                        experimental_class_decorators.push((mod_idx, decorator_type));
-                    } else {
-                        // ES decorators: tsc anchors TS1238 at the whole decorator
-                        // (including `@`) when the factory requires too many args, but
-                        // at the expression alone when the factory has zero parameters.
-                        self.check_es_class_decorator_arity(
-                            mod_idx,
-                            decorator.expression,
-                            decorator_type,
-                        );
-                    }
+                    class_decorators.push((mod_idx, decorator.expression, decorator_type));
                 }
             }
         }
@@ -1008,17 +997,18 @@ impl<'a> CheckerState<'a> {
             let _ = self.get_type_of_symbol(sym_id);
         }
 
-        for (decorator_node, decorator_type) in experimental_class_decorators {
-            // Anchor selection (bare identifier vs. call-expression decorator
-            // does NOT matter; tsc anchors both the same way) lives in
-            // `check_class_decorator_call_signature` itself, mirroring the
-            // `decorator_failure_anchor` rule the member/parameter decorator
-            // paths already use.
-            self.check_class_decorator_call_signature(
+        let legacy = self.ctx.compiler_options.experimental_decorators;
+        for (decorator_node, decorator_expr, decorator_type) in class_decorators {
+            // TS1238: validate the class decorator call signature. The anchor
+            // (expression vs. whole decorator) is chosen per failure kind
+            // inside the handler, mirroring tsc's call-node arity anchoring.
+            self.check_class_decorator_signature(
                 decorator_node,
+                decorator_expr,
                 decorator_type,
                 stmt_idx,
                 class,
+                legacy,
             );
         }
     }

--- a/crates/tsz-checker/src/state/state_checking/class_decorators.rs
+++ b/crates/tsz-checker/src/state/state_checking/class_decorators.rs
@@ -2,14 +2,14 @@
 //! accessor-pair decorator rules, ES decorator call-signature/arity checks, and
 //! the decorator grammar check.
 //!
-//! Extracted verbatim from `class.rs` to keep that module under the 2000-LOC
-//! architecture cap; behavior is unchanged. The four helpers called from the
-//! class-declaration/expression paths in `class.rs`
-//! (`first_decorator_in_modifiers`, `check_decorators_on_accessor_pairs`,
-//! `check_class_decorator_call_signature`, `check_es_class_decorator_arity`)
+//! Extracted from `class.rs` to keep that module under the 2000-LOC
+//! architecture cap. The helpers called from the class-declaration path in
+//! `class.rs` (`first_decorator_in_modifiers`,
+//! `check_decorators_on_accessor_pairs`, `check_class_decorator_signature`)
 //! are `pub(super)` so those sibling-module callers keep reaching them; their
 //! visibility was widened only to permit the file split.
 
+use crate::query_boundaries::checkers::decorators as decorator_query;
 use crate::query_boundaries::class_type as class_query;
 use crate::state::CheckerState;
 use rustc_hash::FxHashMap;
@@ -197,26 +197,46 @@ impl<'a> CheckerState<'a> {
         })
     }
 
-    /// TS1238: Check that a class decorator expression has a compatible call signature.
+    /// TS1238: check that a class decorator resolves as a call
+    /// `decorator(value[, context])`, emitting "Unable to resolve signature of
+    /// class decorator when called as an expression." with tsc's full
+    /// elaboration chain on failure.
     ///
-    /// For experimental decorators, the decorator is called as `decoratorExpr(classConstructor)`.
-    /// If the decorator type has no call signatures, or if call resolution against the class
-    /// constructor type fails, emit TS1238.
-    pub(super) fn check_class_decorator_call_signature(
+    /// This is the single owner for both decorator modes:
+    ///
+    /// - **`--experimentalDecorators` (legacy):** the decorator is invoked
+    ///   `decorator(classConstructor)`, and the resolved return type is
+    ///   additionally checked against `void | typeof C` (TS1270).
+    /// - **ES (TC39 stage-3):** the decorator is invoked
+    ///   `decorator(value, context)` where `value: typeof C` and
+    ///   `context: ClassDecoratorContext<typeof C>`, truncated to the
+    ///   decorator's own declared arity (tsc's `getDecoratorArgumentCount`).
+    ///
+    /// A bare-reference zero-argument factory used uncalled (`@d`, `@ns.d`)
+    /// draws the TS1329 "did you mean to call it first" hint; a
+    /// parenthesized/inline factory (`@(() => {})`) instead falls through to
+    /// the arity failure below, matching tsc's `isPotentiallyUncalledDecorator`.
+    /// A callee with no call signatures at all (a non-function value, or a
+    /// class with only construct signatures) reports the not-callable chain
+    /// directly, exactly as tsc's `resolveDecorator` does before it ever
+    /// reaches `resolveCall`.
+    pub(super) fn check_class_decorator_signature(
         &mut self,
         decorator_node: NodeIndex,
+        decorator_expression: NodeIndex,
         decorator_type: TypeId,
         class_idx: NodeIndex,
         class: &tsz_parser::parser::node::ClassData,
+        legacy: bool,
     ) {
-        use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
-        use crate::query_boundaries::common::call_signatures_for_type;
+        use crate::query_boundaries::common::{CallResult, call_signatures_for_type};
 
-        // Skip validation for error types or any — these won't produce meaningful diagnostics
-        if decorator_type == TypeId::ERROR
-            || decorator_type == TypeId::ANY
-            || decorator_type == TypeId::UNKNOWN
-        {
+        // Skip validation for error/any/unknown — these won't produce
+        // meaningful diagnostics.
+        if matches!(
+            decorator_type,
+            TypeId::ERROR | TypeId::ANY | TypeId::UNKNOWN
+        ) {
             return;
         }
 
@@ -224,9 +244,7 @@ impl<'a> CheckerState<'a> {
         // type queries can see the underlying type shape.
         self.ensure_relation_input_ready(decorator_type);
         let resolved = self.evaluate_type_for_assignability(decorator_type);
-
-        // After evaluation, any/unknown/error → skip
-        if resolved == TypeId::ERROR || resolved == TypeId::ANY || resolved == TypeId::UNKNOWN {
+        if matches!(resolved, TypeId::ERROR | TypeId::ANY | TypeId::UNKNOWN) {
             return;
         }
 
@@ -238,69 +256,106 @@ impl<'a> CheckerState<'a> {
             return;
         };
 
-        // A decorator whose every call signature takes zero parameters is
-        // the "forgot to call the factory" shape (`@d` instead of `@d()`);
-        // tsc reports only the TS1329 hint there, not TS1238 — mirroring the
-        // member/parameter decorator paths in `decorator_signature_checks.rs`.
-        let decorator_expr = self.decorator_expression_anchor(decorator_node);
-        if self.decorator_has_zero_arg_factory_shape(decorator_expr, resolved, decorator_node) {
+        // TS1329: a bare-reference zero-argument factory used without its
+        // call. Parenthesized/inline factories are excluded and fall through
+        // to the arity/signature failure below.
+        if self.decorator_expression_is_reference(decorator_expression)
+            && self.decorator_has_zero_arg_factory_shape(
+                decorator_expression,
+                resolved,
+                decorator_node,
+            )
+        {
             return;
         }
 
-        // Check if the decorator type is callable.
-        // TypeData::Function has a single call signature (function declarations/expressions).
-        // TypeData::Callable has overloaded call/construct signatures (interfaces).
+        // No call signatures at all (a non-function value, or a class used as
+        // a decorator — construct signatures but no call signatures). tsc
+        // reports the not-callable chain directly from `resolveDecorator`,
+        // before it ever reaches `resolveCall`, and anchors it at the
+        // decorator expression.
         let has_call_signatures = class_query::has_function_shape(self.ctx.types, resolved)
             || call_signatures_for_type(self.ctx.types, resolved)
                 .is_some_and(|sigs| !sigs.is_empty());
-
         if !has_call_signatures {
-            // No call signatures at all (e.g., a class used as decorator — has construct
-            // signatures but no call signatures, or a bare primitive). tsc attaches the
-            // "This expression is not callable." / "Type 'X' has no call signatures."
-            // chain beneath TS1238 (oracle-verified, typescript@7.0.2).
-            let anchor = self.decorator_failure_anchor(decorator_node, resolved, 1);
-            self.emit_class_decorator_not_callable(anchor, resolved);
+            self.emit_class_decorator_not_callable(
+                self.decorator_expression_anchor(decorator_node),
+                resolved,
+            );
             return;
         }
 
-        // Has call signatures — try to resolve the call with the class constructor type.
-        // resolve_call handles both Function and Callable types internally.
-        // If resolution fails (type mismatch, arity error), emit TS1238.
         let class_constructor_type = self.get_class_constructor_type(class_idx, class);
         if class_constructor_type == TypeId::ERROR {
             return;
         }
 
-        let (result, _, _) = self.resolve_call_with_checker_adapter(
-            resolved,
-            &[class_constructor_type],
-            false,
-            None,
-            None,
-        );
+        let args = self.class_decorator_argument_types(resolved, class_constructor_type, legacy);
+        let (result, _, _) =
+            self.resolve_call_with_checker_adapter(resolved, &args, false, None, None);
 
-        let crate::query_boundaries::common::CallResult::Success(return_type) = &result else {
-            let anchor = self.decorator_failure_anchor(decorator_node, resolved, 1);
-            self.emit_decorator_signature_error(
-                anchor,
-                diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
-                diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
-                &result,
-            );
+        let CallResult::Success(return_type) = &result else {
+            self.emit_class_decorator_signature_error(decorator_node, &result, resolved);
             return;
         };
 
-        let return_type = self.evaluate_type_for_assignability(*return_type);
+        if legacy {
+            self.check_legacy_class_decorator_return_type(
+                decorator_node,
+                class_constructor_type,
+                *return_type,
+            );
+        }
+    }
+
+    /// The runtime argument list a class decorator is invoked with:
+    /// `[classConstructor]` under `--experimentalDecorators`, or the ES
+    /// `[value, ClassDecoratorContext<typeof C>]` truncated to the decorator's
+    /// own declared arity (tsc's `getDecoratorArgumentCount`, so a
+    /// single-parameter ES decorator receives only `value`).
+    fn class_decorator_argument_types(
+        &mut self,
+        resolved: TypeId,
+        class_constructor_type: TypeId,
+        legacy: bool,
+    ) -> Vec<TypeId> {
+        if legacy {
+            return vec![class_constructor_type];
+        }
+        // A single-parameter ES decorator receives only `value`, so skip the
+        // `ClassDecoratorContext<typeof C>` lib lookup entirely when the
+        // context argument would be truncated away.
+        if self.es_member_decorator_argument_count(resolved) <= 1 {
+            return vec![class_constructor_type];
+        }
+        let context = self
+            .resolve_decorator_context_type("ClassDecoratorContext", vec![class_constructor_type])
+            .unwrap_or(TypeId::OBJECT);
+        vec![class_constructor_type, context]
+    }
+
+    /// TS1270 for legacy class decorators: the resolved return type must be
+    /// assignable to `void | typeof C`. `any`/`unknown`/error short-circuit.
+    fn check_legacy_class_decorator_return_type(
+        &mut self,
+        decorator_node: NodeIndex,
+        class_constructor_type: TypeId,
+        return_type: TypeId,
+    ) {
+        use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+
+        let return_type = self.evaluate_type_for_assignability(return_type);
         if matches!(return_type, TypeId::ERROR | TypeId::ANY | TypeId::UNKNOWN) {
             return;
         }
 
-        let expected_return = self
-            .ctx
-            .types
-            .factory()
-            .union2(TypeId::VOID, class_constructor_type);
+        // The legacy class decorator may return `void` or a replacement
+        // constructor (`typeof C`); reuse the shared `void | replacement`
+        // builder rather than open-coding the union.
+        let expected_return = decorator_query::decorator_void_or_replacement_type(
+            self.ctx.types,
+            class_constructor_type,
+        );
         if !self
             .return_relation_outcome(return_type, expected_return)
             .related
@@ -311,115 +366,16 @@ impl<'a> CheckerState<'a> {
                 diagnostic_messages::DECORATOR_FUNCTION_RETURN_TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                 &[&return_str, &expected_str],
             );
-            let anchor = self.decorator_failure_anchor(decorator_node, resolved, 1);
+            // The call itself resolved successfully (only the return type is
+            // wrong), so this is never a "too few arguments" shape; tsc
+            // anchors at the decorator expression, not the whole `@decorator`
+            // span (oracle-verified, see
+            // `ts1238_experimental_decorator_anchor_tests`).
             self.error_at_node(
-                anchor,
+                self.decorator_expression_anchor(decorator_node),
                 &message,
                 diagnostic_codes::DECORATOR_FUNCTION_RETURN_TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
             );
-        }
-    }
-
-    /// TS1238/TS1329 for ES decorators: check that a class decorator's arity
-    /// is compatible with the runtime call.
-    ///
-    /// ES decorators receive `(value, context)` — at most 2 arguments. A
-    /// zero-parameter decorator is the "forgot to call the factory" shape
-    /// (TS1329, see `decorator_has_zero_arg_factory_shape`); one requiring
-    /// more than 2 required parameters can never be satisfied (TS1238).
-    pub(super) fn check_es_class_decorator_arity(
-        &mut self,
-        decorator_node: NodeIndex,
-        decorator_expression: NodeIndex,
-        decorator_type: TypeId,
-    ) {
-        use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-
-        if decorator_type == TypeId::ERROR
-            || decorator_type == TypeId::ANY
-            || decorator_type == TypeId::UNKNOWN
-        {
-            return;
-        }
-
-        let resolved = self.evaluate_type_for_assignability(decorator_type);
-        if resolved == TypeId::ERROR || resolved == TypeId::ANY || resolved == TypeId::UNKNOWN {
-            return;
-        }
-
-        // Mirror tsc's `isUntypedFunctionCall`: a decorator typed as the
-        // global `Function` interface has no explicit call signatures but is
-        // still callable (see `check_class_decorator_call_signature`, whose
-        // legacy-mode counterpart of this same check applies the identical
-        // fallback).
-        let Some(resolved) = self.prepare_decorator_callee(resolved) else {
-            return;
-        };
-
-        // A decorator whose every call signature takes zero parameters is
-        // the "forgot to call the factory" shape (`@d` instead of `@d()`);
-        // tsc reports only the TS1329 hint there, not TS1238 — same rule as
-        // the legacy (`experimentalDecorators`) class-decorator path above.
-        // A type with no call signature at all (the not-callable case just
-        // below) has no signatures to inspect here, so this is a no-op for
-        // it and falls through correctly. `decorator_has_zero_arg_factory_shape`
-        // itself also declines (returns `false`) for a parenthesized decorator
-        // expression (`@(() => {})`), since tsc keeps the generic TS1238 arity
-        // failure there instead — that shape falls through to the
-        // `required_params == 0` arm below.
-        if self.decorator_has_zero_arg_factory_shape(decorator_expression, resolved, decorator_node)
-        {
-            return;
-        }
-
-        // No call signature at all (bare primitive, a class used as a
-        // decorator, ...): tsc's TS1238 "not callable" chain fires
-        // identically here as it does under `--experimentalDecorators`
-        // (oracle-verified, typescript@7.0.2). Previously this whole
-        // function only inspected `function_shape`, so any decorator type
-        // without a single-signature function shape (a primitive, a class,
-        // an overloaded callable) silently passed arity validation with no
-        // diagnostic at all.
-        let has_call_signatures =
-            crate::query_boundaries::class_type::has_function_shape(self.ctx.types, resolved)
-                || crate::query_boundaries::common::call_signatures_for_type(
-                    self.ctx.types,
-                    resolved,
-                )
-                .is_some_and(|sigs| !sigs.is_empty());
-        if !has_call_signatures {
-            self.emit_class_decorator_not_callable(decorator_expression, resolved);
-            return;
-        }
-
-        // Check the function shape for required parameter count
-        if let Some(shape) =
-            crate::query_boundaries::class_type::function_shape(self.ctx.types, resolved)
-        {
-            let required_params = shape
-                .params
-                .iter()
-                .filter(|p| !p.optional && !p.rest)
-                .count();
-            // ES decorators are invoked with `(value, context)`. When the
-            // factory requires more than two parameters, the call cannot
-            // supply them; tsc anchors that "too few arguments" failure at
-            // the whole decorator (including `@`) — same convention as the
-            // shared `decorator_failure_anchor` helper the legacy class- and
-            // member-decorator paths use. Zero required params is normally
-            // the TS1329 decorator-factory hint above, but a parenthesized
-            // expression opts out of that hint and still needs the arity
-            // failure here; since 0 declared params is never "too few" for
-            // a 2-argument call, that case anchors at the decorator
-            // expression instead (oracle-verified, typescript@7.0.2).
-            if required_params > 2 || required_params == 0 {
-                let anchor = self.decorator_failure_anchor(decorator_node, resolved, 2);
-                self.error_at_node(
-                    anchor,
-                    diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
-                    diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
-                );
-            }
         }
     }
 

--- a/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/decorator_signature_checks.rs
@@ -3,6 +3,7 @@
 use crate::diagnostics::{
     Diagnostic, DiagnosticRelatedInformation, diagnostic_codes, diagnostic_messages, format_message,
 };
+use crate::error_reporter::DiagnosticAnchorKind;
 use crate::query_boundaries::checkers::decorators as decorator_query;
 use crate::query_boundaries::common::CallResult;
 use crate::state::CheckerState;
@@ -35,8 +36,13 @@ impl<'a> CheckerState<'a> {
     /// trailing `...rest: any[]`) and too few arguments were supplied; a
     /// fixed-length rest tuple (`...rest: [string, number]`) still has a
     /// concrete `expected_max` and takes the exact-N wording (TS1278).
+    ///
+    /// When the failure is *too few* arguments, a second cross-location
+    /// pointer is attached at the first parameter the runtime cannot supply
+    /// (see [`Self::decorator_missing_argument_pointer`]).
     fn decorator_arity_related_info(
         &self,
+        decorator_node: NodeIndex,
         result: &CallResult,
     ) -> Vec<DiagnosticRelatedInformation> {
         let &CallResult::ArgumentCountMismatch {
@@ -63,26 +69,189 @@ impl<'a> CheckerState<'a> {
                 )
         };
         let expected_str = expected.to_string();
-        vec![Diagnostic::related_message(
+        let mut related = vec![Diagnostic::related_message(
             code,
             self.ctx.file_name.clone(),
             0,
             0,
             format_message(message_template, &[&expected_str, &actual_str]),
-        )]
+        )];
+        // Only a *too-few-arguments* failure attaches the "argument not
+        // provided" pointer; a "too many" failure supplies every declared
+        // parameter, so tsc adds no second line there.
+        if actual < expected_min
+            && let Some(pointer) = self.decorator_missing_argument_pointer(decorator_node, actual)
+        {
+            related.push(pointer);
+        }
+        related
     }
 
-    /// Emit a decorator signature-resolution error, attaching
-    /// [`Self::decorator_arity_related_info`] when `result` is an
-    /// argument-count mismatch.
-    pub(crate) fn emit_decorator_signature_error(
+    /// Cross-location pointer (`tsc`'s `relatedInformation`) beneath the
+    /// decorator signature-resolution error, anchored at the first declared
+    /// parameter the runtime invocation cannot supply.
+    ///
+    /// Mirrors tsc's `getArgumentArityError`, which — after the primary
+    /// TS1238/1239/1240/1241 and its TS1278/TS1279 elaboration — attaches a
+    /// pointer at `parameters[argCount]` (the first position the fixed decorator
+    /// calling convention leaves unfilled):
+    /// - TS6210 `An argument for '{0}' was not provided.` for an ordinary
+    ///   named parameter,
+    /// - TS6236 `Arguments for the rest parameter '{0}' were not provided.`
+    ///   when that parameter is variadic,
+    /// - TS6211 `An argument matching this binding pattern was not provided.`
+    ///   when it is a destructured (binding-pattern) parameter.
+    ///
+    /// Returns `None` when the decorator does not reference a single locatable
+    /// function-like declaration (an overloaded, imported, factory-call, or
+    /// property-access decorator): tsc anchors at the resolved signature's
+    /// declaration there, but without a unique local one the exact anchor
+    /// cannot be reproduced, so no pointer is attached rather than a wrong one.
+    fn decorator_missing_argument_pointer(
+        &self,
+        decorator_node: NodeIndex,
+        actual: usize,
+    ) -> Option<DiagnosticRelatedInformation> {
+        let params = self.decorator_declaration_value_parameter_nodes(decorator_node)?;
+        let param_idx = *params.get(actual)?;
+        let param_node = self.ctx.arena.get(param_idx)?;
+        let param = self.ctx.arena.get_parameter(param_node)?;
+        let anchor = self.resolve_diagnostic_anchor(param_idx, DiagnosticAnchorKind::Exact)?;
+
+        let name_node = self.ctx.arena.get(param.name);
+        let name_ident = name_node.and_then(|n| self.ctx.arena.get_identifier(n));
+        let (code, message) = if param.dot_dot_dot_token {
+            let name = name_ident?.escaped_text.to_string();
+            (
+                diagnostic_codes::ARGUMENTS_FOR_THE_REST_PARAMETER_WERE_NOT_PROVIDED,
+                format_message(
+                    diagnostic_messages::ARGUMENTS_FOR_THE_REST_PARAMETER_WERE_NOT_PROVIDED,
+                    &[&name],
+                ),
+            )
+        } else if let Some(ident) = name_ident {
+            let name = ident.escaped_text.to_string();
+            (
+                diagnostic_codes::AN_ARGUMENT_FOR_WAS_NOT_PROVIDED,
+                format_message(
+                    diagnostic_messages::AN_ARGUMENT_FOR_WAS_NOT_PROVIDED,
+                    &[&name],
+                ),
+            )
+        } else {
+            // A destructured parameter has no single name to quote.
+            (
+                diagnostic_codes::AN_ARGUMENT_MATCHING_THIS_BINDING_PATTERN_WAS_NOT_PROVIDED,
+                diagnostic_messages::AN_ARGUMENT_MATCHING_THIS_BINDING_PATTERN_WAS_NOT_PROVIDED
+                    .to_string(),
+            )
+        };
+        Some(Diagnostic::related_pointer(
+            code,
+            self.ctx.file_name.clone(),
+            anchor.start,
+            anchor.length,
+            message,
+        ))
+    }
+
+    /// The value-parameter declaration nodes (any leading explicit `this`
+    /// parameter removed, so the list is indexed the way the runtime supplies
+    /// value arguments) of the single function-like declaration a decorator
+    /// expression references, or `None` when the decorator is not a bare
+    /// `@name` bound to exactly one locatable function-like declaration.
+    fn decorator_declaration_value_parameter_nodes(
+        &self,
+        decorator_node: NodeIndex,
+    ) -> Option<Vec<NodeIndex>> {
+        let ident = self.decorator_callee_reference_identifier(decorator_node)?;
+        let sym_id = self.resolve_identifier_symbol_without_tracking(ident)?;
+        let decls = self.ctx.binder.get_symbol(sym_id)?.declarations.clone();
+        let mut found: Option<Vec<NodeIndex>> = None;
+        for decl in decls {
+            if let Some(params) = self.function_like_value_parameter_nodes(decl) {
+                if found.is_some() {
+                    // Overloaded / multiply-declared: the resolved signature is
+                    // ambiguous from the node alone, so decline rather than guess.
+                    return None;
+                }
+                found = Some(params);
+            }
+        }
+        found
+    }
+
+    /// Parameter declaration nodes of a function-like declaration — a function,
+    /// function expression, arrow, or method, or a variable initialized with
+    /// one — with any leading explicit `this` parameter removed.
+    fn function_like_value_parameter_nodes(&self, decl: NodeIndex) -> Option<Vec<NodeIndex>> {
+        let node = self.ctx.arena.get(decl)?;
+        let params = match node.kind {
+            k if k == syntax_kind_ext::FUNCTION_DECLARATION
+                || k == syntax_kind_ext::FUNCTION_EXPRESSION
+                || k == syntax_kind_ext::ARROW_FUNCTION =>
+            {
+                &self.ctx.arena.get_function(node)?.parameters
+            }
+            k if k == syntax_kind_ext::METHOD_DECLARATION => {
+                &self.ctx.arena.get_method_decl(node)?.parameters
+            }
+            k if k == syntax_kind_ext::VARIABLE_DECLARATION => {
+                let init = self.ctx.arena.get_variable_declaration(node)?.initializer;
+                if init.is_none() {
+                    return None;
+                }
+                return self.function_like_value_parameter_nodes(init);
+            }
+            _ => return None,
+        };
+        Some(
+            params
+                .nodes
+                .iter()
+                .copied()
+                .filter(|&p| !self.parameter_is_this(p))
+                .collect(),
+        )
+    }
+
+    /// Whether a parameter declaration is an explicit `this: T` parameter,
+    /// which tsc excludes from the value-argument positions. The `this` name
+    /// parses as a `ThisKeyword` (not an ordinary identifier), so this defers
+    /// to the shared [`Self::is_this_parameter_name`] check.
+    fn parameter_is_this(&self, param_idx: NodeIndex) -> bool {
+        self.ctx
+            .arena
+            .get(param_idx)
+            .and_then(|n| self.ctx.arena.get_parameter(n))
+            .is_some_and(|p| self.is_this_parameter_name(p.name))
+    }
+
+    /// The identifier a decorator expression directly references, for a bare
+    /// `@name` (optionally parenthesized). Property-access (`@ns.dec`),
+    /// factory-call (`@make()`), and other forms return `None`.
+    fn decorator_callee_reference_identifier(
+        &self,
+        decorator_node: NodeIndex,
+    ) -> Option<NodeIndex> {
+        let node = self.ctx.arena.get(decorator_node)?;
+        let expr = self.ctx.arena.get_decorator(node)?.expression;
+        let expr = self.ctx.arena.skip_parenthesized(expr);
+        let expr_node = self.ctx.arena.get(expr)?;
+        (expr_node.kind == tsz_scanner::SyntaxKind::Identifier as u16).then_some(expr)
+    }
+
+    /// Emit `message`/`code` at `anchor`, attaching `related` as an
+    /// elaboration chain only when it is non-empty. Centralizes the
+    /// "diagnostic with optional related information" branch shared by every
+    /// decorator signature-error emitter.
+    fn error_at_node_maybe_related(
         &mut self,
         anchor: NodeIndex,
         message: &str,
         code: u32,
-        result: &CallResult,
+        related: Vec<DiagnosticRelatedInformation>,
     ) {
-        let related = self.decorator_arity_related_info(result);
         if related.is_empty() {
             self.error_at_node(anchor, message, code);
         } else {
@@ -90,23 +259,39 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    /// tsc's TS1238 "not callable" shape for a class decorator whose resolved
-    /// type carries no call signature at all — a bare primitive, a class
-    /// (construct signatures only, no call signatures), or any other
-    /// non-callable value. `This expression is not callable.` (TS2349) is
-    /// attached as an elaboration chain link beneath TS1238, with `Type 'X'
-    /// has no call signatures.` (TS2757) nested one level deeper. Oracle-
-    /// verified (`typescript@7.0.2`) to render identically under
-    /// `--experimentalDecorators` and ES (TC39 stage-3) class decorators;
-    /// shared by both call sites in `class_decorators.rs`. Chain-link
-    /// entries carry no real position (matching
-    /// [`Self::decorator_arity_related_info`]'s `(0, 0)` convention) since
-    /// `RelatedInformationKind::ChainLink` renders by depth, not location.
-    pub(crate) fn emit_class_decorator_not_callable(
+    /// Emit a decorator signature-resolution error, attaching
+    /// [`Self::decorator_arity_related_info`] when `result` is an
+    /// argument-count mismatch. `decorator_node` is the `@`-decorator syntax
+    /// node, used to locate the declared parameter the missing-argument pointer
+    /// anchors at.
+    pub(crate) fn emit_decorator_signature_error(
         &mut self,
         anchor: NodeIndex,
-        resolved: TypeId,
+        decorator_node: NodeIndex,
+        message: &str,
+        code: u32,
+        result: &CallResult,
     ) {
+        let related = self.decorator_arity_related_info(decorator_node, result);
+        self.error_at_node_maybe_related(anchor, message, code, related);
+    }
+
+    /// Related-information chain for a decorator whose callee has no call
+    /// signatures, mirroring tsc's `invocationErrorDetails` beneath the
+    /// TS1238/TS1239/TS1240/TS1241 head:
+    ///
+    /// ```text
+    ///   This expression is not callable.
+    ///     Type 'X' has no call signatures.
+    /// ```
+    ///
+    /// Chain-link entries carry no real position (matching
+    /// [`Self::decorator_arity_related_info`]'s `(0, 0)` convention) since
+    /// `RelatedInformationKind::ChainLink` renders by depth, not location.
+    fn decorator_not_callable_related_info(
+        &mut self,
+        resolved: TypeId,
+    ) -> Vec<DiagnosticRelatedInformation> {
         let mut related = vec![Diagnostic::related_message(
             diagnostic_codes::THIS_EXPRESSION_IS_NOT_CALLABLE,
             self.ctx.file_name.clone(),
@@ -123,12 +308,159 @@ impl<'a> CheckerState<'a> {
             detail.depth = 1;
             related.push(detail);
         }
-        self.error_at_node_with_related(
+        related
+    }
+
+    /// Related-information line for a decorator whose call fails because an
+    /// argument type is not assignable to the corresponding parameter: tsc's
+    /// `TS2345`-shaped "Argument of type '{0}' is not assignable to parameter
+    /// of type '{1}'." chained beneath the primary TS1238/… head. Returns
+    /// empty for every other [`CallResult`] shape so the arity and
+    /// not-callable paths keep ownership of theirs.
+    fn decorator_argument_mismatch_related_info(
+        &mut self,
+        result: &CallResult,
+    ) -> Vec<DiagnosticRelatedInformation> {
+        let &CallResult::ArgumentTypeMismatch {
+            expected, actual, ..
+        } = result
+        else {
+            return Vec::new();
+        };
+        let actual_str = self.format_type_diagnostic(actual);
+        let expected_str = self.format_type_diagnostic(expected);
+        vec![Diagnostic::related_message(
+            diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE,
+            self.ctx.file_name.clone(),
+            0,
+            0,
+            format_message(
+                diagnostic_messages::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE,
+                &[&actual_str, &expected_str],
+            ),
+        )]
+    }
+
+    /// Emit a class-decorator signature-resolution failure (TS1238) with the
+    /// full tsc elaboration for the specific [`CallResult`] shape:
+    ///
+    /// - argument-count mismatch -> TS1278/TS1279 ("The runtime will invoke
+    ///   the decorator with {1} arguments, but the decorator expects {0}[ at
+    ///   least]."), plus the TS6210/TS6236 missing-argument pointer;
+    /// - non-callable callee -> the not-callable / no-call-signatures chain;
+    /// - argument type mismatch -> the TS2345 "not assignable" line.
+    ///
+    /// Any other shape falls back to the bare primary message. The class-
+    /// decorator sites feed the *real* value/context argument types
+    /// (`typeof C`, `ClassDecoratorContext<typeof C>`), so the rendered
+    /// argument-mismatch type matches tsc exactly — unlike the legacy member
+    /// paths, which supply synthetic placeholders and therefore keep using
+    /// [`Self::emit_decorator_signature_error`] (arity elaboration only).
+    pub(crate) fn emit_class_decorator_signature_error(
+        &mut self,
+        decorator_node: NodeIndex,
+        result: &CallResult,
+        resolved: TypeId,
+    ) {
+        let anchor = self.class_decorator_failure_anchor(decorator_node, result);
+        // Each failure shape owns exactly one elaboration; dispatch directly
+        // rather than probing each helper in turn.
+        let related = match result {
+            CallResult::ArgumentCountMismatch { .. }
+            | CallResult::OverloadArgumentCountMismatch { .. } => {
+                self.decorator_arity_related_info(decorator_node, result)
+            }
+            CallResult::ArgumentTypeMismatch { .. } => {
+                self.decorator_argument_mismatch_related_info(result)
+            }
+            CallResult::NotCallable { .. } => self.decorator_not_callable_related_info(resolved),
+            _ => Vec::new(),
+        };
+        self.error_at_node_maybe_related(
             anchor,
             diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
             diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
             related,
         );
+    }
+
+    /// The anchor tsc uses for a class-decorator call failure, keyed on the
+    /// failure kind rather than a parameter-count heuristic: the whole
+    /// decorator (spanning the leading `@`) only when the decorator was given
+    /// *too few* arguments (`decorator(classConstructor[, context])` cannot
+    /// supply a required parameter), and the decorator expression alone for a
+    /// too-many-arguments count, an argument type mismatch, or a non-callable
+    /// callee. This mirrors tsc's call-node anchoring and, unlike the
+    /// parameter-count heuristic used for member decorators, is not fooled by
+    /// a rest parameter inflating the declared count on a type-mismatch
+    /// failure.
+    fn class_decorator_failure_anchor(
+        &self,
+        decorator_node: NodeIndex,
+        result: &CallResult,
+    ) -> NodeIndex {
+        let too_few = match result {
+            CallResult::ArgumentCountMismatch {
+                expected_min,
+                actual,
+                ..
+            } => actual < expected_min,
+            CallResult::OverloadArgumentCountMismatch {
+                actual,
+                expected_low,
+                ..
+            } => actual < expected_low,
+            _ => false,
+        };
+        if too_few {
+            decorator_node
+        } else {
+            self.decorator_expression_anchor(decorator_node)
+        }
+    }
+
+    /// tsc's TS1238 "not callable" shape for a class decorator whose resolved
+    /// type carries no call signature at all — a bare primitive, a class
+    /// (construct signatures only, no call signatures), or any other
+    /// non-callable value. Emits the primary TS1238 anchored at `anchor` with
+    /// the "This expression is not callable." / "Type 'X' has no call
+    /// signatures." chain beneath it. Oracle-verified (`typescript@7.0.2`) to
+    /// render identically under `--experimentalDecorators` and ES (TC39
+    /// stage-3) class decorators.
+    pub(crate) fn emit_class_decorator_not_callable(
+        &mut self,
+        anchor: NodeIndex,
+        resolved: TypeId,
+    ) {
+        let related = self.decorator_not_callable_related_info(resolved);
+        self.error_at_node_maybe_related(
+            anchor,
+            diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
+            diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_CLASS_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
+            related,
+        );
+    }
+
+    /// Whether a decorator expression is a bare referenceable entity — an
+    /// identifier, a (possibly nested) property-access chain, or a call
+    /// expression (`@d()`, whose zero-arg *result* can itself be the
+    /// "forgot to call it" shape one level deeper) — rather than a
+    /// parenthesized or inline function expression.
+    ///
+    /// Observed tsc behavior (oracle-verified against `typescript@7.0.2`): the
+    /// TS1329 "did you mean to call it first" hint fires for referenceable
+    /// decorators (`@d`, `@ns.d`, `@d()`). A parenthesized/inline factory
+    /// (`@(() => {})`, `@(d)`) instead reports the plain arity/signature
+    /// failure. The class path gates the shared zero-argument-factory check
+    /// ([`Self::decorator_has_zero_arg_factory_shape`]) on this predicate; the
+    /// member/parameter paths do not front-guard it, so this deliberately does
+    /// not attempt to unify their (separate) handling.
+    pub(crate) fn decorator_expression_is_reference(&self, expr: NodeIndex) -> bool {
+        self.ctx.arena.get(expr).is_some_and(|node| {
+            node.kind == tsz_scanner::SyntaxKind::Identifier as u16
+                || node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+                || node.kind == syntax_kind_ext::CALL_EXPRESSION
+        })
     }
 
     /// tsc anchors member/parameter decorator failures (TS1239/TS1240/TS1241)
@@ -147,9 +479,7 @@ impl<'a> CheckerState<'a> {
             .unwrap_or(decorator_node)
     }
 
-    /// Shared with the class-decorator TS1238 path in `class_decorators.rs`,
-    /// which anchors legacy class-decorator call failures the same way.
-    pub(crate) fn decorator_failure_anchor(
+    fn decorator_failure_anchor(
         &self,
         decorator_node: NodeIndex,
         resolved: TypeId,
@@ -228,6 +558,7 @@ impl<'a> CheckerState<'a> {
         if !matches!(result, CallResult::Success(_)) {
             self.emit_decorator_signature_error(
                 self.decorator_failure_anchor(decorator_node, resolved, args.len()),
+                decorator_node,
                 diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_PROPERTY_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                 diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_PROPERTY_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                 &result,
@@ -365,7 +696,7 @@ impl<'a> CheckerState<'a> {
     /// fixed synthetic argument list cannot reproduce, so the longer 2-argument
     /// form is supplied rather than risk dropping an argument a wider overload
     /// requires.
-    fn es_member_decorator_argument_count(&self, decorator_type: TypeId) -> usize {
+    pub(crate) fn es_member_decorator_argument_count(&self, decorator_type: TypeId) -> usize {
         // `min(max(paramCount, 1), 2)` for a single declared signature; an
         // unknown shape or an overload set falls back to the full two-argument
         // call so exotic callees behave as they did before.
@@ -470,6 +801,7 @@ impl<'a> CheckerState<'a> {
             _ => {
                 self.emit_decorator_signature_error(
                     self.decorator_failure_anchor(decorator_node, resolved, arg_types.len()),
+                    decorator_node,
                     diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_METHOD_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                     diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_METHOD_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                     &result,
@@ -626,7 +958,11 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    fn resolve_decorator_context_type(&mut self, name: &str, args: Vec<TypeId>) -> Option<TypeId> {
+    pub(crate) fn resolve_decorator_context_type(
+        &mut self,
+        name: &str,
+        args: Vec<TypeId>,
+    ) -> Option<TypeId> {
         let lib_binders = self.get_lib_binders();
         let sym_id = self
             .ctx
@@ -861,6 +1197,7 @@ impl<'a> CheckerState<'a> {
             _ => {
                 self.emit_decorator_signature_error(
                     self.decorator_failure_anchor(decorator_node, resolved, arg_types.len()),
+                    decorator_node,
                     diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_PROPERTY_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                     diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_PROPERTY_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                     &result,
@@ -994,6 +1331,7 @@ impl<'a> CheckerState<'a> {
             _ => {
                 self.emit_decorator_signature_error(
                     self.decorator_failure_anchor(decorator_node, resolved, 3),
+                    decorator_node,
                     diagnostic_messages::UNABLE_TO_RESOLVE_SIGNATURE_OF_PARAMETER_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                     diagnostic_codes::UNABLE_TO_RESOLVE_SIGNATURE_OF_PARAMETER_DECORATOR_WHEN_CALLED_AS_AN_EXPRESSION,
                     &result,

--- a/crates/tsz-checker/tests/ts1238_class_decorator_signature_tests.rs
+++ b/crates/tsz-checker/tests/ts1238_class_decorator_signature_tests.rs
@@ -1,0 +1,251 @@
+//! TS1238 class-decorator signature resolution across both decorator modes
+//! (issue #17108).
+//!
+//! Structural rule: a class decorator is resolved as the call
+//! `decorator(value[, context])` — `decorator(classConstructor)` under
+//! `--experimentalDecorators`, and `decorator(typeof C,
+//! ClassDecoratorContext<typeof C>)` (truncated to the decorator's declared
+//! arity) in TC39 stage-3 ES mode. When that resolution fails, tsc reports
+//! TS1238 ("Unable to resolve signature of class decorator when called as an
+//! expression.") with an elaboration keyed on the failure kind:
+//!
+//! - non-callable callee -> "This expression is not callable." /
+//!   "Type 'X' has no call signatures.";
+//! - argument type mismatch -> the TS2345 "Argument of type X is not
+//!   assignable to parameter of type Y." line;
+//! - too few / too many arguments -> the TS1278/TS1279 arity line.
+//!
+//! A bare-reference zero-argument factory used uncalled (`@d`, `@ns.d`) draws
+//! TS1329 instead; a parenthesized/inline factory falls through to the arity
+//! failure.
+//!
+//! tsz previously (a) dropped the diagnostic *entirely* in ES mode for
+//! non-arity failures, and (b) emitted only the bare TS1238 (no elaboration)
+//! under `--experimentalDecorators`. Oracle-verified against pinned
+//! `typescript@7.0.2` in both modes.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_source;
+
+fn es(source: &str) -> Vec<Diagnostic> {
+    check_source(source, "test.ts", CheckerOptions::default())
+}
+
+fn legacy(source: &str) -> Vec<Diagnostic> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            experimental_decorators: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn find(diags: &[Diagnostic], code: u32) -> Option<&Diagnostic> {
+    diags.iter().find(|d| d.code == code)
+}
+
+fn codes(diags: &[Diagnostic]) -> Vec<u32> {
+    diags.iter().map(|d| d.code).collect()
+}
+
+// ───────────────────────── ES mode: non-arity failures ──────────────────────
+//
+// These were the headline #17108 symptom: nothing at all was emitted.
+
+#[test]
+fn es_non_callable_value_emits_ts1238_with_chain() {
+    // A non-function value used as an ES class decorator.
+    let diags = es("const deco = 1;\n@deco\nclass C {}\n");
+    let primary = find(&diags, 1238).expect("expected TS1238 in ES mode");
+    assert_eq!(primary.related_information.len(), 2);
+    assert_eq!(primary.related_information[0].code, 2349);
+    assert_eq!(
+        primary.related_information[0].message_text,
+        "This expression is not callable."
+    );
+    assert_eq!(primary.related_information[1].code, 2757);
+    assert_eq!(primary.related_information[1].depth, 1);
+}
+
+#[test]
+fn es_argument_type_mismatch_emits_ts1238_with_argument_line() {
+    // A rest parameter must not mask the argument type mismatch: `value`
+    // (`typeof C`) is not assignable to the `string` first parameter.
+    let diags = es("function deco(a: string, b: string, ...r: string[]) {}\n@deco\nclass C {}\n");
+    let primary = find(&diags, 1238).expect("expected TS1238 in ES mode");
+    assert_eq!(primary.related_information.len(), 1);
+    assert_eq!(primary.related_information[0].code, 2345);
+    assert_eq!(
+        primary.related_information[0].message_text,
+        "Argument of type 'typeof C' is not assignable to parameter of type 'string'."
+    );
+}
+
+#[test]
+fn es_second_argument_is_checked_against_context_parameter() {
+    // The ES decorator receives a *second* `context` argument, so a `number`
+    // second parameter — which the first argument (`typeof C`) satisfies —
+    // still fails on the context argument. (The full lib renders the context
+    // as `ClassDecoratorContext<typeof C>`, oracle-verified; the reduced
+    // unit-test lib falls back to `{}`, so this asserts the stable target
+    // parameter type rather than the context type's rendered name.)
+    let diags = es("function deco(a: typeof C, b: number) {}\n@deco\nclass C {}\n");
+    let primary = find(&diags, 1238).expect("expected TS1238 in ES mode");
+    assert_eq!(primary.related_information.len(), 1);
+    assert_eq!(primary.related_information[0].code, 2345);
+    assert!(
+        primary.related_information[0]
+            .message_text
+            .ends_with("is not assignable to parameter of type 'number'."),
+        "expected the context argument to fail against the number parameter, got: {}",
+        primary.related_information[0].message_text
+    );
+}
+
+#[test]
+fn es_class_used_as_decorator_is_not_callable() {
+    // A class has construct signatures but no call signatures.
+    let diags = es("class Deco {}\n@Deco\nclass C {}\n");
+    let primary = find(&diags, 1238).expect("expected TS1238 in ES mode");
+    assert_eq!(primary.related_information.len(), 2);
+    assert_eq!(primary.related_information[0].code, 2349);
+    assert_eq!(primary.related_information[1].code, 2757);
+}
+
+// ───────────────────────── ES mode: arity vs TS1329 ─────────────────────────
+
+#[test]
+fn es_bare_reference_zero_arg_factory_is_ts1329_not_ts1238() {
+    // A bare-reference zero-parameter factory draws the "did you mean to call
+    // it first" hint, not the arity TS1238.
+    let diags = es("function deco() {}\n@deco\nclass C {}\n");
+    assert!(codes(&diags).contains(&1329), "got: {:?}", codes(&diags));
+    assert!(!codes(&diags).contains(&1238), "got: {:?}", codes(&diags));
+}
+
+#[test]
+fn es_property_access_zero_arg_factory_is_ts1329() {
+    // The reference form covers property-access chains too (`@ns.deco`).
+    let diags = es("const ns = { deco: () => {} };\n@ns.deco\nclass C {}\n");
+    assert!(codes(&diags).contains(&1329), "got: {:?}", codes(&diags));
+    assert!(!codes(&diags).contains(&1238), "got: {:?}", codes(&diags));
+}
+
+#[test]
+fn es_parenthesized_zero_arg_factory_is_ts1238_not_ts1329() {
+    // A parenthesized/inline factory is NOT a bare reference, so tsc reports
+    // the arity TS1238 rather than the TS1329 call-it-first hint.
+    let diags = es("@(() => {})\nclass C {}\n");
+    assert!(codes(&diags).contains(&1238), "got: {:?}", codes(&diags));
+    assert!(!codes(&diags).contains(&1329), "got: {:?}", codes(&diags));
+}
+
+#[test]
+fn es_too_many_required_params_emits_ts1238_arity() {
+    // Three required parameters cannot be satisfied by the two-argument ES
+    // decorator ABI: the runtime supplies 2, the decorator wants 3, so this is
+    // a too-few-arguments failure from the call's perspective and also gains
+    // the TS6210 missing-argument pointer at the unsupplied third parameter.
+    let diags = es("function deco(a: any, b: any, c: any) {}\n@deco\nclass C {}\n");
+    let primary = find(&diags, 1238).expect("expected TS1238 in ES mode");
+    assert_eq!(primary.related_information.len(), 2);
+    assert_eq!(primary.related_information[0].code, 1278);
+    assert_eq!(
+        primary.related_information[0].message_text,
+        "The runtime will invoke the decorator with 2 arguments, but the decorator expects 3."
+    );
+    assert_eq!(primary.related_information[1].code, 6210);
+}
+
+#[test]
+fn es_one_or_two_param_decorator_is_accepted() {
+    // 1- and 2-parameter `any` decorators satisfy the ES ABI with no error.
+    for source in [
+        "function deco(a: any) {}\n@deco\nclass C {}\n",
+        "function deco(a: any, b: any) {}\n@deco\nclass C {}\n",
+    ] {
+        let diags = es(source);
+        assert!(
+            !codes(&diags).contains(&1238) && !codes(&diags).contains(&1329),
+            "expected no decorator-signature diagnostic for {source:?}, got: {:?}",
+            codes(&diags)
+        );
+    }
+}
+
+// ───────────────────────── legacy mode: non-arity failures ──────────────────
+
+#[test]
+fn legacy_non_callable_value_emits_ts1238_with_chain() {
+    let diags = legacy("const deco = 1;\n@deco\nclass C {}\n");
+    let primary = find(&diags, 1238).expect("expected TS1238 (legacy)");
+    assert_eq!(primary.related_information.len(), 2);
+    assert_eq!(primary.related_information[0].code, 2349);
+    assert_eq!(primary.related_information[1].code, 2757);
+    assert_eq!(primary.related_information[1].depth, 1);
+}
+
+#[test]
+fn legacy_argument_type_mismatch_emits_ts1238_with_argument_line() {
+    let diags = legacy("function deco(target: string) {}\n@deco\nclass C {}\n");
+    let primary = find(&diags, 1238).expect("expected TS1238 (legacy)");
+    assert_eq!(primary.related_information.len(), 1);
+    assert_eq!(primary.related_information[0].code, 2345);
+    assert_eq!(
+        primary.related_information[0].message_text,
+        "Argument of type 'typeof C' is not assignable to parameter of type 'string'."
+    );
+}
+
+#[test]
+fn legacy_bare_reference_zero_arg_factory_is_ts1329() {
+    // A zero-parameter legacy class decorator factory used uncalled.
+    let diags = legacy("function deco() {}\n@deco\nclass C {}\n");
+    assert!(codes(&diags).contains(&1329), "got: {:?}", codes(&diags));
+    assert!(!codes(&diags).contains(&1238), "got: {:?}", codes(&diags));
+}
+
+#[test]
+fn legacy_too_few_args_keeps_arity_elaboration() {
+    // Regression guard: the legacy too-few arity elaboration still fires.
+    let diags = legacy("function deco(target: Function, extra: string) {}\n@deco\nclass C {}\n");
+    let primary = find(&diags, 1238).expect("expected TS1238 (legacy)");
+    assert_eq!(primary.related_information[0].code, 1278);
+}
+
+#[test]
+fn legacy_well_typed_decorator_has_no_signature_diagnostic() {
+    // Positive control: a `(target: Function) => void` decorator is valid.
+    let diags = legacy("function deco(target: Function) {}\n@deco\nclass C {}\n");
+    assert!(
+        !codes(&diags).contains(&1238) && !codes(&diags).contains(&1270),
+        "got: {:?}",
+        codes(&diags)
+    );
+}
+
+// ───────────────────────── renamed-binder invariance ────────────────────────
+
+#[test]
+fn behavior_is_independent_of_decorator_and_class_names() {
+    // Anti-hardcoding: the same non-callable failure must fire regardless of
+    // the identifiers chosen for the decorator and the class.
+    for (deco, class) in [("deco", "C"), ("wrap", "Widget"), ("qqq", "ZZZ")] {
+        let source = format!("const {deco} = 42;\n@{deco}\nclass {class} {{}}\n");
+        let es_diags = es(&source);
+        let legacy_diags = legacy(&source);
+        assert!(
+            codes(&es_diags).contains(&1238),
+            "ES: expected TS1238 for {source:?}, got: {:?}",
+            codes(&es_diags)
+        );
+        assert!(
+            codes(&legacy_diags).contains(&1238),
+            "legacy: expected TS1238 for {source:?}, got: {:?}",
+            codes(&legacy_diags)
+        );
+    }
+}

--- a/crates/tsz-checker/tests/ts1278_ts1279_decorator_arity_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/ts1278_ts1279_decorator_arity_elaboration_tests.rs
@@ -1,25 +1,31 @@
-//! TS1278/TS1279 elaboration for decorator signature-resolution failures.
+//! TS1278/TS1279 elaboration + TS6210/TS6236 missing-argument pointer for
+//! decorator signature-resolution failures.
 //!
 //! Structural rule: when a decorator's call resolution fails specifically
-//! because of an argument-count mismatch, tsc attaches a related-information
-//! chain link to the primary TS1238/1239/1240/1241 ("Unable to resolve
-//! signature of ... decorator when called as an expression."):
+//! because of an argument-count mismatch, tsc attaches, beneath the primary
+//! TS1238/1239/1240/1241 ("Unable to resolve signature of ... decorator when
+//! called as an expression."):
 //! - TS1278 ("The runtime will invoke the decorator with {1} arguments, but
 //!   the decorator expects {0}.") when the decorator's declared arity has a
-//!   concrete upper bound.
-//! - TS1279 ("...but the decorator expects at least {0}.") when too few
-//!   arguments were supplied and the decorator's arity is genuinely
-//!   open-ended (a trailing `...rest: any[]`).
+//!   concrete upper bound, or TS1279 ("...expects at least {0}.") when too few
+//!   arguments were supplied and the arity is open-ended (`...rest: any[]`); and
+//! - a *cross-location pointer* at the first declared parameter the fixed
+//!   decorator calling convention leaves unsupplied — TS6210 ("An argument for
+//!   '{0}' was not provided.") for a named parameter, or TS6236 ("Arguments for
+//!   the rest parameter '{0}' were not provided.") when that parameter is
+//!   variadic. This second line fires only for a *too-few* failure; a *too-many*
+//!   failure supplies every declared parameter and gets only the TS1278 line.
 //!
-//! tsz previously reported only the primary message, with no related
-//! information at all — the elaboration line was silently dropped in both
-//! the too-few and too-many argument shapes, across all five
-//! resolve-call-based decorator-signature-check sites (class, ES member,
-//! method/accessor, legacy property, parameter). A non-arity failure (e.g. an
-//! argument type mismatch) is deliberately left untouched: tsc attaches a
-//! different elaboration there (a `TS2345`-style "not assignable" line) that
-//! this change does not wire, so those diagnostics keep their pre-existing
-//! shape (no related information) rather than attaching the wrong kind.
+//! For the **class-decorator** sites (both `--experimentalDecorators` and ES
+//! modes), a non-arity failure now carries its own tsc elaboration too (issue
+//! #17108): the TS2345-shaped "Argument of type X is not assignable to
+//! parameter of type Y." line for an argument type mismatch, and the
+//! "This expression is not callable." / "Type 'X' has no call signatures."
+//! chain for a non-callable callee. This is safe there because the class
+//! sites feed the *real* value/context argument types (`typeof C`,
+//! `ClassDecoratorContext<typeof C>`), so the rendered types match tsc. The
+//! member/parameter sites still supply synthetic placeholder arguments, so
+//! their non-arity failures keep the arity-only elaboration.
 //!
 //! Oracle-verified against pinned `typescript@7.0.2` for every shape below.
 
@@ -48,47 +54,84 @@ fn find(
     diags.iter().find(|d| d.code == code)
 }
 
-// ───────────────────────── class decorator (TS1238, legacy) ─────────────────
+/// Byte offset of the first occurrence of `needle` in `source`, used to check
+/// the missing-argument pointer anchors at the parameter declaration.
+fn offset_of(source: &str, needle: &str) -> u32 {
+    u32::try_from(source.find(needle).expect("needle present in source")).expect("offset fits u32")
+}
+
+/// Assert the primary diagnostic carries exactly the TS1278/TS1279 elaboration
+/// line, then the TS6210/TS6236 pointer at `param_start`.
+fn assert_arity_chain(
+    primary: &tsz_checker::diagnostics::Diagnostic,
+    expect_runtime_code: u32,
+    expect_runtime_message: &str,
+    expect_pointer_code: u32,
+    expect_pointer_message: &str,
+    param_start: u32,
+) {
+    let related = &primary.related_information;
+    assert_eq!(
+        related.len(),
+        2,
+        "expected the runtime-arity line and the missing-argument pointer, got: {related:?}"
+    );
+    assert_eq!(related[0].code, expect_runtime_code);
+    assert_eq!(related[0].message_text, expect_runtime_message);
+    assert_eq!(related[1].code, expect_pointer_code);
+    assert_eq!(related[1].message_text, expect_pointer_message);
+    assert_eq!(
+        related[1].start, param_start,
+        "TS{expect_pointer_code} must anchor at the missing parameter declaration"
+    );
+}
+
+// ───────────────────── class decorator (TS1238, legacy) ─────────────────
 
 #[test]
 fn ts1278_class_decorator_too_few_args_exact() {
     // `classDec` declares 2 required params; a legacy class decorator is
-    // invoked with exactly 1 (the class constructor) -> TS1278 "expects 2".
-    let diags = diagnostics_experimental(
-        r#"
+    // invoked with exactly 1 (the class constructor) -> TS1278 "expects 2",
+    // plus a TS6210 pointer at the unsupplied `extra` parameter.
+    let source = r#"
 function classDec(target: Function, extra: string) {}
 
 @classDec
 class C {}
-"#,
-    );
+"#;
+    let diags = diagnostics_experimental(source);
     let primary = find(&diags, 1238).expect("expected TS1238");
-    assert_eq!(primary.related_information.len(), 1);
-    assert_eq!(primary.related_information[0].code, 1278);
-    assert_eq!(
-        primary.related_information[0].message_text,
-        "The runtime will invoke the decorator with 1 arguments, but the decorator expects 2."
+    assert_arity_chain(
+        primary,
+        1278,
+        "The runtime will invoke the decorator with 1 arguments, but the decorator expects 2.",
+        6210,
+        "An argument for 'extra' was not provided.",
+        offset_of(source, "extra: string"),
     );
 }
 
 #[test]
 fn ts1279_class_decorator_too_few_args_at_least() {
     // A genuinely variadic decorator (`...rest: any[]`) with a required
-    // `name` param that isn't supplied -> TS1279 "expects at least 2".
-    let diags = diagnostics_experimental(
-        r#"
+    // `name` param that isn't supplied -> TS1279 "expects at least 2". The
+    // first unsupplied parameter is the ordinary `name`, so the pointer is
+    // TS6210 (named), not TS6236 (rest).
+    let source = r#"
 function classDec(target: Function, name: string, ...rest: any[]) {}
 
 @classDec
 class C {}
-"#,
-    );
+"#;
+    let diags = diagnostics_experimental(source);
     let primary = find(&diags, 1238).expect("expected TS1238");
-    assert_eq!(primary.related_information.len(), 1);
-    assert_eq!(primary.related_information[0].code, 1279);
-    assert_eq!(
-        primary.related_information[0].message_text,
-        "The runtime will invoke the decorator with 1 arguments, but the decorator expects at least 2."
+    assert_arity_chain(
+        primary,
+        1279,
+        "The runtime will invoke the decorator with 1 arguments, but the decorator expects at least 2.",
+        6210,
+        "An argument for 'name' was not provided.",
+        offset_of(source, "name: string"),
     );
 }
 
@@ -97,29 +140,35 @@ fn ts1278_class_decorator_fixed_length_rest_stays_exact() {
     // A fixed-length tuple rest param (`...rest: [string, number]`) has a
     // concrete max arity, so this stays TS1278 ("expects 3"), not TS1279 --
     // the discriminator is a concrete upper bound, not the presence of `...`.
-    let diags = diagnostics_experimental(
-        r#"
+    // The first unsupplied position is the tuple rest, so the pointer is
+    // TS6236 anchored at it.
+    let source = r#"
 function classDec(target: Function, ...rest: [string, number]) {}
 
 @classDec
 class C {}
-"#,
-    );
+"#;
+    let diags = diagnostics_experimental(source);
     let primary = find(&diags, 1238).expect("expected TS1238");
-    assert_eq!(primary.related_information.len(), 1);
-    assert_eq!(primary.related_information[0].code, 1278);
-    assert_eq!(
-        primary.related_information[0].message_text,
-        "The runtime will invoke the decorator with 1 arguments, but the decorator expects 3."
+    assert_arity_chain(
+        primary,
+        1278,
+        "The runtime will invoke the decorator with 1 arguments, but the decorator expects 3.",
+        6236,
+        "Arguments for the rest parameter 'rest' were not provided.",
+        // tsz's normalized parameter anchor starts at the binding name, past the
+        // `...` rest token.
+        offset_of(source, "rest: [string, number]"),
     );
 }
 
 #[test]
-fn ts1238_class_decorator_type_mismatch_stays_unelaborated() {
-    // Control: a non-arity failure (wrong parameter type, not wrong count)
-    // must not gain related information -- tsc's elaboration there is a
-    // different, not-yet-wired shape ("Argument of type X is not assignable
-    // to parameter of type Y."), so this stays exactly as before.
+fn ts1238_class_decorator_type_mismatch_elaborates_argument() {
+    // A non-arity class-decorator failure (wrong parameter type, not wrong
+    // count) attaches tsc's TS2345-shaped "Argument of type X is not
+    // assignable to parameter of type Y." line. The class-decorator sites
+    // feed the real class constructor type (`typeof C`), so the rendered
+    // argument type matches tsc exactly (issue #17108).
     let diags = diagnostics_experimental(
         r#"
 function classDec(target: string) {}
@@ -129,60 +178,218 @@ class C {}
 "#,
     );
     let primary = find(&diags, 1238).expect("expected TS1238");
-    assert!(
-        primary.related_information.is_empty(),
-        "expected no related info for a type-mismatch failure, got: {:?}",
-        primary.related_information
+    assert_eq!(primary.related_information.len(), 1);
+    assert_eq!(primary.related_information[0].code, 2345);
+    assert_eq!(
+        primary.related_information[0].message_text,
+        "Argument of type 'typeof C' is not assignable to parameter of type 'string'."
     );
 }
 
-// ───────────────────────── ES member decorator (TS1240) ─────────────────────
+#[test]
+fn ts1238_class_decorator_non_callable_elaborates_chain() {
+    // A non-callable class decorator (a non-function value) attaches tsc's
+    // two-line "This expression is not callable." / "Type 'X' has no call
+    // signatures." chain beneath the primary TS1238 (issue #17108).
+    let diags = diagnostics_experimental(
+        r#"
+const d = 1;
+
+@d
+class C {}
+"#,
+    );
+    let primary = find(&diags, 1238).expect("expected TS1238");
+    assert_eq!(primary.related_information.len(), 2);
+    assert_eq!(primary.related_information[0].code, 2349);
+    assert_eq!(
+        primary.related_information[0].message_text,
+        "This expression is not callable."
+    );
+    // The "has no call signatures" note nests one level deeper (depth 1).
+    // Its rendered type is the callee's apparent type — `Number` against the
+    // full lib the CLI/oracle use, but the reduced unit-test lib renders the
+    // bare `number` primitive, so match on the stable structure rather than
+    // the primitive's casing.
+    assert_eq!(primary.related_information[1].code, 2757);
+    assert_eq!(primary.related_information[1].depth, 1);
+    assert!(
+        primary.related_information[1]
+            .message_text
+            .ends_with("has no call signatures."),
+        "unexpected note: {}",
+        primary.related_information[1].message_text
+    );
+}
+
+#[test]
+fn ts6210_class_decorator_binder_name_varies() {
+    // The pointer is driven by the decorator's declared parameters, not by any
+    // fixed identifier: a renamed binder still names its own missing parameter.
+    let source = r#"
+function wrap(ctor: Function, label: string) {}
+
+@wrap
+class C {}
+"#;
+    let diags = diagnostics_experimental(source);
+    let primary = find(&diags, 1238).expect("expected TS1238");
+    assert_arity_chain(
+        primary,
+        1278,
+        "The runtime will invoke the decorator with 1 arguments, but the decorator expects 2.",
+        6210,
+        "An argument for 'label' was not provided.",
+        offset_of(source, "label: string"),
+    );
+}
+
+#[test]
+fn ts6210_class_decorator_arrow_const_declaration() {
+    // The declaration is reachable through a `const` initialized with an arrow,
+    // not only a `function` statement.
+    let source = r#"
+const classDec = (target: Function, extra: string) => {};
+
+@classDec
+class C {}
+"#;
+    let diags = diagnostics_experimental(source);
+    let primary = find(&diags, 1238).expect("expected TS1238");
+    assert_arity_chain(
+        primary,
+        1278,
+        "The runtime will invoke the decorator with 1 arguments, but the decorator expects 2.",
+        6210,
+        "An argument for 'extra' was not provided.",
+        offset_of(source, "extra: string"),
+    );
+}
+
+#[test]
+fn ts6210_class_decorator_skips_explicit_this_parameter() {
+    // An explicit `this` parameter is not a value argument, so the pointer must
+    // land on `extra`, not shift by one onto `this`.
+    let source = r#"
+function classDec(this: unknown, target: Function, extra: string) {}
+
+@classDec
+class C {}
+"#;
+    let diags = diagnostics_experimental(source);
+    let primary = find(&diags, 1238).expect("expected TS1238");
+    let pointer = primary
+        .related_information
+        .iter()
+        .find(|r| r.code == 6210)
+        .expect("expected TS6210");
+    assert_eq!(
+        pointer.message_text,
+        "An argument for 'extra' was not provided."
+    );
+    assert_eq!(pointer.start, offset_of(source, "extra: string"));
+}
+
+// ───────────────────── ES class decorator (TS1238, stage-3) ─────────────
+
+#[test]
+fn ts1278_es_class_decorator_too_few_args() {
+    // Gap 2: the ES (stage-3) class-decorator arity path is now routed
+    // through the same real call-resolution `check_class_decorator_signature`
+    // as the legacy path: `(value, context)` = 2 supplied args, a
+    // 3-required-param decorator -> TS1278 "expects 3" + TS6210 at the third
+    // parameter (the first the two-argument convention cannot fill).
+    let source = r#"
+function classDec(value: any, context: any, extra: string) {}
+
+@classDec
+class C {}
+"#;
+    let diags = diagnostics_es(source);
+    let primary = find(&diags, 1238).expect("expected TS1238");
+    assert_arity_chain(
+        primary,
+        1278,
+        "The runtime will invoke the decorator with 2 arguments, but the decorator expects 3.",
+        6210,
+        "An argument for 'extra' was not provided.",
+        offset_of(source, "extra: string"),
+    );
+}
+
+#[test]
+fn ts1279_es_class_decorator_variadic_too_few_args() {
+    // ES class decorator with an open-ended arity (`...rest: any[]`) and a
+    // third required parameter -> TS1279 "at least 3" + TS6210 at `extra`.
+    let source = r#"
+function classDec(value: any, context: any, extra: string, ...rest: any[]) {}
+
+@classDec
+class C {}
+"#;
+    let diags = diagnostics_es(source);
+    let primary = find(&diags, 1238).expect("expected TS1238");
+    assert_arity_chain(
+        primary,
+        1279,
+        "The runtime will invoke the decorator with 2 arguments, but the decorator expects at least 3.",
+        6210,
+        "An argument for 'extra' was not provided.",
+        offset_of(source, "extra: string"),
+    );
+}
+
+// ───────────────────── ES member decorator (TS1240) ─────────────────
 
 #[test]
 fn ts1278_es_field_decorator_too_few_args() {
     // ES (TC39) field decorators are invoked with `(value, context)` -- at
     // most 2 synthetic args, capped by `es_member_decorator_argument_count`.
-    // A decorator declaring 3+ required params always underflows that cap
-    // (a 1- or 2-required-param decorator gets exactly the args it declared,
-    // per `min(max(paramCount, 1), 2)`, and never fails on arity alone).
-    let diags = diagnostics_es(
-        r#"
+    // A decorator declaring 3+ required params always underflows that cap.
+    let source = r#"
 function d(value: any, context: any, extra: string): any { return value; }
 class C { @d field = 1; }
-"#,
-    );
+"#;
+    let diags = diagnostics_es(source);
     let primary = find(&diags, 1240).expect("expected TS1240");
-    assert_eq!(primary.related_information.len(), 1);
-    assert_eq!(primary.related_information[0].code, 1278);
-    assert_eq!(
-        primary.related_information[0].message_text,
-        "The runtime will invoke the decorator with 2 arguments, but the decorator expects 3."
+    assert_arity_chain(
+        primary,
+        1278,
+        "The runtime will invoke the decorator with 2 arguments, but the decorator expects 3.",
+        6210,
+        "An argument for 'extra' was not provided.",
+        offset_of(source, "extra: string"),
     );
 }
 
-// ───────────────────────── method/accessor decorator (TS1241) ───────────────
+// ───────────────────── method/accessor decorator (TS1241) ───────────────
 
 #[test]
 fn ts1278_method_decorator_too_few_args() {
-    let diags = diagnostics_es(
-        r#"
+    let source = r#"
 function d(value: any, context: any, extra: string): any { return value; }
 class C { @d method() {} }
-"#,
-    );
+"#;
+    let diags = diagnostics_es(source);
     let primary = find(&diags, 1241).expect("expected TS1241");
-    assert_eq!(primary.related_information.len(), 1);
-    assert_eq!(primary.related_information[0].code, 1278);
+    assert_arity_chain(
+        primary,
+        1278,
+        "The runtime will invoke the decorator with 2 arguments, but the decorator expects 3.",
+        6210,
+        "An argument for 'extra' was not provided.",
+        offset_of(source, "extra: string"),
+    );
 }
 
-// ───────────────────────── legacy property decorator (TS1240) ───────────────
+// ───────────────────── legacy property decorator (TS1240) ───────────────
 
 #[test]
 fn ts1278_legacy_property_decorator_too_many_args() {
     // Legacy field decorators are invoked `(target, propertyKey)`; a
     // 1-parameter decorator overflows -> TS1278 "expects 1" (the "too many"
-    // shape, not "too few" -- proves the exact-vs-at-least split isn't keyed
-    // on which direction the mismatch runs).
+    // shape). A too-many failure supplies every declared parameter, so there
+    // is NO missing-argument pointer -- only the single TS1278 line.
     let diags = diagnostics_experimental(
         r#"
 function propDec(target: any) {}
@@ -202,27 +409,28 @@ class C {
     );
 }
 
-// ───────────────────────── parameter decorator (TS1239) ─────────────────────
+// ───────────────────── parameter decorator (TS1239) ─────────────────
 
 #[test]
 fn ts1278_parameter_decorator_too_few_args() {
     // Parameter decorators are always invoked with 3 args
     // (`target, propertyKey, parameterIndex`); a 4-required-param decorator
-    // underflows -> TS1278 "expects 4".
-    let diags = diagnostics_experimental(
-        r#"
+    // underflows -> TS1278 "expects 4" + TS6210 at the fourth parameter.
+    let source = r#"
 function paramDec(a: any, b: any, c: any, d: any) {}
 
 class C {
   m(@paramDec x: number) {}
 }
-"#,
-    );
+"#;
+    let diags = diagnostics_experimental(source);
     let primary = find(&diags, 1239).expect("expected TS1239");
-    assert_eq!(primary.related_information.len(), 1);
-    assert_eq!(primary.related_information[0].code, 1278);
-    assert_eq!(
-        primary.related_information[0].message_text,
-        "The runtime will invoke the decorator with 3 arguments, but the decorator expects 4."
+    assert_arity_chain(
+        primary,
+        1278,
+        "The runtime will invoke the decorator with 3 arguments, but the decorator expects 4.",
+        6210,
+        "An argument for 'd' was not provided.",
+        offset_of(source, "d: any"),
     );
 }


### PR DESCRIPTION
Resolves #17108 and #17104, superseding the stuck, conflicting duplicate pair #17126/#17127 (open 33+ hours, conflicting with each other, per the board note at https://github.com/tsz-org/tsz/issues/15994#issuecomment-5255862875) by combining what each got right rather than leaving the underlying defect unlanded.

**Structural rule.** A class decorator is resolved as the call `decorator(value[, context])` — `decorator(classConstructor)` under `--experimentalDecorators`, `decorator(typeof C, ClassDecoratorContext<typeof C>)` (truncated to the decorator's declared arity) in ES (TC39 stage-3) mode. `tsc` always routes this through real call resolution and elaborates TS1238 by the `CallResult` failure kind. tsz's ES path (`check_es_class_decorator_arity`) never called `resolve_call_with_checker_adapter` at all — it hand-inspected `function_shape.params.len()` — so it silently dropped the whole diagnostic for a non-callable callee or an argument-type mismatch, and never got the TS1278/TS1279 arity elaboration the legacy path already had.

**Fix** (owner: checker class-decorator path, `class_decorators.rs` + `decorator_signature_checks.rs`). Unify both decorator modes onto one `check_class_decorator_signature` that always resolves the real call and routes every `CallResult` failure shape through tsc's elaboration — not-callable chain, TS2345 argument-mismatch line, or TS1278/TS1279 arity line — via `emit_class_decorator_signature_error`. On top of that, extend the shared `decorator_arity_related_info` (used by every arity-mismatch decorator site: class, ES member, method/accessor, legacy property, parameter) to attach tsc's second `relatedInformation` pointer at the first declared parameter the runtime cannot supply: TS6210 for a named parameter, TS6236 for a rest parameter, TS6211 for a destructured one.

Because the class path now runs through the same real call-resolution machinery as every other decorator kind, the ES arity case (issue #17104) gets the TS6210/TS6236 pointer for free — no separate synthesized-`CallResult` path was needed the way #17126 built one.

**Adjacent-case matrix** (oracle-verified against pinned `typescript@7.0.2`, both decorator modes): non-callable callee, argument-type mismatch, too-few/too-many arity with the missing-argument pointer, bare-reference vs. parenthesized vs. call-expression zero-arg factory (TS1329 vs TS1238), renamed binders, explicit `this` parameter skipped, arrow-`const` declarations, and positive (well-typed) controls in both modes.

**Caught during the merge** (running the full decorator regression matrix, not just the two source PRs' own suites — this is exactly why they hadn't landed):
- #17127's diff regressed the TS1270 (decorator return-type mismatch) anchor from the decorator expression to the whole `@decorator` span — fixed by keeping `decorator_expression_anchor` for the always-post-success-call return-type check.
- #17127's `decorator_expression_is_reference` gate omitted call expressions, regressing `@d()` (a zero-arg factory *call* whose result is itself zero-arg-callable) from TS1329 to TS1238 — fixed by including `CALL_EXPRESSION` in the reference-shape predicate.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts1238_class_decorator_signature_tests` — 15/15 (new).
- `cargo test -p tsz-checker --test ts1278_ts1279_decorator_arity_elaboration_tests` — 14/14 (merged/extended from both source PRs).
- `cargo test -p tsz-checker --test ts1238_tests --test ts1238_generic_decorator_tests --test ts1238_experimental_decorator_anchor_tests --test ts1238_class_decorator_not_callable_chain_tests --test ts1239_parameter_decorator_tests --test ts1240_tests --test ts1240_accessor_decorator_tests --test ts1241_method_decorator_tests --test ts1249_method_overload_decorator_tests --test ts1271_parameter_decorator_return_type_tests --test ts1207_decorated_accessor_tests --test ts1329_class_decorator_zero_arg_factory_tests --test ts1329_decorator_parenthesized_expression_gate_tests --test ts2449_parameter_decorator_no_tdz_tests --test decorator_method_tdz_tests --test es_member_decorator_arity_tests --test issue_7681_super_decorator_tests --test decorator_this_binding_tests --test ts18036_class_decorator_static_private_identifier_tests` — all green (179 tests total across the full decorator regression matrix).
- `cargo test -p tsz-checker --lib architecture_contract` — 160/160.
- `cargo clippy -p tsz-checker --all-targets -- -D warnings` — clean.
- `python3 scripts/arch/arch_guard.py` — passes.
- `cargo fmt -p tsz-checker` applied; pre-commit hook's own clippy + arch-size + local verification passed.
- Full `cargo test -p tsz-checker --lib` (~11k tests) was still completing at push time — it ran cleanly through all tests up to the known pre-existing slow `ts2589_tests::recursive_conditional_alias_omitted_default_transform_emits_definition_ts2589` (unrelated conditional-type recursion depth, not decorator code) before I stopped it to keep to the hourly budget. Owed as a follow-up confirmation; will re-run and report before landing.
- Conformance/emit/fourslash run on the nightly lane per repo convention; this PR's `clippy` + `arch-size` CI gate is the per-merge check.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude


---
_Generated by [Claude Code](https://claude.ai/code/session_01KfMDYHVdjiNUGRrX7AE1zS)_