### PR TITLE
fix(checker): TS2390 reports once per constructor overload set and honours abstract (#17160)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2881,3 +2881,6 @@ path = "tests/ts2300_merged_interface_property_method_conflict_tests.rs"
 [[test]]
 name = "ts2694_typeof_import_qualified_type_only_member_tests"
 path = "tests/ts2694_typeof_import_qualified_type_only_member_tests.rs"
+[[test]]
+name = "constructor_implementation_missing_ts2390_tests"
+path = "tests/constructor_implementation_missing_ts2390_tests.rs"

--- a/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
@@ -1197,15 +1197,55 @@ impl<'a> CheckerState<'a> {
                     if let Some(ctor) = self.ctx.arena.get_constructor(node)
                         && ctor.body.is_none()
                     {
-                        // Constructor overload signature - check for implementation
-                        let has_impl = self.find_constructor_impl(members, i + 1);
-                        if !has_impl {
+                        // Constructor overload signature. Like methods (and like
+                        // tsc's `checkFunctionOrConstructorSymbol`), the
+                        // missing-implementation diagnostic belongs to the *last*
+                        // declaration of the overload set, reported once — not once
+                        // per bodyless signature. Advance past all consecutive
+                        // bodyless constructor signatures to that last one before
+                        // deciding, tracking whether that last signature is
+                        // `abstract` as we go (tsc suppresses the diagnostic on an
+                        // abstract last declaration — an abstract member needs no
+                        // implementation, exactly as the method arm below skips
+                        // abstract methods. `abstract` on a constructor is itself a
+                        // grammar error, TS1242, but tsc still honours it here, so
+                        // `abstract constructor()` reports only TS1242, never
+                        // TS2390).
+                        let mut last_overload_i = i;
+                        let mut last_is_abstract = self.has_abstract_modifier(&ctor.modifiers);
+                        let mut j = i + 1;
+                        while j < members.len() {
+                            let next_idx = members[j];
+                            let Some(next_node) = self.ctx.arena.get(next_idx) else {
+                                break;
+                            };
+                            if next_node.kind == syntax_kind_ext::CONSTRUCTOR
+                                && let Some(next_ctor) = self.ctx.arena.get_constructor(next_node)
+                                && next_ctor.body.is_none()
+                            {
+                                last_overload_i = j;
+                                last_is_abstract = self.has_abstract_modifier(&next_ctor.modifiers);
+                                j += 1;
+                                continue;
+                            }
+                            break;
+                        }
+
+                        // tsc anchors the missing-implementation error on the last
+                        // overload signature.
+                        let report_member_idx = members[last_overload_i];
+                        let has_impl = self.find_constructor_impl(members, last_overload_i + 1);
+                        if !has_impl && !last_is_abstract {
                             self.error_at_node(
-                                member_idx,
+                                report_member_idx,
                                 "Constructor implementation is missing.",
                                 diagnostic_codes::CONSTRUCTOR_IMPLEMENTATION_IS_MISSING,
                             );
                         }
+
+                        // Skip past every overload we just folded into this group.
+                        i = last_overload_i + 1;
+                        continue;
                     }
                 }
                 syntax_kind_ext::METHOD_DECLARATION => {

--- a/crates/tsz-checker/tests/constructor_implementation_missing_ts2390_tests.rs
+++ b/crates/tsz-checker/tests/constructor_implementation_missing_ts2390_tests.rs
@@ -1,0 +1,142 @@
+//! Regression tests for TS2390 ("Constructor implementation is missing.") on
+//! constructor overload sets.
+//!
+//! tsc reports the missing-implementation diagnostic on the *last* declaration
+//! of a constructor overload set, exactly once, and suppresses it entirely when
+//! that last declaration carries the `abstract` modifier (an abstract member
+//! needs no implementation — even though `abstract` on a constructor is itself a
+//! grammar error, TS1242). tsz previously reported TS2390 once per bodyless
+//! constructor signature (a duplicate on any 2+-overload set) and did not honour
+//! `abstract`, producing a spurious TS2390 on `abstract constructor()`.
+//!
+//! Verified against `tsc@6.0.2 --noEmit --strict --target es2022 --module
+//! esnext`. The class binders are varied so no fix can key on a specific name.
+
+use tsz_checker::test_utils::check_source_code_messages as get_diagnostics;
+
+const TS2390: u32 = 2390;
+
+fn count(source: &str, code: u32) -> usize {
+    get_diagnostics(source)
+        .iter()
+        .filter(|d| d.0 == code)
+        .count()
+}
+
+fn has(source: &str, code: u32) -> bool {
+    count(source, code) > 0
+}
+
+/// A lone bodyless constructor signature with no implementation reports exactly
+/// one TS2390.
+#[test]
+fn single_bodyless_constructor_reports_one_ts2390() {
+    let source = "class Widget { constructor(); }\n";
+    assert_eq!(count(source, TS2390), 1);
+}
+
+/// Two constructor overload signatures with no implementation report TS2390
+/// exactly once — on the last signature — not once per signature.
+#[test]
+fn two_constructor_overloads_report_one_ts2390() {
+    let source = "class Gadget { constructor(x: number); constructor(x: string); }\n";
+    assert_eq!(
+        count(source, TS2390),
+        1,
+        "TS2390 belongs to the last overload only, reported once"
+    );
+}
+
+/// Three overload signatures still collapse to a single TS2390.
+#[test]
+fn three_constructor_overloads_report_one_ts2390() {
+    let source = "class Sprocket {\n  constructor(x: number);\n  constructor(x: string);\n  constructor(x: boolean);\n}\n";
+    assert_eq!(count(source, TS2390), 1);
+}
+
+/// Overload signatures followed by an implementation report no TS2390.
+#[test]
+fn constructor_overloads_with_implementation_no_ts2390() {
+    let source =
+        "class Cog { constructor(x: number); constructor(x: string); constructor(x: any) {} }\n";
+    assert!(!has(source, TS2390));
+}
+
+/// A single constructor with a body reports no TS2390.
+#[test]
+fn single_constructor_with_body_no_ts2390() {
+    let source = "class Lever { constructor(x: number) {} }\n";
+    assert!(!has(source, TS2390));
+}
+
+/// An `abstract` constructor signature (a grammar error, TS1242) needs no
+/// implementation: tsc reports only TS1242, never TS2390. This was the original
+/// false positive.
+#[test]
+fn abstract_constructor_suppresses_ts2390() {
+    let source = "class Pulley { abstract constructor(); }\n";
+    assert!(
+        !has(source, TS2390),
+        "an abstract constructor needs no implementation"
+    );
+}
+
+/// Two abstract constructor signatures: still no TS2390 (the last one, on which
+/// the diagnostic would anchor, is abstract).
+#[test]
+fn two_abstract_constructors_suppress_ts2390() {
+    let source =
+        "class Winch { abstract constructor(x: number); abstract constructor(x: string); }\n";
+    assert!(!has(source, TS2390));
+}
+
+/// When the *last* overload is non-abstract the diagnostic is not suppressed —
+/// an earlier abstract signature does not exempt a trailing concrete one.
+#[test]
+fn abstract_then_nonabstract_constructor_reports_one_ts2390() {
+    let source = "class Ratchet { abstract constructor(); constructor(x: number); }\n";
+    assert_eq!(count(source, TS2390), 1);
+}
+
+/// When the last overload is abstract, TS2390 is suppressed even if an earlier
+/// signature was concrete.
+#[test]
+fn nonabstract_then_abstract_constructor_suppresses_ts2390() {
+    let source = "class Flywheel { constructor(); abstract constructor(x: number); }\n";
+    assert!(!has(source, TS2390));
+}
+
+/// An `abstract class` with two non-abstract constructor overload signatures
+/// still reports a single TS2390: the class being abstract does not make its
+/// constructors abstract.
+#[test]
+fn abstract_class_nonabstract_constructor_overloads_report_one_ts2390() {
+    let source = "abstract class Turbine { constructor(x: number); constructor(x: string); }\n";
+    assert_eq!(count(source, TS2390), 1);
+}
+
+/// Parameter properties on the overload signatures (their own TS2369) do not
+/// change the single-TS2390 outcome.
+#[test]
+fn constructor_overloads_with_parameter_properties_report_one_ts2390() {
+    let source = "class Motor { constructor(public a: number); constructor(public b: string); }\n";
+    assert_eq!(count(source, TS2390), 1);
+}
+
+/// A non-constructor member between two constructor signatures breaks the
+/// consecutive overload set into two independent sets, each of which reports its
+/// own TS2390 — matching tsc (constructors of a class are one symbol, but a
+/// bodyless-then-interrupted signature is diagnosed per contiguous run).
+#[test]
+fn non_consecutive_constructor_signatures_report_ts2390_per_run() {
+    let source = "class Piston { constructor(x: number); static s = 1; constructor(x: string); }\n";
+    assert_eq!(count(source, TS2390), 2);
+}
+
+/// A bodyless constructor followed by an unrelated method still reports its lone
+/// TS2390 (the method does not count as the constructor's implementation).
+#[test]
+fn constructor_signature_then_method_reports_one_ts2390() {
+    let source = "class Camshaft { constructor(x: number); rev() {} }\n";
+    assert_eq!(count(source, TS2390), 1);
+}


### PR DESCRIPTION
Fixes #17160.

The constructor arm of `check_class_member_implementations`
(`crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs`)
reported `TS2390` ("Constructor implementation is missing.") once **per**
bodyless constructor signature and ignored the `abstract` modifier, diverging
from `tsc` in two ways:

- `class A { constructor(x: number); constructor(x: string); }` emitted `TS2390`
  **twice** (once per signature); `tsc` emits it once, anchored on the last
  signature.
- `class A { abstract constructor(); }` emitted a spurious `TS2390` on top of the
  `TS1242` grammar error; `tsc` reports only `TS1242`, because an `abstract`
  member needs no implementation even when the modifier is itself illegal.

**Structural rule:** when a class has bodyless constructor overload signatures
and no implementation, `tsc` reports the missing-implementation diagnostic
exactly once, on the last declaration of the contiguous overload run, and
suppresses it entirely when that last declaration carries `abstract` — the same
rule the sibling method arm (`TS2391`) already applies. The constructor arm now
mirrors it: advance to the last consecutive bodyless constructor, track whether
that last signature is `abstract`, and report once unless an implementation
follows or the last signature is abstract. Owner layer: checker
(`member_declaration_checks.rs`), the AST-order class-member walk.

## Goal
Goal: hold

## Verification
- **New regression tests** (13):
  `crates/tsz-checker/tests/constructor_implementation_missing_ts2390_tests.rs`
  — single/2/3 overloads, overloads + implementation, single-with-body,
  abstract-first vs abstract-last, two abstract signatures, abstract class with
  concrete constructor overloads, parameter-property signatures, non-contiguous
  runs (one `TS2390` per contiguous run, matching `tsc`), signature-then-method.
  Class binders varied so no fix keys on a name. All pass.
- **Direct `tsc@6.0.2` differential** across a 15-case constructor matrix: every
  `TS2390` count matches `tsc`.
- **Conformance compare-to-parent** (`tsz-conformance` against the checked-in
  `tsc-cache-full.json`, 12043 runnable tests, `--workers 12`): parent PASS =
  11581, this branch PASS = 11581 — **0 regressions, 0 improvements**, parity
  floor held exactly. (Deterministic across two runs; the change is a strict
  no-op for any class without bodyless constructor overload signatures.)
- Related suites hold: `overload_modifier_tests`,
  `abstract_constructor_argument_tests`,
  `abstract_constructor_elaboration_tests`,
  `abstract_parameter_property_impl_tests`,
  `abstract_method_overload_ts2416_tests`,
  `accessor_missing_body_modifier_suppression_tests`,
  `class_member_modifier_ts2687_tests`.

Not in scope: `TS2512` ("Overload signatures must all be abstract or
non-abstract") is still not emitted for constructors — a distinct check, noted
in #17160 for a separate follow-up.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01MPtKmgp1rEqKTgbgs3Wydv

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPtKmgp1rEqKTgbgs3Wydv)_