### PR TITLE
fix(solver): promote missing-property failures against readonly array targets to TS2740 (#17154)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2568,6 +2568,10 @@ name = "call_argument_bound_type_parameter_missing_property_promotion_tests"
 path = "tests/call_argument_bound_type_parameter_missing_property_promotion_tests.rs"
 
 [[test]]
+name = "call_argument_readonly_array_missing_property_promotion_tests"
+path = "tests/call_argument_readonly_array_missing_property_promotion_tests.rs"
+
+[[test]]
 name = "type_param_pick_subset_assignability_tests"
 path = "tests/type_param_pick_subset_assignability_tests.rs"
 

--- a/crates/tsz-checker/tests/call_argument_readonly_array_missing_property_promotion_tests.rs
+++ b/crates/tsz-checker/tests/call_argument_readonly_array_missing_property_promotion_tests.rs
@@ -1,0 +1,229 @@
+//! Missing-property promotion when the target is a `readonly T[]` /
+//! `ReadonlyArray<T>` array type (#17154).
+//!
+//! Structural rule: when an object value that is missing the array surface is
+//! assigned to — or passed as a call argument to a parameter of — an array
+//! type, tsc promotes the failure to TS2740 (many missing properties), naming
+//! the array's members. This holds for the mutable `Array<T>` surface and,
+//! symmetrically, for the readonly surface: a `readonly T[]` / `ReadonlyArray<T>`
+//! target carries the same members MINUS the mutating methods
+//! (`push`/`pop`/`shift`/`unshift`/`splice`/`sort`/`reverse`/`fill`/`copyWithin`),
+//! so its missing list is `length, concat, join, slice, ...` — never `push`/`pop`.
+//!
+//! Root cause: the object-source-vs-array-target arm of the solver's failure
+//! explainer peeled only a *mutable* `Array<T>` element (`array_element_type`),
+//! so a readonly-wrapped target fell through to a bare TS2322/TS2345 head with
+//! no property list. The explainer now also peels the readonly wrapper (syntax
+//! `readonly T[]` and the `ReadonlyArray<T>` application) and, for a readonly
+//! target, strips the mutating methods from the required set so the promoted
+//! list matches tsc's readonly member set exactly.
+//!
+//! Tests vary the binder names (function / parameter / element-type spellings)
+//! and cover both the call-argument and direct-assignment paths, asserting on
+//! the promoted diagnostic *code* and that the readonly member list is used
+//! (mutating methods must NOT appear), rather than on exact type rendering.
+
+use tsz_checker::context::CheckerOptions;
+
+fn strict_diagnostics(source: &str) -> Vec<(u32, String)> {
+    let libs = tsz_checker::test_utils::load_default_lib_files();
+    tsz_checker::test_utils::check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|d| (d.code, d.message_text))
+    .collect()
+}
+
+/// A TS2740 "missing the following properties from type ..." head whose list
+/// begins with the read-only array surface and contains none of the mutating
+/// methods a `ReadonlyArray` omits.
+fn has_readonly_array_missing_head(diags: &[(u32, String)]) -> bool {
+    diags.iter().any(|(code, msg)| {
+        *code == 2740
+            && msg.contains("missing the following properties from type")
+            && msg.contains("length")
+            && msg.contains("concat")
+            && !msg.contains("push")
+            && !msg.contains("pop")
+    })
+}
+
+/// A TS2740 head whose list is the mutable array surface (includes `push`/`pop`).
+fn has_mutable_array_missing_head(diags: &[(u32, String)]) -> bool {
+    diags.iter().any(|(code, msg)| {
+        *code == 2740
+            && msg.contains("missing the following properties from type")
+            && msg.contains("push")
+            && msg.contains("pop")
+    })
+}
+
+#[test]
+fn call_argument_to_readonly_array_promotes_ts2740() {
+    let diags = strict_diagnostics(
+        r#"
+declare function accept(value: ReadonlyArray<string>): void;
+accept({});
+"#,
+    );
+    assert!(
+        has_readonly_array_missing_head(&diags),
+        "call argument `{{}}` to a `ReadonlyArray<string>` parameter should promote to \
+         TS2740 with the readonly member list; got {diags:?}"
+    );
+    assert!(
+        !diags.iter().any(|(code, _)| *code == 2345),
+        "must not fall back to a bare TS2345 head; got {diags:?}"
+    );
+}
+
+#[test]
+fn call_argument_to_readonly_array_syntax_promotes_ts2740() {
+    // `readonly T[]` syntax, renamed binders — a spelling-keyed fix would miss it.
+    let diags = strict_diagnostics(
+        r#"
+declare function take(items: readonly number[]): void;
+take({});
+"#,
+    );
+    assert!(
+        has_readonly_array_missing_head(&diags),
+        "call argument `{{}}` to a `readonly number[]` parameter should promote to TS2740 with \
+         the readonly member list; got {diags:?}"
+    );
+    assert!(
+        !diags.iter().any(|(code, _)| *code == 2345),
+        "must not fall back to a bare TS2345; got {diags:?}"
+    );
+}
+
+#[test]
+fn assignment_to_readonly_array_promotes_ts2740() {
+    // The direct-assignment path shares the same explainer and must promote too.
+    let diags = strict_diagnostics(
+        r#"
+const value: ReadonlyArray<string> = {};
+const syntax: readonly string[] = {};
+"#,
+    );
+    let promoted = diags.iter().filter(|(code, _)| *code == 2740).count();
+    assert_eq!(
+        promoted, 2,
+        "both readonly-array assignments should promote to TS2740; got {diags:?}"
+    );
+    assert!(
+        has_readonly_array_missing_head(&diags),
+        "the readonly member list must be used; got {diags:?}"
+    );
+    assert!(
+        !diags.iter().any(|(code, _)| *code == 2322),
+        "must not fall back to a bare TS2322 head; got {diags:?}"
+    );
+}
+
+#[test]
+fn readonly_array_of_object_element_promotes_ts2740() {
+    // Renamed element type; still promotes with the readonly surface.
+    let diags = strict_diagnostics(
+        r#"
+interface Point { x: number; y: number; }
+declare function plot(points: ReadonlyArray<Point>): void;
+plot({});
+"#,
+    );
+    assert!(
+        has_readonly_array_missing_head(&diags),
+        "a `ReadonlyArray<Point>` target should promote to TS2740 with the readonly member \
+         list; got {diags:?}"
+    );
+}
+
+#[test]
+fn mutable_array_target_keeps_mutable_member_list() {
+    // Guard: the readonly stripping must NOT touch a mutable `Array<T>` target,
+    // whose promoted list still includes the mutating methods.
+    let diags = strict_diagnostics(
+        r#"
+declare function push_all(xs: Array<string>): void;
+push_all({});
+const arr: string[] = {};
+"#,
+    );
+    assert!(
+        has_mutable_array_missing_head(&diags),
+        "a mutable array target must keep the mutable member list (with push/pop); got {diags:?}"
+    );
+    assert!(
+        !has_readonly_array_missing_head(&diags),
+        "a mutable array target must not use the stripped readonly list; got {diags:?}"
+    );
+}
+
+#[test]
+fn readonly_tuple_target_is_not_promoted_to_array_head() {
+    // Over-promotion guard: a readonly *tuple* target is not an array surface;
+    // tsc keeps the generic TS2345 head, so the array missing-property promotion
+    // must not fire.
+    let diags = strict_diagnostics(
+        r#"
+declare function pair(p: readonly [string, number]): void;
+pair({});
+"#,
+    );
+    assert!(
+        diags.iter().any(|(code, _)| *code == 2345),
+        "a readonly tuple target keeps the bare TS2345 head; got {diags:?}"
+    );
+    assert!(
+        !has_readonly_array_missing_head(&diags) && !has_mutable_array_missing_head(&diags),
+        "must not synthesize an array missing-property head for a tuple target; got {diags:?}"
+    );
+}
+
+#[test]
+fn readonly_array_element_mismatch_keeps_element_chain() {
+    // Over-promotion guard: when the source IS a readonly array with a mismatched
+    // element, tsc elaborates the element relation (TS2322 + inner element line),
+    // not a missing-property head.
+    let diags = strict_diagnostics(
+        r#"
+declare const src: readonly string[];
+const dst: readonly number[] = src;
+"#,
+    );
+    assert!(
+        diags.iter().any(|(code, _)| *code == 2322),
+        "an element-type mismatch on a readonly array must stay a TS2322 chain; got {diags:?}"
+    );
+    assert!(
+        !has_readonly_array_missing_head(&diags),
+        "an element mismatch must not become a missing-property head; got {diags:?}"
+    );
+}
+
+#[test]
+fn readonly_array_partial_source_lists_only_missing_members() {
+    // A source that supplies some of the array surface promotes with the
+    // remaining readonly members (still no mutating methods).
+    let diags = strict_diagnostics(
+        r#"
+declare function take(items: readonly string[]): void;
+take({ length: 1 });
+"#,
+    );
+    assert!(
+        diags.iter().any(|(code, msg)| *code == 2740
+            && msg.contains("missing the following properties from type")
+            && !msg.contains("push")
+            && !msg.contains("pop")),
+        "a partial source should promote to TS2740 listing the remaining readonly members; \
+         got {diags:?}"
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -1403,6 +1403,26 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         array_element_type(self.interner, inner)
     }
 
+    /// The element type of an array-like `target` together with whether the
+    /// target is `readonly` (`readonly T[]` syntax or a `ReadonlyArray<T>`
+    /// application). Mirrors the extraction the boolean readonly-array dispatch
+    /// performs, so the failure explainer can reach the array member surface for
+    /// readonly targets — not just mutable `Array<T>`.
+    pub(crate) fn array_or_readonly_array_element(
+        &self,
+        target: TypeId,
+        resolved_target: TypeId,
+    ) -> Option<(TypeId, bool)> {
+        if let Some(elem) = array_element_type(self.interner, resolved_target) {
+            return Some((elem, false));
+        }
+        self.readonly_array_syntax_element(resolved_target)
+            .or_else(|| self.readonly_array_application_element(resolved_target))
+            .or_else(|| self.readonly_array_syntax_element(target))
+            .or_else(|| self.readonly_array_application_element(target))
+            .map(|elem| (elem, true))
+    }
+
     pub(crate) fn type_contains_readonly_array_syntax(&self, type_id: TypeId) -> bool {
         if self.readonly_array_syntax_element(type_id).is_some() {
             return true;

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -639,9 +639,15 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             }
         }
 
-        // Object source vs array target: resolve Array<T> to its interface properties
-        // and find missing members. TSC emits TS2740 here (missing properties from array).
-        if let Some(t_elem) = array_element_type(self.interner, resolved_target) {
+        // Object source vs array target: resolve the array interface to its
+        // members and find those missing on the source. tsc emits TS2740 here.
+        // Both the mutable `Array<T>` surface and the `readonly T[]` /
+        // `ReadonlyArray<T>` surface (the mutable set minus its mutating methods)
+        // are handled; without the readonly peel the readonly target previously
+        // fell through to a bare TS2322/TS2345.
+        if let Some((t_elem, target_readonly)) =
+            self.array_or_readonly_array_element(target, resolved_target)
+        {
             let s_shape_id = object_shape_id(self.interner, resolved_source)
                 .or_else(|| object_with_index_shape_id(self.interner, resolved_source));
             if let Some(s_sid) = s_shape_id
@@ -655,33 +661,36 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     instantiate_type(self.interner, array_base, &subst)
                 };
                 let resolved_inst = self.resolve_lazy_type(instantiated);
-                // The Array interface may resolve to an object shape or a callable shape
-                // (with properties like length, push, concat, etc.)
+                // The Array interface may resolve to an object shape or a callable
+                // shape (with properties like length, push, concat, etc.).
                 let s_shape = self.interner.object_shape(s_sid);
-                if let Some(t_obj_sid) = object_shape_id(self.interner, resolved_inst)
+                let target_props = object_shape_id(self.interner, resolved_inst)
                     .or_else(|| object_with_index_shape_id(self.interner, resolved_inst))
-                {
-                    let t_shape = self.interner.object_shape(t_obj_sid);
+                    .map(|sid| self.interner.object_shape(sid).properties.clone())
+                    .or_else(|| {
+                        callable_shape_id(self.interner, resolved_inst).and_then(|sid| {
+                            let callable = self.interner.callable_shape(sid);
+                            (!callable.properties.is_empty()).then(|| callable.properties.clone())
+                        })
+                    });
+                if let Some(mut target_props) = target_props {
+                    // A readonly-array target omits the mutating methods, so they
+                    // are never "missing" — strip them to match tsc's readonly
+                    // member list (the mutable arm keeps the full surface).
+                    if target_readonly {
+                        target_props.retain(|p| {
+                            !crate::operations::property::property_helpers::is_array_mutating_method(
+                                self.interner.resolve_atom_ref(p.name).as_ref(),
+                            )
+                        });
+                    }
                     return self.explain_object_failure(
                         source,
                         target,
                         &s_shape.properties,
                         Some(s_sid),
-                        &t_shape.properties,
+                        &target_props,
                     );
-                }
-                // Array interface resolved to a callable shape — use its properties
-                if let Some(callable_sid) = callable_shape_id(self.interner, resolved_inst) {
-                    let callable = self.interner.callable_shape(callable_sid);
-                    if !callable.properties.is_empty() {
-                        return self.explain_object_failure(
-                            source,
-                            target,
-                            &s_shape.properties,
-                            Some(s_sid),
-                            &callable.properties,
-                        );
-                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes #17154.

Structural rule: when an object value missing the array surface is assigned to — or passed as a call argument to a parameter of — an array type, tsc promotes the failure to **TS2740** naming the array's members. This held for the mutable `Array<T>` surface but not for the readonly surface: a `readonly T[]` / `ReadonlyArray<T>` target fell through to a bare **TS2322** (assignment) / **TS2345** (call) head with no property list. Owner layer: the solver failure explainer (`crates/tsz-solver/src/relations/subtype/explain.rs`).

The issue reported the call-argument shape; the same gap also dropped the promotion on the **direct-assignment** path, since both consume the shared `explain_failure` reason — so this is fixed broadly, not just for the reported witness.

### Root cause
The object-source-vs-array-target arm of `explain_failure` peeled only a *mutable* `Array<T>` element via `array_element_type`, which does not see a readonly wrapper (`Readonly(Array<T>)` syntax or a `ReadonlyArray<T>` application). The readonly target therefore never reached the missing-property enumeration and the reason stayed a generic `TypeMismatch`.

### Fix
- Extract `array_or_readonly_array_element` (`relations/subtype/core.rs`), which also peels the readonly element via the existing `readonly_array_syntax_element` / `readonly_array_application_element` helpers, returning a `target_readonly` flag.
- For a readonly target, strip the mutating methods (`push`/`pop`/`shift`/`unshift`/`splice`/`sort`/`reverse`/`fill`/`copyWithin`) from the required member set via the canonical `is_array_mutating_method` predicate, so the promoted list matches tsc's readonly member set exactly (`length, concat, join, slice, and 19 more`, not the mutable `length, pop, push, concat, and 28 more`). This mirrors the boolean subtype dispatch, which already treats those methods as satisfied on a readonly-array target.
- No fixture/name/text checks: the decision is structural (readonly-array shape + the canonical mutating-method predicate), and the member list is the real instantiated interface surface.

### Oracle parity (pinned tsc 7.0.2)
| case | before | after / tsc |
| --- | --- | --- |
| call arg `ReadonlyArray<string>` | TS2345 (bare) | **TS2740** `length, concat, join, slice, and 19 more` |
| assignment `ReadonlyArray<string>` | TS2322 (bare) | **TS2740** (same) |
| call arg `readonly string[]` | TS2345 (bare) | **TS2740** (same) |
| call arg / assignment `string[]` (mutable) | TS2740 ✓ | **TS2740** `length, pop, push, concat, and 28 more` (unchanged) |
| `readonly [string, number]` (tuple) | TS2345 | TS2345 (unchanged — not an array surface) |
| `readonly string[]` vs `readonly number[]` (element mismatch) | TS2322 chain | TS2322 chain (unchanged) |

## Goal
Goal: green

## Verification
- New suite `crates/tsz-checker/tests/call_argument_readonly_array_missing_property_promotion_tests.rs` (8 tests): call-argument + assignment promotion for `ReadonlyArray<T>` and `readonly T[]`, object-element target, mutable-target guard (keeps push/pop), readonly-tuple over-promotion guard, element-mismatch guard (stays TS2322 chain), partial-source list. Binder names varied.
- `cargo test -p tsz-solver --lib` — 7658 passed.
- `cargo test -p tsz-checker` array/ts2322/promotion suites — pass (`ts2322_tests`, `extends_readonly_array_assignability_tests`, `conditional_extends_readonly_variance_tests`, `array_subclass_inheritance_tests`, `call_argument_bound_type_parameter_missing_property_promotion_tests`, etc.).
- `cargo clippy -p tsz-solver` — clean; `scripts/arch/arch_guard.py` — green.
- Conformance / emit / fourslash: deferred to CI's nightly lane (TypeScript corpus/baselines not checked out locally). Kept **draft** until CI validates.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJ2Tppcd4cFw7FvJhXj6cy)_