### PR TITLE
fix(checker): re-resolve bare import-type type arguments through the canonical import path (#17158)

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/core.rs
+++ b/crates/tsz-checker/src/state/type_resolution/core.rs
@@ -5,6 +5,7 @@ use crate::query_boundaries::state::type_resolution as query;
 use crate::state::CheckerState;
 use crate::symbol_resolver::TypeSymbolResolution;
 use tsz_binder::symbol_flags;
+use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::{NodeIndex, NodeList, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
@@ -60,6 +61,29 @@ impl CheckerState<'_> {
     }
 
     fn type_arg_needs_checker_resolution(&self, arg_idx: NodeIndex) -> bool {
+        // A *bare* `import("mod").X` type argument (no type arguments of its own)
+        // must be re-resolved by the checker. `TypeLowering`, which lowered the
+        // generic base, cannot perform module resolution: it binds the
+        // import-type qualifier through the syntactic `resolve_def_id` path to
+        // the *defining* file's arena-local instance. A direct checker reference
+        // instead routes through `check_import_type_and_resolve`, yielding the
+        // importing file's canonical instance. Left as the lowered form the two
+        // diverge — a structurally-equal but non-identical instance — and an
+        // identity-keyed decision goes wrong: a conditional `T extends X ? _ : _`
+        // instantiated with `import("mod").X` compares the stale build against
+        // the canonical reference of a plain `X` in the extends clause, reads the
+        // relation as undetermined, and stays deferred as `boolean`.
+        //
+        // Restricted to bare references on purpose. A *generic* import-type
+        // application (`import("mod").Wrap<A>`) keeps both the extends operand
+        // (resolved via the conditional body's `collect_import_type_overrides`
+        // pass) and the argument on the same lowering-based identity, so they
+        // already agree; re-resolving only the argument through a different path
+        // would instead introduce a divergence in the `infer`-matching base.
+        if self.type_arg_contains_bare_import_type(arg_idx, 0) {
+            return true;
+        }
+
         let Some(type_lit) = self
             .ctx
             .arena
@@ -77,6 +101,36 @@ impl CheckerState<'_> {
                 .and_then(|sig| self.ctx.arena.get(sig.name))
                 .is_some_and(|name| name.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME)
         })
+    }
+
+    /// Whether the type node subtree rooted at `idx` contains a bare
+    /// `TYPE_REFERENCE` whose `type_name` roots in an `import(...)` call and
+    /// carries no type arguments of its own (`import("mod").X`,
+    /// `import("mod").A.B`, or such a reference nested inside another type
+    /// argument like `LocalBox<import("mod").X>`). Bounded to match the
+    /// codebase's AST-walker depth convention.
+    fn type_arg_contains_bare_import_type(&self, idx: NodeIndex, depth: u32) -> bool {
+        if depth > 64 {
+            return false;
+        }
+        let Some(node) = self.ctx.arena.get(idx) else {
+            return false;
+        };
+        if node.kind == syntax_kind_ext::TYPE_REFERENCE
+            && let Some(type_ref) = self.ctx.arena.get_type_ref(node)
+            && type_ref
+                .type_arguments
+                .as_ref()
+                .is_none_or(|args| args.nodes.is_empty())
+            && self.find_leftmost_import_call(type_ref.type_name).is_some()
+        {
+            return true;
+        }
+        self.ctx
+            .arena
+            .get_children(idx)
+            .into_iter()
+            .any(|child_idx| self.type_arg_contains_bare_import_type(child_idx, depth + 1))
     }
 
     /// Get type from a type reference node (e.g., "number", "string", "`MyType`").

--- a/scripts/ci/known-failures.txt
+++ b/scripts/ci/known-failures.txt
@@ -122,10 +122,10 @@
 # other two). Fixed by migrating both test files to
 # `check_multi_file_with_libs_unique_module_locals`, same as the 2026-08-06
 # kysely fix above. `import_type_extends_structural_match_no_false_positive`
-# stays listed: it reproduces the identical `boolean`-vs-`true` mismatch even
-# after the helper swap, and reproduces through the real `tsz` CLI binary too
-# (no test-harness collision involved) — a genuine cross-file import-type
-# identity gap in conditional-type evaluation. Filed as #17158.
+# (#17158) is now fixed and delisted: a bare `import("mod").X` type argument is
+# re-resolved through the checker's canonical import path instead of keeping the
+# `TypeLowering` cross-arena re-mint, so it shares identity with a plain `X`
+# reference and the conditional branch selects correctly.
 tsz-checker::commonjs_module_export_alias_tests::test_module_exports_forward_read_reports_ts2565
 tsz-checker::conditional_application_display_tests::deferred_generic_conditional_keeps_branch_union
 tsz-checker::conformance_issues_features::features::namespace_construct_signature::part_00::test_js_void_zero_expando_reports_named_receiver_type
@@ -141,7 +141,6 @@ tsz-checker::cross_module_nested_interface_tests::test_workspace_property_type_r
 tsz-checker::generic_call_assignment_flow_tests::colliding_generic_terminals_keep_flow_diagnostics_clean_across_file_orders
 tsz-checker::generic_call_assignment_flow_tests::imported_generic_result_narrows_inside_reduce_arrow
 tsz-checker::generic_generator_member_substitution_tests::generic_generator_genuine_mismatch_still_errors_with_substituted_source
-tsz-checker::import_type_utility_identity_tests::import_type_extends_structural_match_no_false_positive
 tsz-checker::issue_14123_repro_tests::issue_14123_alias_array_infer_reports_mismatch
 tsz-checker::js_export_surface_tests::part_01::test_current_file_exports_reads_use_prior_assignment_types
 tsz-checker::js_export_surface_tests::part_01::test_current_file_module_exports_reads_use_prior_assignment_types


### PR DESCRIPTION
A conditional `type IsBox<T> = T extends Box ? true : false` instantiated with `IsBox<import("./module").Box>` produced `boolean` where `tsc` collapses to `true` (false-positive TS2322 on the downstream `const t1Check: true = t1`).

**Structural rule:** when a type argument is written as the type-position import qualifier `import("./mod").X` and `X` is a bare (non-generic) type-forming declaration, `tsc` resolves it to the same type identity as a plain reference to `X`; tsz must do the same through the checker's canonical import path, not the lowering-based cross-arena re-mint.

**Root cause:** when a generic reference's type arguments are lowered, `TypeLowering` cannot perform module resolution, so it binds an `import("mod").X` argument through the syntactic `resolve_def_id` path to the *defining* file's arena-local class-instance build. A plain reference to the same class instead resolves to the importing file's canonical instance. The two are structurally equal but not identical — invisible to structural assignability, but fatal to identity-keyed decisions: the conditional's branch relation compared the stale cross-arena instance (`Object(105)`) against the still-unmaterialized canonical `Lazy(Box)` of the plain `Box` in the extends clause, read the relation as *undetermined* (unresolved-`Lazy` sentinel), and left the conditional deferred as `boolean`.

**Fix / owner layer:** `rebuild_application_with_checker_type_args` already re-resolves selected type-argument slots through the checker; its gate `type_arg_needs_checker_resolution` (checker, `crates/tsz-checker/src/state/type_resolution/core.rs`) only recognized computed-name type literals. It now also recognizes a *bare* `import("mod").X` argument — including one nested inside another argument (`LocalBox<import("mod").X>`) — so the slot is re-resolved through `check_import_type_and_resolve` and shares identity with a plain reference. The branch then selects correctly.

**Scope / adjacent matrix:**
- `IsBox<import("mod").Box>` with a regular `Box` extends clause (the report) → now `true`.
- `IsBox<{ unrelated }>` false-branch case → stays `false`.
- `keyof import("mod").Box`, `typeof import("mod").fn` (Parameters/ReturnType) → unaffected, still green.
- Generic import-type application `import("mod").Wrap<A>` / `Wrap<infer U>` in a conditional → **intentionally left on the lowering-based path**: both the extends operand (resolved via the conditional body's `collect_import_type_overrides` pass) and the argument already agree there; re-resolving only the argument through a different path would diverge the `infer`-matching base. The bare-only gate preserves those cases.

Fully unifying the two import-type resolution paths (delegate vs. current-context) is a larger refactor; this change closes the reported identity gap without disturbing the already-consistent generic path.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test import_type_utility_identity_tests` → **7 passed / 0 failed** (previously the target row `import_type_extends_structural_match_no_false_positive` failed and was known-listed; delisted here).
- Repro through the real CLI binary (`tsz --strict main.ts`) → no diagnostics (was `TS2322: Type 'boolean' is not assignable to type 'true'`).
- `cargo test -p tsz-checker --test import_type_ambient_module_member_tests --test cross_module_nested_interface_tests --test conditional_application_display_tests` → only the pre-existing known failure `deferred_generic_conditional_keeps_branch_union` (unchanged).
- Pre-commit hook: clippy + arch-size + local verification passed.
- Conformance/emit/fourslash not yet run locally in this session; relying on the nightly gates.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ngjq5zH8Cbu6Gqvwd7jfK4)_