### PR TITLE
fix(checker): TS-syntax import(...).Member resolves CommonJS expando class exports

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -672,6 +672,9 @@ mod ts18048_unary_arithmetic_nullish_tests;
 #[path = "../tests/ts7032_zero_parameter_setter_tests.rs"]
 mod ts7032_zero_parameter_setter_tests;
 #[cfg(test)]
+#[path = "../tests/ts_import_type_commonjs_expando_class_tests.rs"]
+mod ts_import_type_commonjs_expando_class_tests;
+#[cfg(test)]
 #[path = "../tests/variadic_tuple_elaboration_tests.rs"]
 mod variadic_tuple_elaboration_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/js_exports.rs
+++ b/crates/tsz-checker/src/query_boundaries/js_exports.rs
@@ -1584,7 +1584,7 @@ impl<'a> CheckerState<'a> {
         Some((ctor_name, member_name))
     }
 
-    fn commonjs_named_export_class_symbol_for_file(
+    pub(crate) fn commonjs_named_export_class_symbol_for_file(
         &self,
         target_file_idx: usize,
         export_name: &str,

--- a/crates/tsz-checker/src/query_boundaries/js_exports.rs
+++ b/crates/tsz-checker/src/query_boundaries/js_exports.rs
@@ -1589,6 +1589,13 @@ impl<'a> CheckerState<'a> {
         target_file_idx: usize,
         export_name: &str,
     ) -> Option<(SymbolId, usize)> {
+        // A file with ESM syntax is not a CommonJS module: `module.exports.X`
+        // there is an ordinary property write, not an export, so tsc keeps
+        // reporting the member as missing (TS2694).
+        if self.source_file_idx_has_esm_syntax(target_file_idx) {
+            return None;
+        }
+
         let target_arena = self.ctx.get_arena_for_file(target_file_idx as u32);
         let target_binder = self.ctx.get_binder_for_file(target_file_idx)?;
         let source_file = target_arena.source_files.first()?;

--- a/crates/tsz-checker/src/state/type_resolution/import_type.rs
+++ b/crates/tsz-checker/src/state/type_resolution/import_type.rs
@@ -188,6 +188,22 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        // A CommonJS expando export (`module.exports.Member = Member` /
+        // `exports.Member = Member`) records no `SymbolId` in the binder's
+        // export tables — those only track ES `export` syntax — so none of
+        // the lookups above see it. When the target is a JS module and the
+        // expando RHS is a class declaration's own identifier, the exported
+        // member carries type meaning: resolve it through the synthesized JS
+        // export surface, mirroring the JSDoc `import(...).Member` path.
+        // The same-shaped assignment inside a TS file is not an export
+        // (tsc keeps TS2694 there), hence the JS-file gate.
+        if crate::context::is_js_file_name(&target_file_name)
+            && let Some((sym_id, _)) =
+                self.commonjs_named_export_class_symbol_for_file(target_file_idx, member_name)
+        {
+            return record_and_return(sym_id);
+        }
+
         None
     }
 

--- a/crates/tsz-checker/tests/ts_import_type_commonjs_expando_class_tests.rs
+++ b/crates/tsz-checker/tests/ts_import_type_commonjs_expando_class_tests.rs
@@ -180,6 +180,32 @@ type X = import('./modf').bar;
 }
 
 #[test]
+fn ts_import_type_alias_expando_class_in_esm_js_file_still_reports_ts2694() {
+    // Negative control for the CommonJS gate: a JS file with ESM syntax is
+    // not a CommonJS module, so `module.exports.C = C` there is an ordinary
+    // property write, not an export — tsc keeps TS2694 (oracle-verified on
+    // typescript@7.0.2).
+    let diagnostics = check_ts_consumer_with_module_source(
+        "mixed.js",
+        r#"
+export const other = 1;
+class C {
+    s() {}
+}
+module.exports.C = C
+"#,
+        r#"
+type X = import('./mixed').C;
+"#,
+    );
+    assert!(
+        !diagnostics_with_code(&diagnostics, 2694).is_empty(),
+        "Expected TS2694 for an expando-shaped assignment inside an ESM-syntax JS file, \
+         got: {diagnostics:?}"
+    );
+}
+
+#[test]
 fn ts_import_type_alias_expando_class_in_ts_file_still_reports_ts2694() {
     // Negative control for the JS gate: the same expando-shaped assignment in
     // a TS module is not an export (tsc keeps TS2694; the assignment itself

--- a/crates/tsz-checker/tests/ts_import_type_commonjs_expando_class_tests.rs
+++ b/crates/tsz-checker/tests/ts_import_type_commonjs_expando_class_tests.rs
@@ -1,0 +1,206 @@
+//! Tests for TS-syntax `type X = import("./mod").Member` references to
+//! CommonJS expando class exports (`module.exports.Member = Member` /
+//! `exports.Member = Member`).
+//!
+//! Structural rule (oracle: typescript@7.0.2): a CommonJS expando assignment
+//! records no SymbolId in the binder's syntactic export tables — those only
+//! track ES `export` syntax. When the target is a JS module and the expando
+//! RHS is a class declaration's own identifier, the exported member carries
+//! type meaning, so the import-type reference resolves to the class instance
+//! type instead of reporting TS2694. A plain function expando export stays
+//! value-only (TS2694), and the same-shaped assignment inside a TS file is
+//! not an export at all (TS2694 stays). Mirrors the JSDoc-path fix from
+//! #17167 on the TS-syntax alias resolver.
+
+use crate::context::CheckerOptions;
+use crate::state::CheckerState;
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::sync::Arc;
+use tsz_binder::BinderState;
+use tsz_common::diagnostics::Diagnostic;
+use tsz_parser::parser::ParserState;
+use tsz_solver::construction::TypeInterner;
+
+fn local_module_specifiers(file_name: &str) -> Vec<String> {
+    let base = file_name
+        .rsplit('/')
+        .next()
+        .unwrap_or(file_name)
+        .rsplit('\\')
+        .next()
+        .unwrap_or(file_name);
+    let mut specs = vec![format!("./{base}")];
+    for suffix in [
+        ".d.ts", ".d.tsx", ".d.mts", ".d.cts", ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx",
+        ".mjs", ".cjs",
+    ] {
+        if let Some(stem) = base.strip_suffix(suffix) {
+            specs.push(format!("./{stem}"));
+            break;
+        }
+    }
+    specs
+}
+
+fn check_ts_consumer_with_module_source(
+    module_name: &str,
+    module_source: &str,
+    consumer_source: &str,
+) -> Vec<Diagnostic> {
+    let options = CheckerOptions {
+        allow_js: true,
+        check_js: true,
+        ..Default::default()
+    };
+
+    let mut parser_module = ParserState::new(module_name.to_string(), module_source.to_string());
+    let root_module = parser_module.parse_source_file();
+    let mut binder_module = BinderState::new();
+    binder_module.bind_source_file(parser_module.get_arena(), root_module);
+
+    let consumer_name = "consumer.ts";
+    let mut parser_consumer =
+        ParserState::new(consumer_name.to_string(), consumer_source.to_string());
+    let root_consumer = parser_consumer.parse_source_file();
+    let mut binder_consumer = BinderState::new();
+    binder_consumer.bind_source_file(parser_consumer.get_arena(), root_consumer);
+
+    let arena_module = Arc::new(parser_module.get_arena().clone());
+    let arena_consumer = Arc::new(parser_consumer.get_arena().clone());
+    let all_arenas = Arc::new(vec![Arc::clone(&arena_module), Arc::clone(&arena_consumer)]);
+
+    let binder_module = Arc::new(binder_module);
+    let binder_consumer = Arc::new(binder_consumer);
+    let all_binders = Arc::new(vec![
+        Arc::clone(&binder_module),
+        Arc::clone(&binder_consumer),
+    ]);
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        arena_consumer.as_ref(),
+        binder_consumer.as_ref(),
+        &types,
+        consumer_name.to_string(),
+        options,
+    );
+    checker.ctx.set_all_arenas(all_arenas);
+    checker.ctx.set_all_binders(all_binders);
+    checker.ctx.set_current_file_idx(1);
+    checker.ctx.set_lib_contexts(Vec::new());
+
+    let mut resolved_module_paths: FxHashMap<(usize, String), usize> = FxHashMap::default();
+    let mut resolved_modules: FxHashSet<String> = FxHashSet::default();
+    for specifier in local_module_specifiers(module_name) {
+        resolved_module_paths.insert((1, specifier.clone()), 0);
+        resolved_modules.insert(specifier);
+    }
+    checker
+        .ctx
+        .set_resolved_module_paths(Arc::new(resolved_module_paths));
+    checker.ctx.set_resolved_modules(resolved_modules);
+
+    checker.check_source_file(root_consumer);
+    checker.ctx.diagnostics
+}
+
+fn diagnostics_with_code(diagnostics: &[Diagnostic], code: u32) -> Vec<&Diagnostic> {
+    diagnostics.iter().filter(|d| d.code == code).collect()
+}
+
+#[test]
+fn ts_import_type_alias_resolves_module_exports_expando_class() {
+    let diagnostics = check_ts_consumer_with_module_source(
+        "types.js",
+        r#"
+class C {
+    s() {}
+}
+module.exports.C = C
+"#,
+        r#"
+type X = import('./types.js').C;
+declare const c: X;
+c.s();
+"#,
+    );
+    assert!(
+        diagnostics.is_empty(),
+        "Expected no diagnostics for a `module.exports.C = C` expando class export \
+         referenced as `import(...).C`, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn ts_import_type_alias_resolves_bare_exports_expando_class_renamed_binder() {
+    // Adjacent case: the short `exports.X = X` form (no `module.` prefix),
+    // extensionless specifier, and a differently named binder — the fix must
+    // not depend on the identifier `C` or the `module.exports.` spelling.
+    let diagnostics = check_ts_consumer_with_module_source(
+        "widget.js",
+        r#"
+class Widget {
+    render() {}
+}
+exports.Widget = Widget
+"#,
+        r#"
+type W = import('./widget').Widget;
+declare const w: W;
+w.render();
+"#,
+    );
+    assert!(
+        diagnostics.is_empty(),
+        "Expected no diagnostics for an `exports.Widget = Widget` expando class export \
+         referenced as `import(...).Widget`, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn ts_import_type_alias_expando_function_export_still_reports_ts2694() {
+    // Negative control: an expando export whose RHS is a plain function is
+    // value-only — TS7 dropped constructor-function inference, so the bare
+    // type-position reference must still report TS2694.
+    let diagnostics = check_ts_consumer_with_module_source(
+        "modf.js",
+        r#"
+function bar() {}
+module.exports.bar = bar
+"#,
+        r#"
+type X = import('./modf').bar;
+"#,
+    );
+    assert!(
+        !diagnostics_with_code(&diagnostics, 2694).is_empty(),
+        "Expected TS2694 for a value-only `module.exports.bar = bar` function export, \
+         got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn ts_import_type_alias_expando_class_in_ts_file_still_reports_ts2694() {
+    // Negative control for the JS gate: the same expando-shaped assignment in
+    // a TS module is not an export (tsc keeps TS2694; the assignment itself
+    // only draws a "cannot find name 'module'" error in the target file), so
+    // the fallback must not resolve through it.
+    let diagnostics = check_ts_consumer_with_module_source(
+        "types.ts",
+        r#"
+export {};
+class C {
+    s() {}
+}
+module.exports.C = C
+"#,
+        r#"
+type X = import('./types').C;
+"#,
+    );
+    assert!(
+        !diagnostics_with_code(&diagnostics, 2694).is_empty(),
+        "Expected TS2694 for an expando-shaped assignment inside a TS target file, \
+         got: {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
Follow-up to #17167, picking up ClaudeDE's handoff NOTE on the coordination board (#15994): the TS-syntax `type X = import("./mod").Member` alias resolver had the same CommonJS expando-export gap that #17167 fixed for the JSDoc `import(...).Member` path.

Structural rule: when a TS-syntax import-type member reference names a CommonJS expando class export (`module.exports.C = C` / `exports.C = C` in a JS module, RHS being a class declaration's own identifier), tsc resolves the member through the same export surface used for value access; tsz now does the same through the `commonjs_named_export_class_symbol_for_file` query-boundary helper, wired as the last fallback in `resolve_ts_import_type_member_symbol` (checker symbol resolution, `state/type_resolution/import_type.rs`). The fallback is gated to JS target files: the same-shaped assignment inside a TS file is not an export, so TS2694 stays.

Hardening found while writing the adjacent matrix (oracle-verified): a JS file with ESM syntax is not a CommonJS module either — `module.exports.C` there is an ordinary property write, and tsc keeps TS2694. The shared helper now returns `None` for ESM-syntax target files, which also hardens the landed JSDoc path (#17167) at the owning layer.

All three consumers of the resolver are covered by the one fallback: the TS2694 missing-member context (`import_type_missing_member_context`), the type resolution itself (`resolve_import_type_reference`), and the TS2344 target-symbol query (`resolve_import_type_target_symbol`).

Adjacent-case matrix (all oracle-verified against typescript@7.0.2 with `--allowJs --checkJs`):
- `module.exports.C = C` class expando, `type X = import('./types.js').C` — resolves, instance members usable (was false-positive TS2694).
- Bare `exports.Widget = Widget` form, extensionless specifier, renamed binder — resolves.
- Negative: `module.exports.bar = bar` function expando — still TS2694 (value-only; TS7 dropped constructor-function inference).
- Negative (JS gate): same expando shape inside a TS target file — still TS2694.
- Negative (CommonJS gate): expando shape inside an ESM-syntax JS file — still TS2694.

## Goal
Goal: hold

## Verification
- Red-before-fix demonstrated against parent `aa04356`: the two positive tests fail with the false-positive TS2694, both negative controls pass (2 failed / 2 passed); green after the fix: 5/5 in `ts_import_type_commonjs_expando_class_tests`.
- Related families: `cargo test -p tsz-checker --lib -- ts_import_type_commonjs_expando jsdoc_typedef_module_export import_type ts2694 commonjs jsdoc` — 672 passed, 0 failed.
- `cargo fmt --all -- --check` clean; `cargo clippy --profile ci-lint -p tsz-checker --lib --tests -- -D warnings` clean (matches CI's ci-lint lane on the affected crate).
- Conformance note: the change only converts a previously-failing resolution (`None`) into a hit for the narrow JS-CommonJS-expando-class shape, plus the new ESM gate on the shared helper; the stale committed `conformance-detail.json` shows no failing row in this exact family. Zero corpus movement is the expected signature for this class of fix (board precedent: #16016/#16020/#16039/#16270); the oracle-pinned targeted matrix above is the primary evidence.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: medium
AgentName: Wozniak

https://claude.ai/code/session_014LhbjWewmNWMmn3ZhdvjHv

---
_Generated by [Claude Code](https://claude.ai/code/session_014LhbjWewmNWMmn3ZhdvjHv)_