### PR TITLE
fix(checker): suppress TS2391 when a method overload group's last signature is abstract

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2884,3 +2884,6 @@ path = "tests/ts2694_typeof_import_qualified_type_only_member_tests.rs"
 [[test]]
 name = "constructor_implementation_missing_ts2390_tests"
 path = "tests/constructor_implementation_missing_ts2390_tests.rs"
+[[test]]
+name = "abstract_method_overload_ts2391_suppression_tests"
+path = "tests/abstract_method_overload_ts2391_suppression_tests.rs"

--- a/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
@@ -1268,8 +1268,16 @@ impl<'a> CheckerState<'a> {
                             // group with the same name, so skip ahead to find it.
                             let method_name = self.get_method_name_from_node(member_idx);
                             if let Some(name) = method_name {
-                                // Advance past consecutive bodyless method overloads with the same name.
+                                // Advance past consecutive bodyless method overloads with the same name,
+                                // tracking whether the LAST one is `abstract` as we go. tsc suppresses
+                                // the missing-implementation diagnostic when the group's last signature
+                                // is abstract — an abstract member needs no implementation, exactly like
+                                // the constructor arm above (`abstract m(x: string): void;` after a
+                                // non-abstract overload reports only TS2512, never TS2391). The starting
+                                // member here is always non-abstract (gated above), so a group with no
+                                // abstract siblings keeps reporting as before.
                                 let mut last_overload_i = i;
+                                let mut last_is_abstract = false;
                                 let mut j = i + 1;
                                 while j < members.len() {
                                     let next_idx = members[j];
@@ -1284,6 +1292,8 @@ impl<'a> CheckerState<'a> {
                                         let next_name = self.get_method_name_from_node(next_idx);
                                         if next_name.as_deref() == Some(name.as_str()) {
                                             last_overload_i = j;
+                                            last_is_abstract =
+                                                self.has_abstract_modifier(&next_method.modifiers);
                                             j += 1;
                                             continue;
                                         }
@@ -1304,7 +1314,7 @@ impl<'a> CheckerState<'a> {
 
                                 let (has_impl, impl_name, impl_idx) =
                                     self.find_method_impl(members, last_overload_i + 1, &name);
-                                if !has_impl {
+                                if !has_impl && !last_is_abstract {
                                     self.error_at_node(
                                         report_error_node,
                                         "Function implementation is missing or not immediately following the declaration.",

--- a/crates/tsz-checker/tests/abstract_method_overload_ts2391_suppression_tests.rs
+++ b/crates/tsz-checker/tests/abstract_method_overload_ts2391_suppression_tests.rs
@@ -1,0 +1,96 @@
+//! Regression tests: TS2391 ("Function implementation is missing or not
+//! immediately following the declaration.") must be suppressed when the LAST
+//! bodyless signature in a method overload group carries the `abstract`
+//! modifier — mirroring the constructor-overload rule already covered by
+//! `constructor_implementation_missing_ts2390_tests.rs`. An abstract member
+//! needs no implementation, so a group that *ends* abstract reports only
+//! TS2512 ("Overload signatures must all be abstract or non-abstract."), not
+//! TS2391 as well.
+//!
+//! tsz previously included abstract siblings in the same-name group scan but
+//! never checked whether the group's last member was abstract before
+//! reporting TS2391, so `m(x: number): void; abstract m(x: string): void;`
+//! in an abstract class produced a spurious TS2391 alongside the correct
+//! TS2512.
+//!
+//! Verified against the pinned `typescript@7.0.2` oracle
+//! (`--noEmit --pretty false --strict`). Binder names are varied so no fix
+//! can key on a specific identifier.
+
+use tsz_checker::test_utils::check_source_code_messages as get_diagnostics;
+
+const TS2391: u32 = 2391;
+const TS2512: u32 = 2512;
+
+fn count(source: &str, code: u32) -> usize {
+    get_diagnostics(source)
+        .iter()
+        .filter(|d| d.0 == code)
+        .count()
+}
+
+/// Non-abstract overload followed by an abstract last signature: tsc reports
+/// only TS2512, TS2391 is suppressed.
+#[test]
+fn non_abstract_then_abstract_last_suppresses_ts2391() {
+    let source =
+        "abstract class Widget {\n  run(x: number): void;\n  abstract run(x: string): void;\n}\n";
+    assert_eq!(
+        count(source, TS2391),
+        0,
+        "abstract last overload suppresses TS2391"
+    );
+    assert_eq!(count(source, TS2512), 1);
+}
+
+/// Same shape with three signatures: two non-abstract, then abstract last —
+/// still exactly one TS2512, zero TS2391.
+#[test]
+fn two_non_abstract_then_abstract_last_suppresses_ts2391() {
+    let source = "abstract class Sprocket {\n  build(x: number): void;\n  build(x: string): void;\n  abstract build(x: boolean): void;\n}\n";
+    assert_eq!(count(source, TS2391), 0);
+    assert_eq!(count(source, TS2512), 1);
+}
+
+/// Abstract-first, non-abstract-last is the mirror shape: TS2391 still fires
+/// (the group's LAST signature decides, not the first) alongside TS2512.
+#[test]
+fn abstract_first_non_abstract_last_still_reports_ts2391() {
+    let source = "abstract class Gadget {\n  abstract render(x: number): void;\n  render(x: string): void;\n}\n";
+    assert_eq!(
+        count(source, TS2391),
+        1,
+        "non-abstract last overload still needs an implementation"
+    );
+    assert_eq!(count(source, TS2512), 1);
+}
+
+/// A group with no abstract member at all is unaffected: TS2391 still fires
+/// normally when no implementation follows.
+#[test]
+fn no_abstract_member_still_reports_ts2391() {
+    let source =
+        "abstract class Plain {\n  compute(x: number): void;\n  compute(x: string): void;\n}\n";
+    assert_eq!(count(source, TS2391), 1);
+    assert_eq!(count(source, TS2512), 0);
+}
+
+/// A single standalone abstract method (no overload group) is unaffected —
+/// no TS2391, no TS2512.
+#[test]
+fn single_abstract_method_reports_neither_code() {
+    let source = "abstract class Solo {\n  abstract compute(x: number): void;\n}\n";
+    assert_eq!(count(source, TS2391), 0);
+    assert_eq!(count(source, TS2512), 0);
+}
+
+/// An abstract-last group whose overloads are eventually implemented in a
+/// *subclass* still reports nothing in the declaring abstract class — the
+/// suppression is purely about the last signature's own modifier, not about
+/// whether any implementation exists anywhere in the program.
+#[test]
+fn abstract_last_group_with_renamed_binder_and_multiple_params_suppresses_ts2391() {
+    let source = "abstract class Zeta {\n  handle(x: number, y: number): void;\n  handle(x: string, y: string): void;\n  abstract handle(x: boolean, y: boolean): void;\n}\n";
+    assert_eq!(count(source, TS2391), 0);
+    assert_eq!(count(source, TS2512), 1);
+}


### PR DESCRIPTION
Structural rule: when a bodyless method overload group's LAST same-name signature carries the `abstract` modifier, tsc suppresses TS2391 ("Function implementation is missing...") entirely — an abstract member needs no implementation. tsz already had this exemption for constructor overload groups (`check_class_member_implementations`'s CONSTRUCTOR arm) but not for methods: the group-advance scan folded abstract siblings into the same-name group without tracking whether the group's last member was abstract, so `run(x: number): void; abstract run(x: string): void;` in an abstract class reported a spurious TS2391 alongside the correct TS2512.

Owner layer: checker member-implementation checks (`crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs`, METHOD_DECLARATION arm of `check_class_member_implementations`), mirroring the existing CONSTRUCTOR arm's `last_is_abstract` pattern in the same function.

Found while investigating #17166 (missing TS2512 for mixed abstract/non-abstract *constructor* overloads) via its own suggestion to pair the fix with the method analogue. tsz already emits TS2512 correctly for methods; this is the adjacent false-positive that same code path was hiding.

**Adjacent-case matrix** (all renamed binders, oracle-verified against pinned typescript@7.0.2):
- non-abstract, then abstract last → TS2391 suppressed (was firing)
- two non-abstract, then abstract last → same
- abstract first, non-abstract last → TS2391 still fires (last decides)
- no abstract member in the group → TS2391 still fires (unaffected)
- single standalone abstract method → neither code (unaffected)
- abstract-last group with multiple params → TS2391 suppressed

**Not fixed here:** #17166's original constructor TS2512 gap. Oracle testing during this session found that tsc's TS2512 for constructors is emitted program-wide **at most once** (deduped across every class/file in the compilation) with **no source location at all** (`error TS2512: ...` with no `file(line,col):` prefix under `--pretty false`) — verified with 2 classes in one file and 2 separate files, both collapsing to a single occurrence. Matching that exactly needs a real "global diagnostic" concept tsz's `Diagnostic` (`file: String`, always populated) doesn't have today, plus cross-file dedup — out of scope for this fix. Left as a comment on #17166 and a NOTE on the coordination board for whoever picks it up next.

## Goal
Goal: hold

## Verification
- New suite `abstract_method_overload_ts2391_suppression_tests.rs` (6 tests, all oracle-verified against pinned typescript@7.0.2), registered in `Cargo.toml` (`autotests = false` in this crate).
- `cargo test -p tsz-checker --lib abstract` — 97/97 pass.
- `cargo test -p tsz-checker --lib overload` — 431/431 pass.
- `cargo test -p tsz-checker --lib class` — 1029/1029 pass.
- `cargo clippy -p tsz-checker --lib --tests` — clean.
- `python3 scripts/arch/arch_guard.py` — green.
- `python3 scripts/ci/check-test-file-reachability.py` — 0 orphans.
- `cargo fmt -p tsz-checker` — clean.
- Conformance / emit / fourslash: deferred to CI's nightly lane; this path is only reachable through a pre-existing grammar-error shape (abstract on a bodyless method overload), unlikely to move corpus counts, but not measured locally this session.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-5
Effort: medium
AgentName: ClaudeClaude

---
_Generated by [Claude Code](https://claude.ai/code/session_01NiYosKqF6kXcvXuCNVUCvJ)_