### PR TITLE
fix(checker): report TS2512 for mixed abstract/non-abstract constructor overloads (#17166)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -396,6 +396,9 @@ path = "tests/abstract_constructor_elaboration_tests.rs"
 name = "ts2511_abstract_type_param_tests"
 path = "tests/ts2511_abstract_type_param_tests.rs"
 [[test]]
+name = "ts2512_abstract_overload_consistency_tests"
+path = "tests/ts2512_abstract_overload_consistency_tests.rs"
+[[test]]
 name = "ts2513_abstract_super_access_tests"
 path = "tests/ts2513_abstract_super_access_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking_members/class_type_param_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/class_type_param_checks.rs
@@ -475,6 +475,10 @@ impl<'a> CheckerState<'a> {
 
     /// Check that all method overload signatures in a group share the same abstract modifier
     /// (TS2512: Overload signatures must all be abstract or non-abstract).
+    ///
+    /// Constructors form their own nameless overload set and are checked
+    /// separately by [`Self::check_constructor_abstract_overload_consistency`],
+    /// invoked at the end of this pass.
     pub(crate) fn check_abstract_overload_consistency(
         &mut self,
         members: &[tsz_parser::parser::NodeIndex],
@@ -556,6 +560,78 @@ impl<'a> CheckerState<'a> {
             }
 
             i += group.len();
+        }
+
+        self.check_constructor_abstract_overload_consistency(members);
+    }
+
+    /// Check that all constructor overload signatures share the same abstract
+    /// modifier (TS2512), the nameless-overload-set analogue of
+    /// [`Self::check_abstract_overload_consistency`].
+    ///
+    /// A class has a single constructor symbol, so every `constructor`
+    /// declaration in `members` belongs to one overload set regardless of
+    /// contiguity — matching tsc's `checkFunctionOrConstructorSymbol`, which
+    /// gathers the symbol's declarations rather than a syntactic run. tsc takes
+    /// the canonical abstractness from `implementation ?? overloads[0]` and
+    /// flags every signature that deviates.
+    ///
+    /// Because tsc reports on `getNameOfDeclaration(o)` and a constructor has no
+    /// name, that anchor resolves to `undefined`, so the diagnostic is emitted
+    /// with no source location (see [`Self::error_program_level`]) — unlike the
+    /// method case above, which anchors on each deviating method's name. tsc's
+    /// repeated location-less `error(undefined, ...)` calls collapse to a single
+    /// entry, so one program-level TS2512 is reported for the set.
+    pub(crate) fn check_constructor_abstract_overload_consistency(
+        &mut self,
+        members: &[tsz_parser::parser::NodeIndex],
+    ) {
+        use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+        use tsz_parser::parser::syntax_kind_ext;
+
+        // Gather every constructor declaration in declaration order, recording
+        // whether each is `abstract` and whether it is the implementation (has a
+        // body).
+        let mut ctors: Vec<(bool /* is_abstract */, bool /* has_body */)> = Vec::new();
+        for &member_idx in members {
+            let Some(node) = self.ctx.arena.get(member_idx) else {
+                continue;
+            };
+            if node.kind != syntax_kind_ext::CONSTRUCTOR {
+                continue;
+            }
+            let Some(ctor) = self.ctx.arena.get_constructor(node) else {
+                continue;
+            };
+            let is_abstract = self.has_abstract_modifier(&ctor.modifiers);
+            let has_body = ctor.body.is_some();
+            ctors.push((is_abstract, has_body));
+        }
+
+        // An overload set needs at least two signatures to disagree.
+        if ctors.len() < 2 {
+            return;
+        }
+
+        // Canonical abstractness: the implementation's when one exists, else the
+        // first signature's (tsc: `implementation ?? overloads[0]`).
+        let canonical_abstract = ctors
+            .iter()
+            .find(|&&(_, has_body)| has_body)
+            .map_or(ctors[0].0, |&(is_abstract, _)| is_abstract);
+
+        // tsc reports a single location-less TS2512 for the set as soon as any
+        // signature deviates from the canonical abstractness (its repeated
+        // `error(undefined, ...)` calls collapse to one entry).
+        if ctors
+            .iter()
+            .any(|&(is_abstract, _)| is_abstract != canonical_abstract)
+        {
+            self.error_program_level(
+                diagnostic_messages::OVERLOAD_SIGNATURES_MUST_ALL_BE_ABSTRACT_OR_NON_ABSTRACT
+                    .to_string(),
+                diagnostic_codes::OVERLOAD_SIGNATURES_MUST_ALL_BE_ABSTRACT_OR_NON_ABSTRACT,
+            );
         }
     }
 

--- a/crates/tsz-checker/tests/ts2512_abstract_overload_consistency_tests.rs
+++ b/crates/tsz-checker/tests/ts2512_abstract_overload_consistency_tests.rs
@@ -1,0 +1,216 @@
+//! Tests for TS2512 ("Overload signatures must all be abstract or
+//! non-abstract.") across the two overload-set shapes that carry it.
+//!
+//! tsc routes both through `checkFunctionOrConstructorSymbol`: it takes the
+//! canonical abstractness from `implementation ?? overloads[0]` and flags every
+//! signature that deviates, reporting on `getNameOfDeclaration(o)`.
+//!
+//! - A **method** overload set has a name, so the diagnostic is anchored at the
+//!   deviating method's name (a located `test.ts(line,col)` diagnostic).
+//! - A **constructor** overload set has no name, so `getNameOfDeclaration`
+//!   resolves to `undefined` and tsc emits the diagnostic with *no source
+//!   location* at all — it prints as a bare `error TS2512: ...`. Several
+//!   deviating constructor signatures collapse to a single entry through the
+//!   diagnostic set's deduplication.
+//!
+//! tsz previously implemented only the method arm, so a mixed abstract /
+//! non-abstract constructor overload set silently dropped TS2512 (issue
+//! #17166). The constructor `abstract`-modifier form is itself a grammar error
+//! (TS1242), so this shape only arises in already-erroneous code, but tsc still
+//! runs the abstract-consistency check and so must tsz.
+//!
+//! Oracle-verified against pinned `typescript@7.0.2` with
+//! `--noEmit --pretty false --singleThreaded --strict`. Class and method
+//! binders are varied so no fix can key on a specific name.
+
+use tsz_checker::test_utils::{check_source_code_messages, check_source_diagnostics};
+
+const TS2512: u32 = 2512;
+
+fn count(source: &str, code: u32) -> usize {
+    check_source_code_messages(source)
+        .iter()
+        .filter(|d| d.0 == code)
+        .count()
+}
+
+fn has(source: &str, code: u32) -> bool {
+    count(source, code) > 0
+}
+
+// ---------------------------------------------------------------------------
+// Constructor overload sets — the fixed case.
+// ---------------------------------------------------------------------------
+
+/// The reported repro: a non-abstract constructor signature followed by an
+/// `abstract` one. The canonical abstractness is the first signature's
+/// (non-abstract), so the `abstract` signature deviates -> one TS2512.
+#[test]
+fn mixed_constructor_overloads_report_ts2512() {
+    let source = "class A { constructor(x: number); abstract constructor(x: string); }\n";
+    assert_eq!(count(source, TS2512), 1);
+}
+
+/// The constructor TS2512 is emitted with no source location — an empty file
+/// and a zero span — matching tsc's location-less `error(undefined, ...)`.
+#[test]
+fn constructor_ts2512_is_location_less() {
+    let source = "class A { constructor(x: number); abstract constructor(x: string); }\n";
+    let ts2512: Vec<_> = check_source_diagnostics(source)
+        .into_iter()
+        .filter(|d| d.code == TS2512)
+        .collect();
+    assert_eq!(ts2512.len(), 1, "exactly one TS2512");
+    let diag = &ts2512[0];
+    assert!(
+        diag.file.is_empty(),
+        "constructor TS2512 has no file, got {:?}",
+        diag.file
+    );
+    assert_eq!(diag.start, 0, "constructor TS2512 has a zero span start");
+    assert_eq!(diag.length, 0, "constructor TS2512 has a zero span length");
+}
+
+/// The abstractness order does not matter: an `abstract` signature first, then
+/// non-abstract ones, still reports TS2512. The canonical is the first
+/// (abstract) signature, so the two non-abstract signatures each deviate — but
+/// the identical location-less diagnostics collapse to a single entry, exactly
+/// as tsc reports it once.
+#[test]
+fn two_deviating_constructors_collapse_to_one_ts2512() {
+    let source = "class Ledger {\n  abstract constructor(x: number);\n  constructor(x: string);\n  constructor(x: boolean);\n}\n";
+    assert_eq!(
+        count(source, TS2512),
+        1,
+        "multiple deviating constructors dedupe to a single TS2512"
+    );
+}
+
+/// When an implementation body is present, its abstractness (non-abstract — an
+/// abstract member cannot have a body) is canonical, so a preceding `abstract`
+/// signature deviates -> TS2512.
+#[test]
+fn constructor_with_implementation_flags_abstract_signature() {
+    let source =
+        "class Meter { abstract constructor(x: number); constructor(x: string | number) {} }\n";
+    assert_eq!(count(source, TS2512), 1);
+}
+
+/// Two non-abstract constructor overloads agree -> no TS2512.
+#[test]
+fn all_non_abstract_constructor_overloads_no_ts2512() {
+    let source = "class Dial { constructor(x: number); constructor(x: string); }\n";
+    assert!(!has(source, TS2512));
+}
+
+/// A single `abstract` constructor is not an overload *set* (one declaration),
+/// so there is nothing to disagree with -> no TS2512 (only the TS1242 grammar
+/// error, checked elsewhere).
+#[test]
+fn abstract_constructor_alone_no_ts2512() {
+    let source = "class Gauge { abstract constructor(); }\n";
+    assert!(!has(source, TS2512));
+}
+
+/// Two `abstract` constructor signatures agree with each other -> no TS2512.
+#[test]
+fn two_abstract_constructor_overloads_no_ts2512() {
+    let source =
+        "class Valve { abstract constructor(x: number); abstract constructor(x: string); }\n";
+    assert!(!has(source, TS2512));
+}
+
+/// A single constructor with a body is not an overload set -> no TS2512.
+#[test]
+fn single_constructor_no_ts2512() {
+    let source = "class Piston { constructor(x: number) {} }\n";
+    assert!(!has(source, TS2512));
+}
+
+/// The fix does not key on a class name: a renamed binder around the same mixed
+/// shape still reports exactly one location-less TS2512.
+#[test]
+fn mixed_constructor_ts2512_binder_name_varies() {
+    let source =
+        "class ZqxWidgetFactory { constructor(a: number); abstract constructor(a: string); }\n";
+    let ts2512: Vec<_> = check_source_diagnostics(source)
+        .into_iter()
+        .filter(|d| d.code == TS2512)
+        .collect();
+    assert_eq!(ts2512.len(), 1);
+    assert!(ts2512[0].file.is_empty());
+}
+
+/// Two classes in one compilation, each with a mixed constructor overload set,
+/// still yield exactly one TS2512: the location-less diagnostics share the
+/// `(start, code)` dedup key and collapse to a single entry, matching tsc (which
+/// emits its program-level TS2512 at most once across the whole compilation,
+/// even across classes and files).
+#[test]
+fn two_classes_share_a_single_ts2512() {
+    let source = "class A { constructor(x: number); abstract constructor(x: string); }\nclass B { constructor(y: number); abstract constructor(y: string); }\n";
+    assert_eq!(count(source, TS2512), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Method overload sets — the legal analogue (already handled; pinned here so
+// the two export forms of the same rule stay paired).
+// ---------------------------------------------------------------------------
+
+/// A mixed abstract / non-abstract method overload set in an abstract class —
+/// the legal shape where TS2512 actually matters — reports TS2512. (The paired
+/// TS2391 abstract-final suppression on this same shape is covered by
+/// `abstract_method_overload_ts2391_suppression_tests`.)
+#[test]
+fn mixed_method_overloads_in_abstract_class_report_ts2512() {
+    let source =
+        "abstract class Shape {\n  m(x: number): void;\n  abstract m(x: string): void;\n}\n";
+    assert_eq!(count(source, TS2512), 1);
+}
+
+/// Unlike the constructor case, a method TS2512 is anchored at the deviating
+/// method's name — a located diagnostic in the file, with a non-zero span.
+#[test]
+fn method_ts2512_is_anchored_at_the_name() {
+    let source =
+        "abstract class Shape {\n  m(x: number): void;\n  abstract m(x: string): void;\n}\n";
+    let ts2512: Vec<_> = check_source_diagnostics(source)
+        .into_iter()
+        .filter(|d| d.code == TS2512)
+        .collect();
+    assert_eq!(ts2512.len(), 1);
+    let diag = &ts2512[0];
+    assert!(
+        !diag.file.is_empty(),
+        "method TS2512 is anchored in the file"
+    );
+    assert!(diag.length > 0, "method TS2512 has a non-zero span");
+}
+
+/// A method implementation body makes its abstractness canonical
+/// (non-abstract), so a preceding abstract signature deviates -> TS2512.
+#[test]
+fn method_with_implementation_flags_abstract_signature() {
+    let source = "abstract class Shape {\n  abstract m(x: string): void;\n  m(x: number | string): void {}\n}\n";
+    assert_eq!(count(source, TS2512), 1);
+}
+
+/// Non-abstract method overloads that agree report no TS2512.
+#[test]
+fn all_non_abstract_method_overloads_no_ts2512() {
+    let source = "abstract class Shape {\n  m(x: number): void;\n  m(x: string): void;\n  m(x: number | string): void {}\n}\n";
+    assert!(!has(source, TS2512));
+}
+
+/// The method arm does not key on a name either: a renamed method around the
+/// same mixed shape still reports exactly one name-anchored TS2512.
+#[test]
+fn mixed_method_ts2512_binder_name_varies() {
+    let source = "abstract class Shape {\n  zqxTransform(x: number): void;\n  abstract zqxTransform(x: string): void;\n}\n";
+    let ts2512: Vec<_> = check_source_diagnostics(source)
+        .into_iter()
+        .filter(|d| d.code == TS2512)
+        .collect();
+    assert_eq!(ts2512.len(), 1);
+    assert!(!ts2512[0].file.is_empty());
+}


### PR DESCRIPTION
Fixes #17166.

**Structural rule:** when a constructor overload set's signatures are not all `abstract` or all non-`abstract`, tsc reports **TS2512** ("Overload signatures must all be abstract or non-abstract"). tsc routes both method and constructor overload sets through `checkFunctionOrConstructorSymbol`, taking the canonical abstractness from `implementation ?? overloads[0]` and flagging deviators.

tsz ran the TS2512 abstract-consistency check **only for method overload groups**, so a mixed-abstractness *constructor* set silently dropped TS2512 — the reported bug.

> The method **TS2391** abstract-final analogue that #17166 also pointed at was fixed separately by **#17173** (already on main). This PR was rebased onto that and now carries **only** the remaining constructor TS2512 gap, which #17173 explicitly left open. #17173 noted that matching tsc here would need "a global-diagnostic concept tsz doesn't have, plus cross-file dedup" — it turns out the existing `error_program_level` emitter (empty `file`, zero span) plus tsz's `(start, code)` dedup already provide exactly that, so no new infrastructure was needed (see the cross-class/cross-file rows below).

What changed (owner: checker `state_checking_members`, no new emitter, no printer coupling, no name/file-string keying):
- `class_type_param_checks.rs` — new `check_constructor_abstract_overload_consistency`, invoked from `check_abstract_overload_consistency`, gathers the class's single (nameless) constructor overload set and reports **one location-less TS2512** when any signature deviates. tsc anchors on `getNameOfDeclaration`, which is `undefined` for a constructor, so the diagnostic prints as a bare `error TS2512: ...` with no `file(line,col):` prefix — emitted through the existing `error_program_level` helper.

Adjacent-case matrix (all oracle-verified against pinned `typescript@7.0.2`, `--strict --pretty false`):

| shape | tsc / tsz (after) |
| --- | --- |
| `constructor(x:number); abstract constructor(x:string);` | TS2512 (location-less) + TS1242 |
| abstract-first, 2 non-abstract sigs | one TS2512 (dedup) + TS1242 + TS2390 |
| impl body present, one abstract sig | TS2512 + TS1242 |
| all non-abstract / all abstract ctors | no TS2512 |
| single `abstract constructor()` | no TS2512 (not a set) |
| **two classes, one file**, both mixed | **one** TS2512 + 2× TS1242 |
| **two files**, each mixed | **one** TS2512 total + 2× TS1242 |
| `m(x:number); abstract m(x:string);` (abstract class) | TS2512 at the name (located, not deduped) |

Binder names are varied across the tests so no fix keys on an identifier.

## Goal
Goal: hold

## Verification
- `cargo test -p tsz-checker --test ts2512_abstract_overload_consistency_tests` — 15/15 new tests (constructor TS2512 located-vs-location-less, dedup within a class list, dedup across two classes in one file, impl-canonical, order-independence, name-invariance; method TS2512 anchored at the name).
- `cargo clippy -p tsz-checker --all-targets` clean; `python3 scripts/arch/arch_guard.py` passes; `python3 scripts/ci/check-test-file-reachability.py` 0 orphans; `cargo fmt --check` clean.
- Parity confirmed against pinned `typescript@7.0.2 --noEmit --pretty false --singleThreaded --strict` for every matrix row above, including the cross-class and cross-file dedup (one TS2512 total). Full conformance/emit/fourslash run in nightly CI (the TypeScript submodule is not checked out in this environment).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus
Effort: high