### PR TITLE
fix(checker): object-literal this.<sibling>() gets the forward sibling's inferred return type (#17157)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -451,6 +451,9 @@ path = "tests/async_return_promise_identity_tests.rs"
 name = "object_literal_getter_widening_tests"
 path = "tests/object_literal_getter_widening_tests.rs"
 [[test]]
+name = "object_literal_forward_method_return_type_tests"
+path = "tests/object_literal_forward_method_return_type_tests.rs"
+[[test]]
 name = "object_literal_method_this_member_order_tests"
 path = "tests/object_literal_method_this_member_order_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/computation/object_literal/computation.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal/computation.rs
@@ -19,6 +19,7 @@ use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
 
+use super::super::object_literal_circularity::SiblingReturnResolver;
 use super::computation_request_facts::ObjectLiteralRequestFacts;
 use super::computation_support::{LITERAL_DISPLAY_ORDER_BASE, direct_member_display_order};
 use super::spread_element::{ObjectLiteralSpreadContext, ObjectLiteralSpreadState};
@@ -108,6 +109,16 @@ impl<'a> CheckerState<'a> {
         let trailing_member_props = self.object_literal_trailing_member_props(&obj.elements.nodes);
         let circular_return_method_sites =
             self.object_literal_circular_return_method_sites(&obj_all_method_names);
+        // Memoized spliced callable types for unannotated, acyclic sibling
+        // members, built on demand when a method/function body references a
+        // forward-declared sibling via `this.<name>()`. Shared across every
+        // synthetic-`this` build for this object literal so each sibling's
+        // callable (and its one-shot body inference) is built at most once.
+        let mut sibling_callable_type_cache: FxHashMap<NodeIndex, TypeId> = FxHashMap::default();
+        let mut sibling_resolver = SiblingReturnResolver {
+            circular_return_method_sites: &circular_return_method_sites,
+            sibling_callable_type_cache: &mut sibling_callable_type_cache,
+        };
 
         for &elem_idx in &obj.elements.nodes {
             let Some(elem_node) = self.ctx.arena.get(elem_idx) else {
@@ -412,7 +423,8 @@ impl<'a> CheckerState<'a> {
                                         &properties,
                                         &obj_all_method_names,
                                         &trailing_member_props,
-                                        &name,
+                                        &mut sibling_resolver,
+                                        elem_idx,
                                     );
                                 self.ctx.this_type_stack.push(synthetic_this_type);
                                 pushed_prop_fn_this = true;
@@ -1383,6 +1395,7 @@ impl<'a> CheckerState<'a> {
                                     &properties,
                                     &obj_all_method_names,
                                     &trailing_member_props,
+                                    &mut sibling_resolver,
                                     elem_idx,
                                     &name,
                                     None,
@@ -1513,6 +1526,7 @@ impl<'a> CheckerState<'a> {
                                 &properties,
                                 &obj_all_method_names,
                                 &trailing_member_props,
+                                &mut sibling_resolver,
                                 elem_idx,
                                 &name,
                                 Some(refined_method_type),

--- a/crates/tsz-checker/src/types/computation/object_literal_circularity.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_circularity.rs
@@ -10,6 +10,31 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
+/// Shared inputs for resolving a *sibling* callable member's return type when
+/// building an object-literal method's synthetic `this`.
+///
+/// `circular_return_method_sites` names the members that participate in a
+/// genuine `this.<name>()` return cycle (kept at `any` so `TS7023` still
+/// fires); `sibling_callable_type_cache` memoizes each acyclic sibling's spliced
+/// callable `TypeId` so its params/return (including the one-shot body
+/// inference) are built at most once across every synthetic-`this` build for one
+/// object literal.
+pub(crate) struct SiblingReturnResolver<'r> {
+    pub circular_return_method_sites: &'r FxHashSet<NodeIndex>,
+    pub sibling_callable_type_cache: &'r mut FxHashMap<NodeIndex, TypeId>,
+}
+
+/// The declaration nodes a sibling callable's spliced type is built from: its
+/// parameter list, its return-type annotation (`NONE` when unannotated), the
+/// function node whose body backs on-demand return inference, and that body
+/// (`None` for a bodyless declaration).
+struct SiblingSignatureNodes {
+    param_nodes: Vec<NodeIndex>,
+    annotation: NodeIndex,
+    fn_idx: NodeIndex,
+    body_idx: Option<NodeIndex>,
+}
+
 impl<'a> CheckerState<'a> {
     /// Whether an object-literal member, when its body is checked, binds the
     /// synthetic object-literal `this` type — i.e. a member whose `this` refers
@@ -659,6 +684,7 @@ impl<'a> CheckerState<'a> {
             tsz_common::interner::Atom,
             tsz_solver::PropertyInfo,
         >,
+        sibling_resolver: &mut SiblingReturnResolver<'_>,
         current_method_idx: NodeIndex,
         current_method_name: &str,
         current_method_type_override: Option<TypeId>,
@@ -728,72 +754,7 @@ impl<'a> CheckerState<'a> {
                     placeholder
                 }
             } else {
-                let (other_params, other_return_type) = self
-                    .ctx
-                    .arena
-                    .get(other_elem_idx)
-                    .and_then(|n| self.ctx.arena.get_method_decl(n))
-                    .map(|other_method| {
-                        let params: Vec<tsz_solver::ParamInfo> = other_method
-                            .parameters
-                            .nodes
-                            .iter()
-                            .filter_map(|&param_idx| {
-                                let param = self
-                                    .ctx
-                                    .arena
-                                    .get(param_idx)
-                                    .and_then(|pn| self.ctx.arena.get_parameter(pn))?;
-                                if let Some(name_node) = self.ctx.arena.get(param.name)
-                                    && let Some(ident) = self.ctx.arena.get_identifier(name_node)
-                                    && ident.escaped_text == "this"
-                                {
-                                    return None;
-                                }
-                                Some(signature_building_boundary::param_info(
-                                    self.ctx
-                                        .arena
-                                        .get(param.name)
-                                        .and_then(|name_node| {
-                                            self.ctx.arena.get_identifier(name_node)
-                                        })
-                                        .map(|ident| {
-                                            self.ctx.types.intern_string(&ident.escaped_text)
-                                        }),
-                                    if param.type_annotation.is_some() {
-                                        self.get_type_from_type_node(param.type_annotation)
-                                    } else {
-                                        TypeId::ANY
-                                    },
-                                    param.question_token || param.initializer.is_some(),
-                                    param.dot_dot_dot_token,
-                                ))
-                            })
-                            .collect();
-                        let return_type = if other_method.type_annotation.is_some() {
-                            self.get_type_from_type_node(other_method.type_annotation)
-                        } else {
-                            TypeId::ANY
-                        };
-                        (params, return_type)
-                    })
-                    .unwrap_or_else(|| {
-                        (
-                            vec![signature_building_boundary::param_info(
-                                None,
-                                TypeId::ANY,
-                                false,
-                                true,
-                            )],
-                            TypeId::ANY,
-                        )
-                    });
-
-                object_context_query::synthetic_this_method_callable(
-                    self.ctx.types,
-                    other_params,
-                    other_return_type,
-                )
+                self.object_literal_sibling_callable_type(other_elem_idx, sibling_resolver)
             };
 
             this_props.push(object_context_query::synthetic_this_method_property(
@@ -823,7 +784,8 @@ impl<'a> CheckerState<'a> {
             tsz_common::interner::Atom,
             tsz_solver::PropertyInfo,
         >,
-        _current_property_name: &str,
+        sibling_resolver: &mut SiblingReturnResolver<'_>,
+        current_property_idx: NodeIndex,
     ) -> TypeId {
         let mut this_props: Vec<tsz_solver::PropertyInfo> = properties.values().cloned().collect();
 
@@ -837,74 +799,20 @@ impl<'a> CheckerState<'a> {
         // in `properties`; splice them in so `this.<laterMember>` resolves.
         Self::merge_trailing_member_props(&mut this_props, trailing_member_props);
 
-        // Add placeholder callable types for pre-scanned method declarations
+        // Add callable types for pre-scanned method/function-expression members.
         for (&method_name_atom, &(other_elem_idx, decl_order)) in obj_all_method_names {
             if this_props.iter().any(|p| p.name == method_name_atom) {
                 continue;
             }
 
-            let (other_params, other_return_type) = self
-                .ctx
-                .arena
-                .get(other_elem_idx)
-                .and_then(|n| self.ctx.arena.get_method_decl(n))
-                .map(|other_method| {
-                    let params: Vec<tsz_solver::ParamInfo> = other_method
-                        .parameters
-                        .nodes
-                        .iter()
-                        .filter_map(|&param_idx| {
-                            let param = self
-                                .ctx
-                                .arena
-                                .get(param_idx)
-                                .and_then(|pn| self.ctx.arena.get_parameter(pn))?;
-                            if let Some(name_node) = self.ctx.arena.get(param.name)
-                                && let Some(ident) = self.ctx.arena.get_identifier(name_node)
-                                && ident.escaped_text == "this"
-                            {
-                                return None;
-                            }
-                            Some(signature_building_boundary::param_info(
-                                self.ctx
-                                    .arena
-                                    .get(param.name)
-                                    .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
-                                    .map(|ident| self.ctx.types.intern_string(&ident.escaped_text)),
-                                if param.type_annotation.is_some() {
-                                    self.get_type_from_type_node(param.type_annotation)
-                                } else {
-                                    TypeId::ANY
-                                },
-                                param.question_token || param.initializer.is_some(),
-                                param.dot_dot_dot_token,
-                            ))
-                        })
-                        .collect();
-                    let return_type = if other_method.type_annotation.is_some() {
-                        self.get_type_from_type_node(other_method.type_annotation)
-                    } else {
-                        TypeId::ANY
-                    };
-                    (params, return_type)
-                })
-                .unwrap_or_else(|| {
-                    (
-                        vec![signature_building_boundary::param_info(
-                            None,
-                            TypeId::ANY,
-                            false,
-                            true,
-                        )],
-                        TypeId::ANY,
-                    )
-                });
-
-            let method_type = object_context_query::synthetic_this_method_callable(
-                self.ctx.types,
-                other_params,
-                other_return_type,
-            );
+            let method_type = if other_elem_idx == current_property_idx {
+                // The property whose body is about to be checked: keep a
+                // permissive placeholder — its real signature is computed by the
+                // main pass, and inferring it here would double-evaluate its body.
+                self.permissive_synthetic_this_callable()
+            } else {
+                self.object_literal_sibling_callable_type(other_elem_idx, sibling_resolver)
+            };
             this_props.push(object_context_query::synthetic_this_method_property(
                 method_name_atom,
                 method_type,
@@ -950,5 +858,188 @@ impl<'a> CheckerState<'a> {
             .get_children(idx)
             .into_iter()
             .any(|child| self.object_literal_initializer_references_name(child, name))
+    }
+
+    /// Callable type spliced into a synthetic object-literal `this` for a
+    /// *sibling* callable member (method shorthand or `function`-expression
+    /// property). Parameters mirror the declaration (an explicit `this`
+    /// parameter is dropped). The return type is the annotation when present;
+    /// otherwise the on-demand-inferred body return type for an acyclic member
+    /// and `any` for a member in a genuine circular-return cycle, which keeps
+    /// the `TS7023` circular-return diagnostic intact.
+    ///
+    /// A sibling's callable is invariant across every synthetic-`this` build for
+    /// one object literal, so the whole `TypeId` is memoized per member node —
+    /// the O(methods) builds each spliced O(methods) siblings, and this collapses
+    /// the param construction, interning, and one-shot body inference to once per
+    /// sibling.
+    fn object_literal_sibling_callable_type(
+        &mut self,
+        other_elem_idx: NodeIndex,
+        sibling_resolver: &mut SiblingReturnResolver<'_>,
+    ) -> TypeId {
+        if let Some(&cached) = sibling_resolver
+            .sibling_callable_type_cache
+            .get(&other_elem_idx)
+        {
+            return cached;
+        }
+        let callable = self.build_object_literal_sibling_callable_type(
+            other_elem_idx,
+            sibling_resolver.circular_return_method_sites,
+        );
+        sibling_resolver
+            .sibling_callable_type_cache
+            .insert(other_elem_idx, callable);
+        callable
+    }
+
+    /// Uncached construction backing [`Self::object_literal_sibling_callable_type`].
+    fn build_object_literal_sibling_callable_type(
+        &mut self,
+        other_elem_idx: NodeIndex,
+        circular_return_method_sites: &FxHashSet<NodeIndex>,
+    ) -> TypeId {
+        // Resolve the callable's parameter nodes, its return-type annotation, the
+        // function node whose body backs on-demand inference, and that body node.
+        let sig = if let Some(other_method) = self
+            .ctx
+            .arena
+            .get(other_elem_idx)
+            .and_then(|n| self.ctx.arena.get_method_decl(n))
+        {
+            SiblingSignatureNodes {
+                param_nodes: other_method.parameters.nodes.clone(),
+                annotation: other_method.type_annotation,
+                fn_idx: other_elem_idx,
+                body_idx: other_method.body.into_option(),
+            }
+        } else if let Some(sig) = self.object_literal_fn_property_signature_nodes(other_elem_idx) {
+            sig
+        } else {
+            // Non-resolvable callable (e.g. an arrow property, whose `this` is
+            // lexical): permissive `(...args: any) => any` placeholder.
+            return self.permissive_synthetic_this_callable();
+        };
+
+        let params = self.object_literal_sibling_param_infos(&sig.param_nodes);
+        let return_type = self.object_literal_sibling_return_type(
+            other_elem_idx,
+            sig.fn_idx,
+            sig.annotation,
+            sig.body_idx,
+            circular_return_method_sites,
+        );
+        object_context_query::synthetic_this_method_callable(self.ctx.types, params, return_type)
+    }
+
+    /// A permissive `(...args: any) => any` callable used for a synthetic-`this`
+    /// member whose real signature is deliberately not resolved here (an arrow
+    /// property, or the member whose own body is about to be checked).
+    fn permissive_synthetic_this_callable(&mut self) -> TypeId {
+        object_context_query::synthetic_this_method_callable(
+            self.ctx.types,
+            vec![signature_building_boundary::param_info(
+                None,
+                TypeId::ANY,
+                false,
+                true,
+            )],
+            TypeId::ANY,
+        )
+    }
+
+    /// Resolve the `SiblingSignatureNodes` of an object-literal
+    /// `function`-expression property member. Returns `None` for any other
+    /// member kind (a method declaration is handled by the caller; an arrow
+    /// property falls through to the permissive placeholder).
+    fn object_literal_fn_property_signature_nodes(
+        &self,
+        elem_idx: NodeIndex,
+    ) -> Option<SiblingSignatureNodes> {
+        let elem_node = self.ctx.arena.get(elem_idx)?;
+        let prop = self.ctx.arena.get_property_assignment(elem_node)?;
+        let initializer = self
+            .ctx
+            .arena
+            .skip_parenthesized_and_assertions(prop.initializer);
+        let init_node = self.ctx.arena.get(initializer)?;
+        if init_node.kind != syntax_kind_ext::FUNCTION_EXPRESSION {
+            return None;
+        }
+        let func = self.ctx.arena.get_function(init_node)?;
+        Some(SiblingSignatureNodes {
+            param_nodes: func.parameters.nodes.clone(),
+            annotation: func.type_annotation,
+            fn_idx: initializer,
+            body_idx: func.body.into_option(),
+        })
+    }
+
+    /// Build `ParamInfo`s for a sibling callable's parameter node list, dropping
+    /// an explicit `this` parameter (which is not part of the callable's
+    /// apparent signature).
+    fn object_literal_sibling_param_infos(
+        &mut self,
+        param_nodes: &[NodeIndex],
+    ) -> Vec<tsz_solver::ParamInfo> {
+        param_nodes
+            .iter()
+            .filter_map(|&param_idx| {
+                let param = self
+                    .ctx
+                    .arena
+                    .get(param_idx)
+                    .and_then(|pn| self.ctx.arena.get_parameter(pn))?;
+                let name_atom = self
+                    .ctx
+                    .arena
+                    .get(param.name)
+                    .and_then(|name_node| self.ctx.arena.get_identifier(name_node))
+                    .map(|ident| ident.escaped_text.clone());
+                if name_atom.as_deref() == Some("this") {
+                    return None;
+                }
+                Some(signature_building_boundary::param_info(
+                    name_atom.map(|name| self.ctx.types.intern_string(&name)),
+                    if param.type_annotation.is_some() {
+                        self.get_type_from_type_node(param.type_annotation)
+                    } else {
+                        TypeId::ANY
+                    },
+                    param.question_token || param.initializer.is_some(),
+                    param.dot_dot_dot_token,
+                ))
+            })
+            .collect()
+    }
+
+    /// Return type spliced for a sibling callable: the annotation when present,
+    /// else the on-demand-inferred body return type for an acyclic member, else
+    /// `any` (a genuine circular-return cycle keeps `any` so `TS7023` fires, and
+    /// a bodyless/unresolvable member has no inferable return).
+    fn object_literal_sibling_return_type(
+        &mut self,
+        other_elem_idx: NodeIndex,
+        fn_idx: NodeIndex,
+        annotation: NodeIndex,
+        body_idx: Option<NodeIndex>,
+        circular_return_method_sites: &FxHashSet<NodeIndex>,
+    ) -> TypeId {
+        if annotation.is_some() {
+            return self.get_type_from_type_node(annotation);
+        }
+        if circular_return_method_sites.contains(&other_elem_idx) {
+            return TypeId::ANY;
+        }
+        let Some(body_idx) = body_idx else {
+            return TypeId::ANY;
+        };
+        // Non-contextual inference; `infer_return_type_from_body` snapshots and
+        // restores diagnostic, node-type, and flow-cache state internally, so it
+        // adds no diagnostics here. A nested `this.<other>()` in the sibling body
+        // degrades to `any` (the other sibling's synthetic `this` is not on the
+        // stack at this point) rather than resolving — never a wrong type.
+        self.infer_return_type_from_body(fn_idx, body_idx, None)
     }
 }

--- a/crates/tsz-checker/tests/object_literal_forward_method_return_type_tests.rs
+++ b/crates/tsz-checker/tests/object_literal_forward_method_return_type_tests.rs
@@ -1,0 +1,147 @@
+//! `this.<sibling>()` inside an object-literal method/`function`-property must
+//! carry the *sibling's inferred return type*, even when the sibling is an
+//! unannotated method declared **later** in the same literal.
+//!
+//! tsz builds the object-literal synthetic `this` incrementally, so a sibling
+//! declared after the current method was spliced in with a hardcoded `any`
+//! return type. Any diagnostic depending on the call's result (TS2322/TS2345/…)
+//! was therefore silently dropped, and declaration order flipped the outcome:
+//!
+//! ```ts
+//! const obj = { foo() { return this.bar(); }, bar() { return 1; } };
+//! const t: string = obj.foo(); // tsc: TS2322; tsz (before fix): no error
+//! ```
+//!
+//! The fix infers an acyclic unannotated sibling's real return type on demand
+//! (memoized per object literal), while keeping `any` for a sibling that is part
+//! of a genuine circular-return cycle so the TS7023 diagnostic still fires.
+
+use tsz_checker::test_utils::check_source_code_messages as get_diagnostics;
+
+fn codes(source: &str) -> Vec<u32> {
+    let mut c: Vec<u32> = get_diagnostics(source)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect();
+    c.sort_unstable();
+    c
+}
+
+/// The reported witness: `foo` calls a *later* unannotated method `bar`; the
+/// `number` result must flow so the `string` assignment is TS2322.
+#[test]
+fn method_calls_later_method_return_type_flows() {
+    let source = r#"
+const obj = { foo() { return this.bar(); }, bar() { return 1; } };
+const t: string = obj.foo();
+"#;
+    assert_eq!(
+        codes(source),
+        vec![2322u32],
+        "a later sibling method's inferred return type must reach the call site"
+    );
+}
+
+/// Control: sibling declared *before* the caller already worked; it must keep
+/// working (same diagnostic, order-independent).
+#[test]
+fn method_calls_earlier_method_return_type_flows() {
+    let source = r#"
+const obj = { bar() { return 1; }, foo() { return this.bar(); } };
+const t: string = obj.foo();
+"#;
+    assert_eq!(codes(source), vec![2322u32]);
+}
+
+/// Structural, not name-based: renamed binders produce the identical result.
+#[test]
+fn forward_method_return_type_renamed_binders() {
+    let source = r#"
+const widget = { alpha() { return this.beta(); }, beta() { return "hi"; } };
+const t: number = widget.alpha();
+"#;
+    assert_eq!(
+        codes(source),
+        vec![2322u32],
+        "the method names must not matter (no name-based fast path)"
+    );
+}
+
+/// A `function`-expression property (which binds the object as `this`) calling a
+/// later method resolves the same way.
+#[test]
+fn function_property_calls_later_method_return_type_flows() {
+    let source = r#"
+const obj = { foo: function () { return this.bar(); }, bar() { return 2; } };
+const t: string = obj.foo();
+"#;
+    assert_eq!(codes(source), vec![2322u32]);
+}
+
+/// A method calling a later `function`-expression-property sibling also resolves
+/// the sibling's inferred return type.
+#[test]
+fn method_calls_later_function_property_return_type_flows() {
+    let source = r#"
+const obj = { foo() { return this.bar(); }, bar: function () { return 3; } };
+const t: string = obj.foo();
+"#;
+    assert_eq!(codes(source), vec![2322u32]);
+}
+
+/// The result is the concrete inferred type (`number`), not `any`: assigning it
+/// to an unrelated object type must be rejected.
+#[test]
+fn forward_method_return_type_is_concrete_not_any() {
+    let source = r#"
+const obj = { foo() { return this.bar(); }, bar() { return 1; } };
+const t: { z: number } = obj.foo();
+"#;
+    assert_eq!(
+        codes(source),
+        vec![2322u32],
+        "obj.foo() must be `number`, not `any` — the object-type assignment errors"
+    );
+}
+
+/// A genuine circular return (`foo -> bar -> foo`) must still yield TS7023 on
+/// both members and must not loop; the acyclic-inference path must not swallow
+/// it.
+#[test]
+fn mutual_circular_return_still_ts7023() {
+    let source = r#"
+const obj = { foo() { return this.bar(); }, bar() { return this.foo(); } };
+const t = obj.foo();
+"#;
+    assert_eq!(
+        codes(source),
+        vec![7023u32, 7023u32],
+        "a real cycle must keep both TS7023 diagnostics"
+    );
+}
+
+/// A sibling whose real return type is itself `any` stays `any`: no new error
+/// when its result is assigned to an unrelated annotation.
+#[test]
+fn sibling_returning_any_stays_any() {
+    let source = r#"
+const obj = { foo() { const s: string = this.bar(); return s; }, bar(): any { return 1; } };
+obj;
+"#;
+    assert_eq!(
+        codes(source),
+        Vec::<u32>::new(),
+        "an `any`-returning sibling must not introduce a spurious mismatch"
+    );
+}
+
+/// An explicitly annotated later sibling uses its annotation (regression guard
+/// for the annotation path).
+#[test]
+fn annotated_later_sibling_uses_annotation() {
+    let source = r#"
+const obj = { foo() { return this.bar(); }, bar(): number { return 1; } };
+const t: string = obj.foo();
+"#;
+    assert_eq!(codes(source), vec![2322u32]);
+}


### PR DESCRIPTION
Fixes #17157.

When an object-literal method (or `function`-expression property) body calls a
**sibling** callable member via `this.<name>()`, and that sibling is an
**unannotated method/function declared later** in the same literal, `tsc`
resolves the call to the sibling's *inferred* return type; tsz collapsed it to
`any`, so every diagnostic depending on the call result (TS2322, TS2345, …) was
silently dropped — and declaration order flipped the outcome.

Structural rule: *when a synthetic object-literal `this` splices in a
forward-declared unannotated sibling callable, `tsc` gives it the sibling's
inferred return type; tsz did so through the checker's object-literal
synthetic-`this` builders, which hardcoded that return to `any`.*

### Root cause

`build_object_literal_method_synthetic_this_type` and its function-expression
sibling hardcoded `TypeId::ANY` for any unannotated sibling's return. A sibling
declared *before* the current member was already resolved in the incremental
`properties` map, so only the forward-declared case lost its return type — hence
the order sensitivity.

### Fix

Both builders route a sibling callable through one shared helper:

- **Annotated sibling** → its annotation (unchanged).
- **Unannotated, acyclic sibling** → its real return type, inferred on demand via
  `infer_return_type_from_body(..., None)` — which snapshots/restores diagnostic,
  node-type, flow-cache, and lazy-resolution-fuel state internally, so the early
  inference emits no diagnostics and does not perturb the authoritative
  body-check pass. The full spliced callable `TypeId` is memoized per member
  node, so each sibling's params/return (and its one-shot body inference) are
  built once across every synthetic-`this` build.
- **Unannotated sibling in a genuine `this.<name>()` return cycle** → kept at
  `any`, gated on the existing `object_literal_circular_return_method_sites`
  set, so TS7023 still fires and inference never recurses.

A deeper `this.a() → this.b() → this.c()` chain degrades to `any` (never a wrong
type); resolving arbitrarily deep chains would require rebuilding each sibling's
synthetic `this` during nested inference and is out of scope. The change also
DRYs ~130 lines of duplicated param/return construction into shared helpers.

Owner layer: **checker**, object-literal synthetic-`this` construction.
Anti-hardcoding: sibling classification uses the structural circular-return call
graph and binder node kinds; return types come from the solver. Tests vary the
binder names.

### Adjacent-case matrix (differential vs `tsc`)

| Case | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `foo` before `bar` (the bug) | TS2322 | — | TS2322 |
| `bar` before `foo` (control) | TS2322 | TS2322 | TS2322 |
| renamed binders (`alpha`/`beta`) | TS2322 | — | TS2322 |
| `function`-expression caller | TS2322 | — | TS2322 |
| `function`-expression sibling | TS2322 | — | TS2322 |
| result is concrete, not `any` (`{ z: number }` target) | TS2322 | — (accepted) | TS2322 |
| mutual cycle `foo↔bar` | TS7023×2 | TS7023×2 | TS7023×2 |
| sibling whose real return is `any` | — | — | — |
| annotated later sibling | TS2322 | TS2322 | TS2322 |
| genuinely-missing member | TS2339 | TS2339 (+pre-existing TS7023) | TS2339 (+pre-existing TS7023) |

## Goal
Goal: hold

## Verification
- New unit suite `object_literal_forward_method_return_type_tests` (9 tests) —
  green.
- Related suites green: `object_literal_method_this_member_order_tests`,
  `object_literal_getter_self_reference_ts7023_tests`,
  `object_literal_synthetic_this_display_order_tests`,
  `inferred_return_error_and_self_call_tests`,
  `ts7023_self_recursive_var_reassigned_return_tests`, `this_type_tests` (107),
  `contextual_typing_tests` (32).
- Broad sweep of 73 related checker test binaries (object-literal / this-type /
  contextual / accessor / inferred-return): **478 passed**. The only in-scope
  failures (`nonnull_contextual_type_arg_inference_tests` tuple-vs-array case; 4
  `arch_source_scans` ratchets) were confirmed to **fail identically on the clean
  baseline** via `git stash` — pre-existing, unrelated to this diff.
- Differential repro against `tsc` (`typescript@6.0.2` oracle),
  `--noEmit --strict --lib es2022 --target es2022`.
- `cargo clippy --release -p tsz-checker`: clean; pre-commit architecture guard
  (arch-size) passed.
- Full conformance/emit suites are the CI-authoritative gates for this row and
  run on this PR; local runs exceeded the session's time budget (they rebuild a
  snapshot tool first). The TS2590/complexity concern raised on the issue does
  not apply: TS2590 is a deterministic function of union size, not of evaluation
  count, and the return-type inference snapshots and restores the
  lazy-resolution fuel counter.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01YV2cbUAsj3nRUzeejjkYYw)_