### PR TITLE
ci(readme-refresh): heal path must trigger CI, or the PR it heals can never merge

### DIFF
--- a/.github/workflows/readme-benchmark-refresh.yml
+++ b/.github/workflows/readme-benchmark-refresh.yml
@@ -33,6 +33,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Persist the automation token, not the default GITHUB_TOKEN, so the
+          # heal path's `git push --force-with-lease` below triggers CI.
+          #
+          # GitHub deliberately suppresses workflow triggers for pushes made
+          # with GITHUB_TOKEN, to stop workflows from recursively triggering
+          # themselves. Creating the PR is unaffected -- `gh pr create` already
+          # runs under TSZ_PR_AUTOMATION_TOKEN, so the `opened` event fires and
+          # CI runs on a brand-new refresh branch. But a *healed* branch is
+          # updated by push alone, which raises `synchronize`, and that event
+          # was being swallowed: the PR ended up with zero check runs and
+          # `CI Summary` (the only required context) could never report, so the
+          # PR was permanently unmergeable -- "the base branch policy prohibits
+          # the merge" -- even though the heal itself worked.
+          #
+          # Falls back to github.token when the secret is absent, matching the
+          # `Open refresh PR` step. In that configuration a healed PR still gets
+          # no checks and needs a manual close/reopen to run them.
+          token: ${{ secrets.TSZ_PR_AUTOMATION_TOKEN || github.token }}
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -108,6 +127,30 @@ jobs:
             echo "Healing existing branch ${branch} (was ${remote_tip}) onto current main."
             git push --force-with-lease="${branch}:${remote_tip}" origin "${branch}"
             echo "Updated the open refresh PR in place; not opening a second one."
+
+            # A healed PR is only useful if CI actually runs on the new head:
+            # `CI Summary` is the sole required context, so a head with zero
+            # check runs is unmergeable no matter how correct its contents are.
+            # The checkout token above normally makes the push raise
+            # `synchronize`, but when TSZ_PR_AUTOMATION_TOKEN is absent we fall
+            # back to GITHUB_TOKEN and that event is suppressed. Verify rather
+            # than assume, and recover by reopening -- CI listens for
+            # `reopened`.
+            pr_number="$(gh pr list --head "${branch}" --state open --json number --jq '.[0].number')"
+            new_head="$(git rev-parse "${branch}")"
+            checks=0
+            for _ in 1 2 3 4 5 6; do
+              sleep 10
+              checks="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${new_head}/check-runs" --jq '.total_count' 2>/dev/null || echo 0)"
+              [ "${checks}" != "0" ] && break
+            done
+            if [ "${checks}" = "0" ]; then
+              echo "Healed head ${new_head} has no check runs; reopening PR #${pr_number} to trigger CI."
+              gh pr close "${pr_number}"
+              gh pr reopen "${pr_number}"
+            else
+              echo "Healed head ${new_head} has ${checks} check run(s)."
+            fi
             exit 0
           fi
 


### PR DESCRIPTION
## The bug

#17075 taught `readme-benchmark-refresh.yml` to heal a conflicted refresh PR in
place instead of regenerating the assets and throwing them away. The heal works
— but the PR it heals **can never merge**.

`actions/checkout` had no `token:`, so it persists the default `GITHUB_TOKEN`,
and `git push --force-with-lease` runs as that identity. GitHub deliberately
suppresses workflow triggers for pushes made with `GITHUB_TOKEN` (the
recursion guard). So the heal raises no `synchronize`, the new head gets **zero
check runs**, and `CI Summary` — the only required status context on `main` —
never reports:

```
$ gh pr merge 17138 --match-head-commit <healed-head>
X Pull request #17138 is not mergeable: the base branch policy prohibits the merge.
```

Creating a refresh PR was never affected, which is why this went unnoticed:
`gh pr create` already runs under `TSZ_PR_AUTOMATION_TOKEN`, so the `opened`
event fires normally. Only the heal path is broken.

Measured on the live incident (#17138), all three on the same branch:

| head | how it was produced | check runs |
| --- | --- | --- |
| `3528450b` | original, `gh pr create` (PAT) | **11** |
| `09a660c6` | healed, `git push` (GITHUB_TOKEN) | **0** |
| #17015 (merged, for reference) | original | 11 |

## The fix

1. **Persist the automation token in `actions/checkout`**, so the heal push is
   attributed to the PAT and raises `synchronize` like any human push.
2. **Verify, don't assume.** The `secrets.X || github.token` fallback silently
   reproduces the original bug whenever the secret is absent. After healing, the
   workflow now polls the new head for check runs and, if there are none,
   closes and reopens the PR — CI listens for `reopened`.

Step 2 is the part I'd argue for keeping even though step 1 should make it dead
code. The failure mode here is *silence*: a heal that reports success, updates
the branch correctly, and leaves behind a PR that looks fine and merges never.
The only way to notice is to try to merge it. A guard that checks the observable
consequence — do check runs exist? — is cheap and does not depend on the token
configuration being right.

## Verification

- `actionlint` clean; YAML parses and the checkout step carries the expected
  `with.token`.
- Root cause confirmed by measurement, not inspection: 11 vs 0 check runs on the
  same branch, differing only in which identity pushed.
- Recovery path confirmed live on #17138 before writing this: closing and
  reopening produced **10 check runs** on the previously-zero head and the PR
  went to `MERGEABLE`. That is exactly what step 2 automates.
- Not exercised end-to-end in this PR: the next scheduled refresh that hits a
  conflicted branch is the first real run of the healed path. Step 2 is the
  backstop if step 1 misbehaves.

## Goal
Goal: hold

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-5[1m]
Effort: high
